### PR TITLE
Bug fixes

### DIFF
--- a/src/core/src/CoreMain.py
+++ b/src/core/src/CoreMain.py
@@ -61,6 +61,8 @@ class CoreMain(object):
 
             # Patching + additional assessment occurs if the operation is 'Installation'
             if patch_operation_requested == Constants.INSTALLATION.lower():
+                # setting current operation here, to include patch_installer init within installation actions, ensuring any exceptions during patch_installer init are added in installation summary errors object
+                status_handler.set_current_operation(Constants.INSTALLATION)
                 patch_installer = container.get('patch_installer')
                 patch_installation_successful = patch_installer.start_installation()
                 patch_assessment_successful = patch_assessor.start_assessment()

--- a/src/core/src/core_logic/PackageFilter.py
+++ b/src/core/src/core_logic/PackageFilter.py
@@ -34,7 +34,7 @@ class PackageFilter(object):
         # Inclusions - note: version based inclusion is optionally supported
         self.installation_included_package_masks = self.execution_config.included_package_name_mask_list
         self.installation_included_packages, self.installation_included_package_versions = self.get_packages_and_versions_from_masks(self.installation_included_package_masks)
-        self.installation_included_classifications = self.execution_config.included_classifications_list
+        self.installation_included_classifications = [] if self.execution_config.included_classifications_list is None else self.execution_config.included_classifications_list
 
         # Neutralize global excluded packages, if customer explicitly includes the package
         packages_to_clear_from_global = []

--- a/src/core/src/core_logic/PatchInstaller.py
+++ b/src/core/src/core_logic/PatchInstaller.py
@@ -137,6 +137,10 @@ class PatchInstaller(object):
         self.status_handler.set_package_install_status(packages, package_versions, Constants.PENDING)
         self.composite_logger.log("\nList of packages to be updated: \n" + str(packages))
 
+        sec_packages, sec_package_versions = self.package_manager.get_security_updates()
+        self.telemetry_writer.send_debug_info("Security packages out of the final package list: " + str(sec_packages))
+        self.status_handler.set_package_install_status_classification(sec_packages, sec_package_versions, classification="Security")
+
         self.composite_logger.log("\nNote: Packages that are neither included nor excluded may still be installed if an included package has a dependency on it.")
         # We will see this as packages going from NotSelected --> Installed. We could remove them preemptively from not_included_packages, but we're explicitly choosing not to.
 

--- a/src/core/src/package_managers/PackageManager.py
+++ b/src/core/src/package_managers/PackageManager.py
@@ -64,7 +64,7 @@ class PackageManager(object):
         class_packages, class_versions = self.get_updates_for_classification(package_filter)
         incl_packages, incl_versions = self.get_updates_for_inclusions(package_filter)
 
-        # classification's package version will supercede any inclusion package version (for future reference: this is by design and not a bug)
+        # classification's package version will supersede any inclusion package version (for future reference: this is by design and not a bug)
         packages, package_versions = self.dedupe_update_packages(class_packages + incl_packages, class_versions + incl_versions)
 
         return packages, package_versions

--- a/src/core/src/service_interfaces/StatusHandler.py
+++ b/src/core/src/service_interfaces/StatusHandler.py
@@ -529,11 +529,19 @@ class StatusHandler(object):
         if self.__current_operation == Constants.ASSESSMENT:
             self.__add_error(self.__assessment_errors, error_detail)
             self.__assessment_total_error_count += 1
-            self.set_assessment_substatus_json()
+            # retain previously set status and code for assessment substatus
+            if self.__assessment_substatus_json is not None:
+                self.set_assessment_substatus_json(status=self.__assessment_substatus_json["status"], code=self.__assessment_substatus_json["code"])
+            else:
+                self.set_assessment_substatus_json()
         elif self.__current_operation == Constants.INSTALLATION:
             self.__add_error(self.__installation_errors, error_detail)
             self.__installation_total_error_count += 1
-            self.set_installation_substatus_json()
+            # retain previously set status and code for installation substatus
+            if self.__installation_substatus_json is not None:
+                self.set_installation_substatus_json(status=self.__installation_substatus_json["status"], code=self.__installation_substatus_json["code"])
+            else:
+                self.set_installation_substatus_json()
         else:
             return
 

--- a/src/core/tests/TestCoreMain.py
+++ b/src/core/tests/TestCoreMain.py
@@ -107,29 +107,36 @@ class TestCoreMain(unittest.TestCase):
         self.assertTrue(substatus_file_data_patch_metadata_summary["shouldReportToHealthStore"])
         runtime.stop()
 
-    # def test_operation_success_for_autopatching_request_with_security_classification(self):
-    #     # test with valid datetime string for maintenance run id
-    #     argument_composer = ArgumentComposer()
-    #     maintenance_run_id = "9/28/2020 02:00:00 PM +00:00"
-    #     classifications_to_include = ["Security", "Critical"]
-    #     argument_composer.maintenance_run_id = str(maintenance_run_id)
-    #     argument_composer.classifications_to_include = classifications_to_include
-    #     runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.ZYPPER)
-    #     runtime.set_legacy_test_type("HappyPath")
-    #     CoreMain(argument_composer.get_composed_arguments())
-    #     with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
-    #         substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
-    #     self.assertEquals(len(substatus_file_data), 3)
-    #     self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
-    #     self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
-    #     self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
-    #     self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_SUCCESS.lower())
-    #     self.assertTrue(substatus_file_data[2]["name"] == Constants.PATCH_METADATA_FOR_HEALTHSTORE)
-    #     self.assertTrue(substatus_file_data[2]["status"] == Constants.STATUS_SUCCESS.lower())
-    #     substatus_file_data_patch_metadata_summary = json.loads(substatus_file_data[2]["formattedMessage"]["message"])
-    #     self.assertEqual(substatus_file_data_patch_metadata_summary["patchVersion"], "2020.09.28")
-    #     self.assertTrue(substatus_file_data_patch_metadata_summary["shouldReportToHealthStore"])
-    #     runtime.stop()
+    def test_operation_success_for_autopatching_request_with_security_classification(self):
+        # test with valid datetime string for maintenance run id
+        argument_composer = ArgumentComposer()
+        maintenance_run_id = "9/28/2020 02:00:00 PM +00:00"
+        classifications_to_include = ["Security", "Critical"]
+        argument_composer.maintenance_run_id = str(maintenance_run_id)
+        argument_composer.classifications_to_include = classifications_to_include
+        runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.APT)
+        runtime.set_legacy_test_type("SuccessInstallPath")
+        CoreMain(argument_composer.get_composed_arguments())
+        with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
+            substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
+        self.assertEquals(len(substatus_file_data), 3)
+        self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
+        self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
+        self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertEqual(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][0]["name"], "python-samba")
+        self.assertTrue("Security" in str(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][0]["classifications"]))
+        self.assertEqual(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][1]["name"], "samba-common-bin")
+        self.assertTrue("Security" in str(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][1]["classifications"]))
+        self.assertEqual(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][2]["name"], "samba-libs")
+        self.assertTrue("python-samba_2:4.4.5+dfsg-2ubuntu5.4" in str(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][0]["patchId"]))
+        self.assertTrue("Security" in str(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][2]["classifications"]))
+        self.assertTrue(substatus_file_data[2]["name"] == Constants.PATCH_METADATA_FOR_HEALTHSTORE)
+        self.assertTrue(substatus_file_data[2]["status"] == Constants.STATUS_SUCCESS.lower())
+        substatus_file_data_patch_metadata_summary = json.loads(substatus_file_data[2]["formattedMessage"]["message"])
+        self.assertEqual(substatus_file_data_patch_metadata_summary["patchVersion"], "2020.09.28")
+        self.assertTrue(substatus_file_data_patch_metadata_summary["shouldReportToHealthStore"])
+        runtime.stop()
 
     def test_invalid_maintenance_run_id(self):
         # test with empty string for maintenence run id
@@ -145,7 +152,7 @@ class TestCoreMain(unittest.TestCase):
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
-        self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_TRANSITIONING.lower())
+        self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_ERROR.lower())
         self.assertTrue(substatus_file_data[2]["name"] == Constants.PATCH_METADATA_FOR_HEALTHSTORE)
         self.assertTrue(substatus_file_data[2]["status"] == Constants.STATUS_SUCCESS.lower())
         substatus_file_data_patch_metadata_summary = json.loads(substatus_file_data[2]["formattedMessage"]["message"])
@@ -167,12 +174,39 @@ class TestCoreMain(unittest.TestCase):
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
-        self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_TRANSITIONING.lower())
+        self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_ERROR.lower())
         self.assertTrue(substatus_file_data[2]["name"] == Constants.PATCH_METADATA_FOR_HEALTHSTORE)
         self.assertTrue(substatus_file_data[2]["status"] == Constants.STATUS_SUCCESS.lower())
         substatus_file_data_patch_metadata_summary = json.loads(substatus_file_data[2]["formattedMessage"]["message"])
         self.assertEqual(substatus_file_data_patch_metadata_summary["patchVersion"], Constants.PATCH_VERSION_UNKNOWN)
         self.assertFalse(substatus_file_data_patch_metadata_summary["shouldReportToHealthStore"])
+        runtime.stop()
+
+    def test_assessment_operation_success(self):
+        argument_composer = ArgumentComposer()
+        argument_composer.operation = Constants.ASSESSMENT
+        runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.ZYPPER)
+        runtime.set_legacy_test_type('HappyPath')
+        CoreMain(argument_composer.get_composed_arguments())
+        with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
+            substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
+        self.assertEquals(len(substatus_file_data), 1)
+        self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
+        self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
+        runtime.stop()
+
+    def test_assessment_operation_fail(self):
+        argument_composer = ArgumentComposer()
+        argument_composer.operation = Constants.ASSESSMENT
+        runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.ZYPPER)
+        runtime.set_legacy_test_type('ExceptionPath')
+        CoreMain(argument_composer.get_composed_arguments())
+        with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
+            substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
+        self.assertEquals(len(substatus_file_data), 1)
+        self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
+        self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_ERROR.lower())
+        self.assertEqual(len(json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"]), 2)
         runtime.stop()
 
 

--- a/src/core/tests/TestCoreMain.py
+++ b/src/core/tests/TestCoreMain.py
@@ -107,6 +107,30 @@ class TestCoreMain(unittest.TestCase):
         self.assertTrue(substatus_file_data_patch_metadata_summary["shouldReportToHealthStore"])
         runtime.stop()
 
+    # def test_operation_success_for_autopatching_request_with_security_classification(self):
+    #     # test with valid datetime string for maintenance run id
+    #     argument_composer = ArgumentComposer()
+    #     maintenance_run_id = "9/28/2020 02:00:00 PM +00:00"
+    #     classifications_to_include = ["Security", "Critical"]
+    #     argument_composer.maintenance_run_id = str(maintenance_run_id)
+    #     argument_composer.classifications_to_include = classifications_to_include
+    #     runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.ZYPPER)
+    #     runtime.set_legacy_test_type("HappyPath")
+    #     CoreMain(argument_composer.get_composed_arguments())
+    #     with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
+    #         substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
+    #     self.assertEquals(len(substatus_file_data), 3)
+    #     self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
+    #     self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
+    #     self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
+    #     self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_SUCCESS.lower())
+    #     self.assertTrue(substatus_file_data[2]["name"] == Constants.PATCH_METADATA_FOR_HEALTHSTORE)
+    #     self.assertTrue(substatus_file_data[2]["status"] == Constants.STATUS_SUCCESS.lower())
+    #     substatus_file_data_patch_metadata_summary = json.loads(substatus_file_data[2]["formattedMessage"]["message"])
+    #     self.assertEqual(substatus_file_data_patch_metadata_summary["patchVersion"], "2020.09.28")
+    #     self.assertTrue(substatus_file_data_patch_metadata_summary["shouldReportToHealthStore"])
+    #     runtime.stop()
+
     def test_invalid_maintenance_run_id(self):
         # test with empty string for maintenence run id
         argument_composer = ArgumentComposer()

--- a/src/core/tests/TestPackageFilter.py
+++ b/src/core/tests/TestPackageFilter.py
@@ -102,6 +102,16 @@ class TestPackageFilter(unittest.TestCase):
         self.assertEqual(runtime.package_filter.is_invalid_classification_combination(), True)
         runtime.stop()
 
+    def test_with_none_for_classifications(self):
+        argument_composer = ArgumentComposer()
+        argument_composer.classifications_to_include = None
+        argument_composer.patches_to_include = []
+        argument_composer.patches_to_exclude = []
+        runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True)
+
+        self.assertEqual(runtime.package_filter.is_invalid_classification_combination(), False)
+        runtime.stop()
+
     def test_inclusions(self):
         argument_composer = ArgumentComposer()
         argument_composer.classifications_to_include = []
@@ -120,6 +130,7 @@ class TestPackageFilter(unittest.TestCase):
         self.assertEqual(runtime.package_filter.check_for_inclusion(["kernel", "firefox"]), False)
         self.assertEqual(runtime.package_filter.check_for_inclusion(["firefox", "ssh-client"]), True)
         runtime.stop()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/core/tests/TestStatusHandler.py
+++ b/src/core/tests/TestStatusHandler.py
@@ -141,6 +141,8 @@ class TestStatusHandler(unittest.TestCase):
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"][0]
         self.assertEqual(len(json.loads(substatus_file_data["formattedMessage"]["message"])["errors"]["details"]), 0)
 
+        self.runtime.status_handler.set_assessment_substatus_json(status=Constants.STATUS_SUCCESS)
+
         # Adding multiple exceptions
         self.runtime.status_handler.add_error_to_status("exception1", Constants.PatchOperationErrorCodes.DEFAULT_ERROR)
         self.runtime.status_handler.add_error_to_status("exception2", Constants.PatchOperationErrorCodes.DEFAULT_ERROR)
@@ -159,6 +161,7 @@ class TestStatusHandler(unittest.TestCase):
         with self.runtime.env_layer.file_system.open(self.runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"][0]
 
+        self.assertEqual("Success".lower(), str(substatus_file_data["status"]).lower())
         self.assertNotEqual(json.loads(substatus_file_data["formattedMessage"]["message"])["errors"], None)
         self.assertTrue("Adding same exception" not in str(json.loads(substatus_file_data["formattedMessage"]["message"])["errors"]["details"]))
         self.assertEqual(substatus_file_data["name"], Constants.PATCH_ASSESSMENT_SUMMARY)

--- a/src/core/tests/TestStatusHandler.py
+++ b/src/core/tests/TestStatusHandler.py
@@ -71,6 +71,42 @@ class TestStatusHandler(unittest.TestCase):
         self.assertEqual(json.loads(substatus_file_data["formattedMessage"]["message"])["patches"][1]["name"], "samba-common-bin")
         self.assertEqual(json.loads(substatus_file_data["formattedMessage"]["message"])["patches"][1]["patchInstallationState"], Constants.INSTALLED)
 
+    def test_set_package_install_status_classification(self):
+        packages, package_versions = self.runtime.package_manager.get_all_updates()
+        self.runtime.status_handler.set_package_install_status(packages, package_versions)
+        sec_packages, sec_package_versions = self.runtime.package_manager.get_security_updates()
+        self.runtime.status_handler.set_package_install_status_classification(sec_packages, sec_package_versions, "Security")
+        substatus_file_data = []
+        with self.runtime.env_layer.file_system.open(self.runtime.execution_config.status_file_path, 'r') as file_handle:
+            substatus_file_data = json.load(file_handle)[0]["status"]["substatus"][0]
+        self.assertEqual(substatus_file_data["name"], Constants.PATCH_INSTALLATION_SUMMARY)
+        self.assertEqual(len(json.loads(substatus_file_data["formattedMessage"]["message"])["patches"]), 3)
+        self.assertEqual(json.loads(substatus_file_data["formattedMessage"]["message"])["patches"][0]["name"], "python-samba")
+        self.assertTrue("Security" in str(json.loads(substatus_file_data["formattedMessage"]["message"])["patches"][0]["classifications"]))
+        self.assertEqual(json.loads(substatus_file_data["formattedMessage"]["message"])["patches"][1]["name"], "samba-common-bin")
+        self.assertTrue("Security" in str(json.loads(substatus_file_data["formattedMessage"]["message"])["patches"][1]["classifications"]))
+        self.assertEqual(json.loads(substatus_file_data["formattedMessage"]["message"])["patches"][2]["name"], "samba-libs")
+        self.assertTrue("python-samba_2:4.4.5+dfsg-2ubuntu5.4" in str(json.loads(substatus_file_data["formattedMessage"]["message"])["patches"][0]["patchId"]))
+        self.assertTrue("Security" in str(json.loads(substatus_file_data["formattedMessage"]["message"])["patches"][2]["classifications"]))
+
+    def test_set_package_install_status_classification_not_set(self):
+        packages, package_versions = self.runtime.package_manager.get_all_updates()
+        self.runtime.status_handler.set_package_install_status(packages, package_versions)
+        sec_packages, sec_package_versions = self.runtime.package_manager.get_security_updates()
+        self.runtime.status_handler.set_package_install_status_classification(sec_packages, sec_package_versions)
+        substatus_file_data = []
+        with self.runtime.env_layer.file_system.open(self.runtime.execution_config.status_file_path, 'r') as file_handle:
+            substatus_file_data = json.load(file_handle)[0]["status"]["substatus"][0]
+        self.assertEqual(substatus_file_data["name"], Constants.PATCH_INSTALLATION_SUMMARY)
+        self.assertEqual(len(json.loads(substatus_file_data["formattedMessage"]["message"])["patches"]), 3)
+        self.assertEqual(json.loads(substatus_file_data["formattedMessage"]["message"])["patches"][0]["name"], "python-samba")
+        self.assertTrue("Other" in str(json.loads(substatus_file_data["formattedMessage"]["message"])["patches"][0]["classifications"]))
+        self.assertEqual(json.loads(substatus_file_data["formattedMessage"]["message"])["patches"][1]["name"], "samba-common-bin")
+        self.assertTrue("Other" in str(json.loads(substatus_file_data["formattedMessage"]["message"])["patches"][1]["classifications"]))
+        self.assertEqual(json.loads(substatus_file_data["formattedMessage"]["message"])["patches"][2]["name"], "samba-libs")
+        self.assertTrue("python-samba_2:4.4.5+dfsg-2ubuntu5.4" in str(json.loads(substatus_file_data["formattedMessage"]["message"])["patches"][0]["patchId"]))
+        self.assertTrue("Other" in str(json.loads(substatus_file_data["formattedMessage"]["message"])["patches"][2]["classifications"]))
+
     def test_set_installation_reboot_status(self):
         self.assertRaises(Exception, self.runtime.status_handler.set_installation_reboot_status, "INVALID_STATUS")
 


### PR DESCRIPTION
Contains bug fixes for

1. Patch not correctly classified in PatchInstallationSummary substatus: 
    - All patches in PatchInstallationSummary were classified as 'Other'. This fix will identify the Security patches within PatchInstallationSummary substatus
    - Added unit test and tested reboot scenario

2. Exception raised when classification is not provided in input/config settings
    - Fixed in PackageFilter where the local var self.installation_included_classifications is set.
    - Added tests to cover this case

3. Any exception raised after patch assessment completes and before patch installation starts, were getting logged under the error objects for PatchAssessmentSummary while the status of PatchInstallationSummary was marked as error
    - Since PatchAssessmentSummary is completed, added these errors to PatchInstallationSummary. Fix added in CoreMain, where patch_installer is initialized, which is only step between patch assessment completion and installation start. 
    - This results in setting current_operation for status_handler, within CoreMain, patch_assessor and patch_installer. We can remove setting current_operation from patch_installer, since it is being set within CoreMain, right before installation starts. But keeping both for now

4. Errors added to any of the substatus, from CoreMain (usually when an exception is raised), were resetting the summary status to 'Transitioning' instead of retaining the summary's previous status
    - This was because the default value for status is Transitioning in set_assessment_substatus_json and set_installation_substatus_json, so the function called after assessment and installation were finished (either completed successfully or errored out), were reset when the any error was added from the exception handling part in CoreMain.
    - Fix involves checking the current status and code in set_assessment_substatus_json and set_installation_substatus_json, before setting any value.