### PR TITLE
Bug fix for unable to status blob incorrect format issue reported by …

### DIFF
--- a/src/core/src/core_logic/PatchAssessor.py
+++ b/src/core/src/core_logic/PatchAssessor.py
@@ -70,5 +70,5 @@ class PatchAssessor(object):
                     self.status_handler.set_assessment_substatus_json(status=Constants.STATUS_ERROR)
                     raise
 
-        self.composite_logger.log("\nPatch assessment competed.\n")
+        self.composite_logger.log("\nPatch assessment completed.\n")
         return True

--- a/src/core/src/local_loggers/CompositeLogger.py
+++ b/src/core/src/local_loggers/CompositeLogger.py
@@ -34,13 +34,14 @@ class CompositeLogger(object):
 
     def log(self, message):
         """log output"""
-        message = CompositeLogger.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
-        for line in message.splitlines():  # allows the extended file logger to strip unnecessary white space
-            if self.current_env in (Constants.DEV, Constants.TEST):
+        message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
+        message = message.strip()
+        if self.current_env in (Constants.DEV, Constants.TEST):
+            for line in message.splitlines():  # allows the extended file logger to strip unnecessary white space
                 print(line)
-            elif self.file_logger is not None:
-                timestamp = self.env_layer.datetime.timestamp()
-                self.file_logger.write("\n" + timestamp + "> " + message.strip(), fail_silently=False)
+        elif self.file_logger is not None:
+            timestamp = self.env_layer.datetime.timestamp()
+            self.file_logger.write("\n" + timestamp + "> " + message.strip(), fail_silently=False)
 
     def log_error(self, message):
         """log errors"""

--- a/src/core/src/service_interfaces/StatusHandler.py
+++ b/src/core/src/service_interfaces/StatusHandler.py
@@ -467,7 +467,7 @@ class StatusHandler(object):
             self.composite_logger.log_error("Core state file path returned a directory. Attempting to reset.")
             shutil.rmtree(self.status_file_path)
 
-        self.env_layer.file_system.write_with_retry(self.status_file_path, '[{0}]'.format(json.dumps(status_file_payload)), mode='w+')
+        self.env_layer.file_system.write_with_retry_using_temp_file(self.status_file_path, '[{0}]'.format(json.dumps(status_file_payload)), mode='w+')
     # endregion
 
     # region - Error objects

--- a/src/tools/status_read_mock/scheduled_file_read.py
+++ b/src/tools/status_read_mock/scheduled_file_read.py
@@ -4,10 +4,12 @@ import datetime
 sleep_time = 0.01  # in seconds
 
 
-def read_file():
+def read_file_and_log_content():
     try:
-        file_loc = r'/var/lib/waagent/Microsoft.CPlat.Core.LinuxPatchExtension-1.6.7/status/21.status'
-        file_handle = open(file_loc, 'r')
+        # add path of the file to be read
+        # eg: file_path = '/test/1.txt'
+        file_path = ''
+        file_handle = open(file_path, 'r')
         data = file_handle.read()
         print(data)
         file_handle.close()
@@ -16,7 +18,10 @@ def read_file():
         data = "Error occurred during file operation: " + repr(error)
 
     try:
-        write_output_to_file = '/var/lib/waagent/Microsoft.CPlat.Core.LinuxPatchExtension-1.6.7/status/21.status.log'
+        # add the location of the log file that will contain the contents of the file that is read. The log file will be created if it does not exist.
+        # NOTE: make sure the file name is diff from the one which is read
+        # eg: write_output_to_file = '/test/1.txt.log'
+        write_output_to_file = ''
         write_file_handle = open(write_output_to_file, 'a')
         write_file_handle.write("TimeStamp: " + str(datetime.datetime.utcnow()) + "\t" + str(data) + "\n\n\n\n\n")
         write_file_handle.close()
@@ -25,6 +30,6 @@ def read_file():
 
 
 while True:  # This loop runs forever
-    read_file()
+    read_file_and_log_content()
     time.sleep(sleep_time)
 

--- a/src/tools/status_read_mock/scheduled_file_read.py
+++ b/src/tools/status_read_mock/scheduled_file_read.py
@@ -1,0 +1,30 @@
+import time
+import datetime
+
+sleep_time = 0.01  # in seconds
+
+
+def read_file():
+    try:
+        file_loc = r'/var/lib/waagent/Microsoft.CPlat.Core.LinuxPatchExtension-1.6.7/status/21.status'
+        file_handle = open(file_loc, 'r')
+        data = file_handle.read()
+        print(data)
+        file_handle.close()
+    except Exception as error:
+        print("Error occurred during file operation: " + repr(error))
+        data = "Error occurred during file operation: " + repr(error)
+
+    try:
+        write_output_to_file = '/var/lib/waagent/Microsoft.CPlat.Core.LinuxPatchExtension-1.6.7/status/21.status.log'
+        write_file_handle = open(write_output_to_file, 'a')
+        write_file_handle.write("TimeStamp: " + str(datetime.datetime.utcnow()) + "\t" + str(data) + "\n\n\n\n\n")
+        write_file_handle.close()
+    except Exception as error:
+        print("Error occurred during file operation: " + repr(error))
+
+
+while True:  # This loop runs forever
+    read_file()
+    time.sleep(sleep_time)
+


### PR DESCRIPTION
…agent and few other minor changes

Changes in the PR:
- writing to status using a temp file. 
NOTE: 
     - using tempfile to create the temporary file and shutil.move() to move/rename the temp file to the original one. 
     - shutil.move() first moves the file from src to dst and then deletes the originial file at source
     - Also, if the src and dst are within the same filesystem, shutil.move() internally calls os.rename() which is an atomic operation
     - So, this should take care of our need for an atomic operation while ensuring a .status file always exists for the agent to read.


- Some logs were being written twice in the log file due to splitlines() which was dividing the log statement into '' and the log text
- nit spell check for Patch assessment completed