### PR TITLE
Temporary fix in maintenanceRunId format

### DIFF
--- a/src/core/src/core_logic/PatchInstaller.py
+++ b/src/core/src/core_logic/PatchInstaller.py
@@ -97,7 +97,9 @@ class PatchInstaller(object):
             # update patch metadata in status for auto patching request, to be reported to healthstore
             if self.execution_config.maintenance_run_id is not None:
                 try:
-                    patch_version = str(self.execution_config.maintenance_run_id)
+                    #todo: temp fix to test auto patching, this will be reset to using the maintenanceRunId string as is, once the corresponding changes in RSM are made
+                    # patch_version = str(self.execution_config.maintenance_run_id)
+                    patch_version = datetime.datetime.strptime(self.execution_config.maintenance_run_id.split(" ")[0], "%m/%d/%Y").strftime('%Y.%m.%d')
                     self.status_handler.set_patch_metadata_for_healthstore_substatus_json(patch_version=patch_version if patch_version is not None and patch_version is not "" else Constants.PATCH_VERSION_UNKNOWN,
                                                                                           report_to_healthstore=True,
                                                                                           wait_after_update=False)

--- a/src/core/tests/TestCoreMain.py
+++ b/src/core/tests/TestCoreMain.py
@@ -88,7 +88,7 @@ class TestCoreMain(unittest.TestCase):
     def test_operation_success_for_autopatching_request(self):
         # test with valid datetime string for maintenance run id
         argument_composer = ArgumentComposer()
-        maintenance_run_id = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+        maintenance_run_id = "9/28/2020 02:00:00 PM +00:00"
         argument_composer.maintenance_run_id = str(maintenance_run_id)
         runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.ZYPPER)
         runtime.set_legacy_test_type('SuccessInstallPath')
@@ -103,28 +103,7 @@ class TestCoreMain(unittest.TestCase):
         self.assertTrue(substatus_file_data[2]["name"] == Constants.PATCH_METADATA_FOR_HEALTHSTORE)
         self.assertTrue(substatus_file_data[2]["status"] == Constants.STATUS_SUCCESS.lower())
         substatus_file_data_patch_metadata_summary = json.loads(substatus_file_data[2]["formattedMessage"]["message"])
-        self.assertEqual(substatus_file_data_patch_metadata_summary["patchVersion"], maintenance_run_id)
-        self.assertTrue(substatus_file_data_patch_metadata_summary["shouldReportToHealthStore"])
-        runtime.stop()
-
-        # test with a random string for maintenance run id
-        argument_composer = ArgumentComposer()
-        maintenance_run_id = "test"
-        argument_composer.maintenance_run_id = maintenance_run_id
-        runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.ZYPPER)
-        runtime.set_legacy_test_type('SuccessInstallPath')
-        CoreMain(argument_composer.get_composed_arguments())
-        with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
-            substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
-        self.assertEquals(len(substatus_file_data), 3)
-        self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
-        self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
-        self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
-        self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_SUCCESS.lower())
-        self.assertTrue(substatus_file_data[2]["name"] == Constants.PATCH_METADATA_FOR_HEALTHSTORE)
-        self.assertTrue(substatus_file_data[2]["status"] == Constants.STATUS_SUCCESS.lower())
-        substatus_file_data_patch_metadata_summary = json.loads(substatus_file_data[2]["formattedMessage"]["message"])
-        self.assertEqual(substatus_file_data_patch_metadata_summary["patchVersion"], maintenance_run_id)
+        self.assertEqual(substatus_file_data_patch_metadata_summary["patchVersion"], "2020.09.28")
         self.assertTrue(substatus_file_data_patch_metadata_summary["shouldReportToHealthStore"])
         runtime.stop()
 
@@ -142,12 +121,34 @@ class TestCoreMain(unittest.TestCase):
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
-        self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_TRANSITIONING.lower())
         self.assertTrue(substatus_file_data[2]["name"] == Constants.PATCH_METADATA_FOR_HEALTHSTORE)
         self.assertTrue(substatus_file_data[2]["status"] == Constants.STATUS_SUCCESS.lower())
         substatus_file_data_patch_metadata_summary = json.loads(substatus_file_data[2]["formattedMessage"]["message"])
         self.assertEqual(substatus_file_data_patch_metadata_summary["patchVersion"], Constants.PATCH_VERSION_UNKNOWN)
-        self.assertTrue(substatus_file_data_patch_metadata_summary["shouldReportToHealthStore"])
+        self.assertFalse(substatus_file_data_patch_metadata_summary["shouldReportToHealthStore"])
+        runtime.stop()
+
+        # todo: This will become a valid success operation run once the temp fix for maintenanceRunId is removed
+        # test with a random string for maintenance run id
+        argument_composer = ArgumentComposer()
+        maintenance_run_id = "test"
+        argument_composer.maintenance_run_id = maintenance_run_id
+        runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.ZYPPER)
+        runtime.set_legacy_test_type('SuccessInstallPath')
+        CoreMain(argument_composer.get_composed_arguments())
+        with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
+            substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
+        self.assertEquals(len(substatus_file_data), 3)
+        self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
+        self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
+        self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_TRANSITIONING.lower())
+        self.assertTrue(substatus_file_data[2]["name"] == Constants.PATCH_METADATA_FOR_HEALTHSTORE)
+        self.assertTrue(substatus_file_data[2]["status"] == Constants.STATUS_SUCCESS.lower())
+        substatus_file_data_patch_metadata_summary = json.loads(substatus_file_data[2]["formattedMessage"]["message"])
+        self.assertEqual(substatus_file_data_patch_metadata_summary["patchVersion"], Constants.PATCH_VERSION_UNKNOWN)
+        self.assertFalse(substatus_file_data_patch_metadata_summary["shouldReportToHealthStore"])
         runtime.stop()
 
 


### PR DESCRIPTION
RSM sends maintenanceRunId in the format DateTimeOffset. Eg: 9/28/2020 02:00:00 PM +00:00. A change will be made in RSM to send maintenanceRunId in the exact format it receives from SMD (i.e. the rollout id we define). Until that change goes in, this is a temporary fix for the extension to be able to read the current format and will be reverted once the RSM change is checked-in