### PR TITLE
Fix for error on assesspatches and modified log retention for core an…

### DIFF
--- a/src/core/src/CoreMain.py
+++ b/src/core/src/CoreMain.py
@@ -50,7 +50,6 @@ class CoreMain(object):
             execution_config = container.get('execution_config')
             patch_operation_requested = execution_config.operation.lower()
             patch_assessor = container.get('patch_assessor')
-            patch_installer = container.get('patch_installer')
             package_manager = container.get('package_manager')
 
             # if this is an auto patching installation request, log and disable (if enabled by default) the current auto OS update status. NOTE: log status in a separate file in config settings
@@ -62,6 +61,7 @@ class CoreMain(object):
 
             # Patching + additional assessment occurs if the operation is 'Installation'
             if patch_operation_requested == Constants.INSTALLATION.lower():
+                patch_installer = container.get('patch_installer')
                 patch_installation_successful = patch_installer.start_installation()
                 patch_assessment_successful = patch_assessor.start_assessment()
 

--- a/src/extension/src/Constants.py
+++ b/src/extension/src/Constants.py
@@ -48,6 +48,8 @@ class Constants(object):
 
     # Environment variables
     SEQ_NO_ENVIRONMENT_VAR = "ConfigSequenceNumber"
+    CORE_MODULE = "Core"
+    EXTENSION_MODULE = "Extension"
 
     # Max runtime for specific commands in minutes
     ENABLE_MAX_RUNTIME = 3

--- a/src/extension/src/local_loggers/Logger.py
+++ b/src/extension/src/local_loggers/Logger.py
@@ -32,17 +32,19 @@ class Logger(object):
         """log output"""
         message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
         for line in message.splitlines():  # allows the extended file logger to strip unnecessary white space
-            print(line)
             if self.file_logger is not None:
-                self.file_logger.write(line)
+                self.file_logger.write("\n" + line)
+            else:
+                print(line)
 
     def log_error(self, message):
         """log errors"""
         message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
         message = (self.NEWLINE_REPLACE_CHAR.join(message.split(os.linesep))).strip()
-        print(self.ERROR + " " + message)
         if self.file_logger is not None:
-            self.file_logger.write(self.ERROR + " " + message)
+            self.file_logger.write("\n" + self.ERROR + " " + message)
+        else:
+            print(self.ERROR + " " + message)
 
     def log_error_and_raise_new_exception(self, message, exception):
         """log errors and raise exception passed in as an arg"""
@@ -54,9 +56,10 @@ class Logger(object):
         """log warning"""
         message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
         message = (self.NEWLINE_REPLACE_CHAR.join(message.split(os.linesep))).strip()
-        print(self.WARNING + " " + message)
         if self.file_logger is not None:
-            self.file_logger.write(self.WARNING + " " + message)
+            self.file_logger.write("\n" + self.WARNING + " " + message)
+        else:
+            print(self.WARNING + " " + message)
 
     def log_debug(self, message):
         """log debug"""
@@ -65,13 +68,13 @@ class Logger(object):
         if self.current_env in (Constants.DEV, Constants.TEST):
             print(self.current_env + ": " + message)  # send to standard output if dev or test env
         if self.file_logger is not None:
-            self.file_logger.write(self.DEBUG + " " + "\n\t".join(message.splitlines()).strip())
+            self.file_logger.write("\n" + self.DEBUG + " " + "\n\t".join(message.splitlines()).strip())
 
     def log_verbose(self, message):
         """log verbose"""
         message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
         if self.file_logger is not None:
-            self.file_logger.write(self.VERBOSE + " " + "\n\t".join(message.strip().splitlines()).strip())
+            self.file_logger.write("\n" + self.VERBOSE + " " + "\n\t".join(message.strip().splitlines()).strip())
 
     @staticmethod
     def __remove_substring_from_message(message, substring=Constants.ERROR_ADDED_TO_STATUS):

--- a/src/extension/src/manifest.xml
+++ b/src/extension/src/manifest.xml
@@ -2,7 +2,7 @@
 <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure">
   <ProviderNameSpace>Microsoft.CPlat.Core</ProviderNameSpace>
   <Type>LinuxPatchExtension</Type>
-  <Version>1.6.9</Version>
+  <Version>1.6.10</Version>
   <Label>Microsoft Azure VM InGuest Patch Extension for Linux Virtual Machines</Label>
   <HostingResources>VmRole</HostingResources>
   <MediaLink></MediaLink>

--- a/src/extension/tests/TestFileLogger.py
+++ b/src/extension/tests/TestFileLogger.py
@@ -22,6 +22,8 @@ import unittest
 from datetime import datetime
 import os
 from os import path
+
+from extension.src.Constants import Constants
 from extension.src.local_loggers.FileLogger import FileLogger
 from extension.tests.helpers.VirtualTerminal import VirtualTerminal
 
@@ -74,18 +76,42 @@ class TestFileLogger(unittest.TestCase):
     def test_delete_older_log_files_success(self):
         files = [
             {"name": '1.ext.log', "lastModified": '2019-07-20T12:12:14Z'},  # reverse sort order seqno: 1
-            {"name": '121.log', "lastModified": '2017-07-21T12:12:14Z'},  # reverse sort order seqno: 7
-            {"name": '122.log', "lastModified": '2017-07-21T12:12:14Z'},  # reverse sort order seqno: 8
-            {"name": '123.log', "lastModified": '2017-07-21T12:12:14Z'},  # reverse sort order seqno: 9
-            {"name": '124.log', "lastModified": '2017-07-21T12:12:14Z'},  # reverse sort order seqno: 10
-            {"name": '125.log', "lastModified": '2017-07-21T12:12:14Z'},  # reverse sort order seqno: 11
-            {"name": '126.log', "lastModified": '2017-07-21T12:12:14Z'},  # reverse sort order seqno: 12
-            {"name": '127.log', "lastModified": '2017-07-21T12:12:14Z'},  # reverse sort order seqno: 13
-            {"name": 'test1.log', "lastModified": '2017-07-21T12:12:14Z'},  # testing with the current log file, reverse sort order seqno: 14
-            {"name": 'test2.log', "lastModified": '2017-07-21T12:12:14Z'},  # testing with the current log file, reverse sort order seqno: 15
-            {"name": 'tes3.log', "lastModified": '2017-07-21T12:12:14Z'},  # testing with the current log file, reverse sort order seqno: 16
-            {"name": 'test4.log', "lastModified": '2017-07-21T12:12:14Z'},  # testing with the current log file, reverse sort order seqno: 17
-            {"name": 'test5.log', "lastModified": '2017-07-21T12:12:14Z'},  # testing with the current log file, reverse sort order seqno: 18
+            {"name": '121.ext.log', "lastModified": '2017-07-21T12:12:14Z'},  # reverse sort order seqno: 7
+            {"name": '122.ext.log', "lastModified": '2017-07-21T12:12:14Z'},  # reverse sort order seqno: 8
+            {"name": '123.ext.log', "lastModified": '2017-07-21T12:12:14Z'},  # reverse sort order seqno: 9
+            {"name": '124.ext.log', "lastModified": '2017-07-21T12:12:14Z'},  # reverse sort order seqno: 10
+            {"name": '125.ext.log', "lastModified": '2017-07-21T12:12:14Z'},  # reverse sort order seqno: 11
+            {"name": '126.ext.log', "lastModified": '2017-07-21T12:12:14Z'},  # reverse sort order seqno: 12
+            {"name": '127.ext.log', "lastModified": '2017-07-21T12:12:14Z'},  # reverse sort order seqno: 13
+            {"name": 'test1.ext.log', "lastModified": '2017-07-21T12:12:14Z'},  # testing with the current log file, reverse sort order seqno: 14
+            {"name": 'test2.ext.log', "lastModified": '2017-07-21T12:12:14Z'},  # testing with the current log file, reverse sort order seqno: 15
+            {"name": 'tes3.ext.log', "lastModified": '2017-07-21T12:12:14Z'},  # testing with the current log file, reverse sort order seqno: 16
+            {"name": 'test4.ext.log', "lastModified": '2017-07-21T12:12:14Z'},  # testing with the current log file, reverse sort order seqno: 17
+            {"name": 'test5.ext.log', "lastModified": '2017-07-21T12:12:14Z'},  # testing with the current log file, reverse sort order seqno: 18
+            {"name": '123.json', "lastModified": '2019-07-20T11:12:14Z'},
+            {"name": '10.settings', "lastModified": '2019-07-20T10:12:14Z'},
+            {"name": '111.txt', "lastModified": '2019-07-20T12:10:14Z'},
+            {"name": '12.ext.log', "lastModified": '2019-07-02T12:12:14Z'},  # reverse sort order seqno: 6
+            {"name": 'dir1', "lastModified": '2019-07-20T12:12:14Z'},
+            {"name": '111111', "lastModified": '2019-07-20T12:12:14Z'},
+            {"name": '2.ext.log', "lastModified": '2019-07-20T12:12:12Z'},  # reverse sort order seqno: 5
+            {"name": '22.ext.log.log', "lastModified": '2019-07-20T12:12:14Z'},  # reverse sort order seqno: 2
+            {"name": 'abc.123.ext.log', "lastModified": '2019-07-20T12:12:14Z'},  # reverse sort order seqno: 3
+            {"name": '.ext.log', "lastModified": '2019-07-20T12:12:14Z'},  # reverse sort order seqno: 4
+
+            {"name": '1.core.log', "lastModified": '2019-07-20T12:12:14Z'},  # reverse sort order seqno: 1
+            {"name": '121.core.log', "lastModified": '2017-07-21T12:12:14Z'},  # reverse sort order seqno: 7
+            {"name": '122.core.log', "lastModified": '2017-07-21T12:12:14Z'},  # reverse sort order seqno: 8
+            {"name": '123.core.log', "lastModified": '2017-07-21T12:12:14Z'},  # reverse sort order seqno: 9
+            {"name": '124.core.log', "lastModified": '2017-07-21T12:12:14Z'},  # reverse sort order seqno: 10
+            {"name": '125.core.log', "lastModified": '2017-07-21T12:12:14Z'},  # reverse sort order seqno: 11
+            {"name": '126.core.log', "lastModified": '2017-07-21T12:12:14Z'},  # reverse sort order seqno: 12
+            {"name": '127.core.log', "lastModified": '2017-07-21T12:12:14Z'},  # reverse sort order seqno: 13
+            {"name": 'test1.core.log', "lastModified": '2017-07-21T12:12:14Z'},  # testing with the current log file, reverse sort order seqno: 14
+            {"name": 'test2.core.log', "lastModified": '2017-07-21T12:12:14Z'},  # testing with the current log file, reverse sort order seqno: 15
+            {"name": 'tes3.core.log', "lastModified": '2017-07-21T12:12:14Z'},  # testing with the current log file, reverse sort order seqno: 16
+            {"name": 'test4.core.log', "lastModified": '2017-07-21T12:12:14Z'},  # testing with the current log file, reverse sort order seqno: 17
+            {"name": 'test5.core.log', "lastModified": '2017-07-21T12:12:14Z'},  # testing with the current log file, reverse sort order seqno: 18
             {"name": '123.json', "lastModified": '2019-07-20T11:12:14Z'},
             {"name": '10.settings', "lastModified": '2019-07-20T10:12:14Z'},
             {"name": '111.txt', "lastModified": '2019-07-20T12:10:14Z'},
@@ -93,9 +119,9 @@ class TestFileLogger(unittest.TestCase):
             {"name": 'dir1', "lastModified": '2019-07-20T12:12:14Z'},
             {"name": '111111', "lastModified": '2019-07-20T12:12:14Z'},
             {"name": '2.core.log', "lastModified": '2019-07-20T12:12:12Z'},  # reverse sort order seqno: 5
-            {"name": '22.log.log', "lastModified": '2019-07-20T12:12:14Z'},  # reverse sort order seqno: 2
-            {"name": 'abc.123.log', "lastModified": '2019-07-20T12:12:14Z'},  # reverse sort order seqno: 3
-            {"name": '.log', "lastModified": '2019-07-20T12:12:14Z'}  # reverse sort order seqno: 4
+            {"name": '22.core.log.log', "lastModified": '2019-07-20T12:12:14Z'},  # reverse sort order seqno: 2
+            {"name": 'abc.123.core.log', "lastModified": '2019-07-20T12:12:14Z'},  # reverse sort order seqno: 3
+            {"name": '.core.log', "lastModified": '2019-07-20T12:12:14Z'}  # reverse sort order seqno: 4
         ]
 
         for file in files:
@@ -113,7 +139,8 @@ class TestFileLogger(unittest.TestCase):
             f.close()
 
         self.file_logger.delete_older_log_files(self.test_dir)
-        self.assertEqual(15, len(self.file_logger.get_all_log_files(self.test_dir)))
+        self.assertEqual(15, len(self.file_logger.get_all_log_files(self.test_dir, Constants.CORE_MODULE)))
+        self.assertEqual(15, len(self.file_logger.get_all_log_files(self.test_dir, Constants.EXTENSION_MODULE)))
         self.file_logger.close()
 
 


### PR DESCRIPTION
…d extension log files

Contains:

- Bug fix for extension failing on assesspatch calls. (patch_installer was always initialized for all requests, including assesspactches, which in turn init reboot_manager, which needed reboot settings input)

- Log rotation: Modified log retention, so core and extension are independent, since we have modified the log file formats (majorly for extension logs) after the seq no read modifications.

- Fixed duplicate logging bug in extension file logger.