### PR TITLE
Modifying how seq no is read for different handler commands

### DIFF
--- a/src/extension/src/Constants.py
+++ b/src/extension/src/Constants.py
@@ -75,6 +75,14 @@ class Constants(object):
     CONFIGURE_PATCHING = "ConfigurePatching"
     CONFIGURE_PATCHING_SUMMARY = "ConfigurePatchingSummary"
 
+    # Handler actions
+    ENABLE = "Enable"
+    UPDATE = "Disable"
+    RESET = "Reset"
+    INSTALL = "Install"
+    UNINSTALL = "Update"
+    DISABLE = "Disable"
+
     # Settings for Error Objects logged in status file
     STATUS_ERROR_MSG_SIZE_LIMIT_IN_CHARACTERS = 128
     STATUS_ERROR_LIMIT = 5

--- a/src/extension/src/Constants.py
+++ b/src/extension/src/Constants.py
@@ -43,7 +43,7 @@ class Constants(object):
     STATUS_FILE_EXTENSION = '.status'
     CORE_CODE_FILE_NAME = 'MsftLinuxPatchCore.py'
     LOG_FILE_EXTENSION = '.log'
-    LOG_FILES_TO_RETAIN = 10
+    LOG_FILES_TO_RETAIN = 15
     MAX_LOG_FILES_ALLOWED = 40
 
     # Environment variables

--- a/src/extension/src/Utility.py
+++ b/src/extension/src/Utility.py
@@ -49,10 +49,10 @@ class Utility(object):
         if raise_if_not_found:
             raise Exception(error_msg)
 
-    def create_log_file(self, log_folder, seq_no):
-        """ Creates <sequencenumber>.ext.log file under the path for logFolder provided in HandlerEnvironment """
-        file_path = str(seq_no) + str(".ext") + Constants.LOG_FILE_EXTENSION
-        if seq_no is not None and os.path.exists(log_folder):
+    def create_log_file(self, log_folder, file_name):
+        """ Creates <file_name>.ext.log file under the path for logFolder provided in HandlerEnvironment """
+        file_path = file_name + str(".ext") + Constants.LOG_FILE_EXTENSION
+        if file_name is not None and os.path.exists(log_folder):
             self.logger.log("Creating log file. [File={0}]".format(file_path))
             return FileLogger(log_folder, file_path)
         else:

--- a/src/extension/src/__main__.py
+++ b/src/extension/src/__main__.py
@@ -51,20 +51,11 @@ def main(argv):
                 exit(Constants.ExitCode.MissingConfig)
 
             ext_config_settings_handler = ExtConfigSettingsHandler(logger, json_file_handler, config_folder)
-            seq_no = ext_config_settings_handler.get_seq_no()
-            if seq_no is None:
-                logger.log_error("Sequence number for current operation not found")
-                exit(Constants.ExitCode.MissingConfig)
-
-            file_logger = utility.create_log_file(ext_env_handler.log_folder, seq_no)
-            if file_logger is not None:
-                stdout_file_mirror = StdOutFileMirror(file_logger)
-
             core_state_handler = CoreStateHandler(config_folder, json_file_handler)
             ext_state_handler = ExtStateHandler(config_folder, utility, json_file_handler)
-            ext_output_status_handler = ExtOutputStatusHandler(logger, utility, json_file_handler, file_logger.log_file_path, seq_no, ext_env_handler.status_folder)
+            ext_output_status_handler = ExtOutputStatusHandler(logger, utility, json_file_handler, ext_env_handler.status_folder)
             process_handler = ProcessHandler(logger, ext_output_status_handler)
-            action_handler = ActionHandler(logger, utility, runtime_context_handler, json_file_handler, ext_env_handler, ext_config_settings_handler, core_state_handler, ext_state_handler, ext_output_status_handler, process_handler, cmd_exec_start_time, seq_no)
+            action_handler = ActionHandler(logger, utility, runtime_context_handler, json_file_handler, ext_env_handler, ext_config_settings_handler, core_state_handler, ext_state_handler, ext_output_status_handler, process_handler, cmd_exec_start_time)
             action_handler.determine_operation(argv[1])
         else:
             error_cause = "No configuration provided in HandlerEnvironment" if ext_env_handler.handler_environment_json is None else "Path to config folder not specified in HandlerEnvironment"
@@ -72,13 +63,13 @@ def main(argv):
             raise Exception(error_msg)
     except Exception as error:
         logger.log_error(repr(error))
-        raise
-        # todo: add a exitcode instead of raising an exception
+        return Constants.ExitCode.HandlerFailed
     finally:
         if stdout_file_mirror is not None:
             stdout_file_mirror.stop()
         if file_logger is not None:
             file_logger.close()
+
 
 if __name__ == '__main__':
     main(sys.argv)

--- a/src/extension/tests/TestActionHandler.py
+++ b/src/extension/tests/TestActionHandler.py
@@ -40,10 +40,10 @@ class TestActionHandler(unittest.TestCase):
         ext_config_settings_handler = ExtConfigSettingsHandler(self.runtime.logger, self.runtime.json_file_handler, ext_env_handler.config_folder)
         core_state_handler = CoreStateHandler(ext_env_handler.config_folder, self.runtime.json_file_handler)
         ext_state_handler = ExtStateHandler(ext_env_handler.config_folder, self.runtime.utility, self.runtime.json_file_handler)
-        ext_output_status_handler = ExtOutputStatusHandler(self.runtime.logger, self.runtime.utility, self.runtime.json_file_handler, 'test/', 0, ext_env_handler.status_folder)
+        ext_output_status_handler = ExtOutputStatusHandler(self.runtime.logger, self.runtime.utility, self.runtime.json_file_handler, ext_env_handler.status_folder)
         process_handler = ProcessHandler(self.runtime.logger, ext_output_status_handler)
         self.action_handler = ActionHandler(self.runtime.logger, self.runtime.utility, runtime_context_handler, self.runtime.json_file_handler, ext_env_handler,
-                                            ext_config_settings_handler, core_state_handler, ext_state_handler, ext_output_status_handler, process_handler, "2020-09-02T13:40:54.8862542Z", 0)
+                                            ext_config_settings_handler, core_state_handler, ext_state_handler, ext_output_status_handler, process_handler, "2020-09-02T13:40:54.8862542Z")
 
     def tearDown(self):
         VirtualTerminal().print_lowlight("\n----------------- tear down test runner -----------------")

--- a/src/extension/tests/TestEnableCommandHandler.py
+++ b/src/extension/tests/TestEnableCommandHandler.py
@@ -49,9 +49,9 @@ class TestEnableCommandHandler(unittest.TestCase):
         self.ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.json_file_handler, self.config_folder)
         self.core_state_handler = CoreStateHandler(self.config_folder, self.json_file_handler)
         self.ext_state_handler = ExtStateHandler(self.config_folder, self.utility, self.json_file_handler)
-        self.ext_output_status_handler = ExtOutputStatusHandler(self.logger, self.utility, self.json_file_handler, "test.log", 1234, self.temp_dir)
+        self.ext_output_status_handler = ExtOutputStatusHandler(self.logger, self.utility, self.json_file_handler, self.temp_dir)
         self.process_handler = ProcessHandler(self.logger, self.ext_output_status_handler)
-        self.enable_command_handler = EnableCommandHandler(self.logger, self.utility, self.runtime_context_handler, self.ext_env_handler, self.ext_config_settings_handler, self.core_state_handler, self.ext_state_handler, self.ext_output_status_handler, self.process_handler, datetime.utcnow(), 1234)
+        self.enable_command_handler = EnableCommandHandler(self.logger, self.utility, self.runtime_context_handler, self.ext_env_handler, self.ext_config_settings_handler, self.core_state_handler, self.ext_state_handler, self.ext_output_status_handler, self.process_handler, datetime.utcnow())
         self.constants = Constants
         self.start_daemon_backup = ProcessHandler.start_daemon
         ProcessHandler.start_daemon = self.mock_start_daemon_to_return_true
@@ -60,6 +60,7 @@ class TestEnableCommandHandler(unittest.TestCase):
         VirtualTerminal().print_lowlight("\n----------------- tear down test runner -----------------")
         # reseting mocks to their original definition
         ProcessHandler.start_daemon = self.start_daemon_backup
+        self.logger.file_logger.close()
         # delete tempdir
         shutil.rmtree(self.temp_dir)
 
@@ -103,7 +104,7 @@ class TestEnableCommandHandler(unittest.TestCase):
         new_settings_file = self.create_helpers_for_enable_request(config_folder_path)
 
         prev_ext_state_json = self.json_file_handler.get_json_file_content(self.constants.EXT_STATE_FILE, config_folder_path)
-        enable_command_handler = EnableCommandHandler(self.logger, self.utility, self.runtime_context_handler, self.ext_env_handler, self.ext_config_settings_handler, self.core_state_handler, self.ext_state_handler, self.ext_output_status_handler, self.process_handler, datetime.utcnow(), 12)
+        enable_command_handler = EnableCommandHandler(self.logger, self.utility, self.runtime_context_handler, self.ext_env_handler, self.ext_config_settings_handler, self.core_state_handler, self.ext_state_handler, self.ext_output_status_handler, self.process_handler, datetime.utcnow())
         with self.assertRaises(SystemExit) as sys_exit:
             enable_command_handler.execute_handler_action()
 
@@ -128,7 +129,7 @@ class TestEnableCommandHandler(unittest.TestCase):
             f.close()
 
         prev_ext_state_json = self.json_file_handler.get_json_file_content(self.constants.EXT_STATE_FILE, config_folder_path)
-        enable_command_handler = EnableCommandHandler(self.logger, self.utility, self.runtime_context_handler, self.ext_env_handler, self.ext_config_settings_handler, self.core_state_handler, self.ext_state_handler, self.ext_output_status_handler, self.process_handler, datetime.utcnow(), 12)
+        enable_command_handler = EnableCommandHandler(self.logger, self.utility, self.runtime_context_handler, self.ext_env_handler, self.ext_config_settings_handler, self.core_state_handler, self.ext_state_handler, self.ext_output_status_handler, self.process_handler, datetime.utcnow())
         with self.assertRaises(SystemExit) as sys_exit:
             enable_command_handler.execute_handler_action()
         self.assertEqual(sys_exit.exception.code, Constants.ExitCode.Okay)
@@ -151,7 +152,7 @@ class TestEnableCommandHandler(unittest.TestCase):
             json.dump(config_settings, f)
             f.truncate()
             f.close()
-        enable_command_handler = EnableCommandHandler(self.logger, self.utility, self.runtime_context_handler, self.ext_env_handler, self.ext_config_settings_handler, self.core_state_handler, self.ext_state_handler, self.ext_output_status_handler, self.process_handler, datetime.utcnow(), 12)
+        enable_command_handler = EnableCommandHandler(self.logger, self.utility, self.runtime_context_handler, self.ext_env_handler, self.ext_config_settings_handler, self.core_state_handler, self.ext_state_handler, self.ext_output_status_handler, self.process_handler, datetime.utcnow())
         with self.assertRaises(SystemExit) as sys_exit:
             enable_command_handler.execute_handler_action()
         self.assertEqual(sys_exit.exception.code, Constants.ExitCode.Okay)
@@ -169,7 +170,7 @@ class TestEnableCommandHandler(unittest.TestCase):
             json.dump(config_settings, f)
             f.truncate()
             f.close()
-        enable_command_handler = EnableCommandHandler(self.logger, self.utility, self.runtime_context_handler, self.ext_env_handler, self.ext_config_settings_handler, self.core_state_handler, self.ext_state_handler, self.ext_output_status_handler, self.process_handler, datetime.utcnow(), 12)
+        enable_command_handler = EnableCommandHandler(self.logger, self.utility, self.runtime_context_handler, self.ext_env_handler, self.ext_config_settings_handler, self.core_state_handler, self.ext_state_handler, self.ext_output_status_handler, self.process_handler, datetime.utcnow())
         with self.assertRaises(SystemExit) as sys_exit:
             enable_command_handler.execute_handler_action()
         self.assertEqual(sys_exit.exception.code, Constants.ExitCode.InvalidConfigSettingPropertyValue)
@@ -196,6 +197,12 @@ class TestEnableCommandHandler(unittest.TestCase):
             timestamp = time.mktime(datetime.strptime('2019-07-20T12:10:14Z', '%Y-%m-%dT%H:%M:%SZ').timetuple())
             os.utime(config_file_path, (timestamp, timestamp))
             f.close()
+
+        # creating a log file
+        log_file_name = datetime.utcnow().strftime("%Y-%m-%d_%H-%M-%S") + "_Enable"
+        file_logger = self.utility.create_log_file(log_folder_path, log_file_name)
+        if file_logger is not None:
+            self.logger.file_logger = file_logger
 
         self.ext_env_handler.config_folder = config_folder_path
         self.ext_env_handler.status_folder = status_folder_path

--- a/src/extension/tests/TestFileLogger.py
+++ b/src/extension/tests/TestFileLogger.py
@@ -81,7 +81,11 @@ class TestFileLogger(unittest.TestCase):
             {"name": '125.log', "lastModified": '2017-07-21T12:12:14Z'},  # reverse sort order seqno: 11
             {"name": '126.log', "lastModified": '2017-07-21T12:12:14Z'},  # reverse sort order seqno: 12
             {"name": '127.log', "lastModified": '2017-07-21T12:12:14Z'},  # reverse sort order seqno: 13
-            {"name": 'test.log', "lastModified": '2017-07-21T12:12:14Z'},  # testing with the current log file, reverse sort order seqno: 14
+            {"name": 'test1.log', "lastModified": '2017-07-21T12:12:14Z'},  # testing with the current log file, reverse sort order seqno: 14
+            {"name": 'test2.log', "lastModified": '2017-07-21T12:12:14Z'},  # testing with the current log file, reverse sort order seqno: 15
+            {"name": 'tes3.log', "lastModified": '2017-07-21T12:12:14Z'},  # testing with the current log file, reverse sort order seqno: 16
+            {"name": 'test4.log', "lastModified": '2017-07-21T12:12:14Z'},  # testing with the current log file, reverse sort order seqno: 17
+            {"name": 'test5.log', "lastModified": '2017-07-21T12:12:14Z'},  # testing with the current log file, reverse sort order seqno: 18
             {"name": '123.json', "lastModified": '2019-07-20T11:12:14Z'},
             {"name": '10.settings', "lastModified": '2019-07-20T10:12:14Z'},
             {"name": '111.txt', "lastModified": '2019-07-20T12:10:14Z'},
@@ -109,7 +113,7 @@ class TestFileLogger(unittest.TestCase):
             f.close()
 
         self.file_logger.delete_older_log_files(self.test_dir)
-        self.assertEqual(11, len(self.file_logger.get_all_log_files(self.test_dir)))
+        self.assertEqual(15, len(self.file_logger.get_all_log_files(self.test_dir)))
         self.file_logger.close()
 
 

--- a/src/extension/tests/TestProcessHandler.py
+++ b/src/extension/tests/TestProcessHandler.py
@@ -36,7 +36,7 @@ class TestProcessHandler(unittest.TestCase):
         self.json_file_handler = runtime.json_file_handler
         seq_no = 1234
         dir_path = os.path.join(os.path.pardir, "tests", "helpers")
-        self.ext_output_status_handler = ExtOutputStatusHandler(self.logger, self.utility, self.json_file_handler, "test.log", seq_no, dir_path)
+        self.ext_output_status_handler = ExtOutputStatusHandler(self.logger, self.utility, self.json_file_handler, dir_path)
         self.process = subprocess.Popen(["echo", "Hello World!"], shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     def tearDown(self):
@@ -170,6 +170,7 @@ class TestProcessHandler(unittest.TestCase):
         # resetting mocks
         ProcessHandler.get_python_cmd = get_python_cmd_backup
         subprocess.Popen = subprocess_popen_backup
+
 
 if __name__ == '__main__':
     SUITE = unittest.TestLoader().loadTestsFromTestCase(TestProcessHandler)


### PR DESCRIPTION
Includes:

- Individual log files for every handler action/command
- Increased the log retention limit to accommodate the separate log files 

For Enable command:

- Reading seq no first from environment variable and validating if the corresponding .settings file exists. Failing if file not found
- If seq no is not set in environment variable, try to fetch it from the config settings files

For Non-Enable command:

- Fetch seq no from environment variable and validate if the corresponding .settings file exists, fail if not found.

- If not found, return None. It is upto individual commands to decide what to do here

Pending:

- Writing to status file for non-enable commands
