### PR TITLE
Fix for rebootPending not set correctly during installation in RHEL and CentOS

### DIFF
--- a/src/core/src/package_managers/YumPackageManager.py
+++ b/src/core/src/package_managers/YumPackageManager.py
@@ -400,5 +400,5 @@ class YumPackageManager(PackageManager):
                 process_count += 1
                 process_list_verbose += process_details[1] + " (" + process_details[0] + "), "  # process name and id
 
-            self.composite_logger.log(" - Processes requiring restart (" + str(process_count) + "): [" + process_list_verbose + "<eol>]")
-            return process_count != 0  # True if there were anys
+        self.composite_logger.log(" - Processes requiring restart (" + str(process_count) + "): [" + process_list_verbose + "<eol>]")
+        return process_count != 0  # True if there were anys

--- a/src/core/src/package_managers/YumPackageManager.py
+++ b/src/core/src/package_managers/YumPackageManager.py
@@ -401,4 +401,4 @@ class YumPackageManager(PackageManager):
                 process_list_verbose += process_details[1] + " (" + process_details[0] + "), "  # process name and id
 
         self.composite_logger.log(" - Processes requiring restart (" + str(process_count) + "): [" + process_list_verbose + "<eol>]")
-        return process_count != 0  # True if there were anys
+        return process_count != 0  # True if there were any

--- a/src/core/tests/TestYumPackageManager.py
+++ b/src/core/tests/TestYumPackageManager.py
@@ -58,12 +58,18 @@ class TestYumPackageManager(unittest.TestCase):
 
     def test_do_processes_require_restart(self):
         """Unit test for yum package manager"""
-        self.runtime.set_legacy_test_type('HappyPath')
 
+        # Restart required
+        self.runtime.set_legacy_test_type('HappyPath')
         package_manager = self.container.get('package_manager')
         self.assertIsNotNone(package_manager)
-
         self.assertTrue(package_manager.do_processes_require_restart())
+
+        # Restart not required
+        self.runtime.set_legacy_test_type('SadPath')
+        package_manager = self.container.get('package_manager')
+        self.assertIsNotNone(package_manager)
+        self.assertFalse(package_manager.do_processes_require_restart())
 
     def test_package_manager(self):
         """Unit test for yum package manager"""

--- a/src/core/tests/TestZypperPackageManager.py
+++ b/src/core/tests/TestZypperPackageManager.py
@@ -143,11 +143,18 @@ class TestZypperPackageManager(unittest.TestCase):
             self.assertFalse(1 != 2, 'Exception did not occur and test failed.')
 
     def test_do_processes_require_restart(self):
-        self.runtime.set_legacy_test_type('HappyPath')
 
+        # Restart required
+        self.runtime.set_legacy_test_type('HappyPath')
         package_manager = self.container.get('package_manager')
         self.assertIsNotNone(package_manager)
         self.assertTrue(package_manager.do_processes_require_restart())
+
+        # Restart not required
+        self.runtime.set_legacy_test_type('SadPath')
+        package_manager = self.container.get('package_manager')
+        self.assertIsNotNone(package_manager)
+        self.assertFalse(package_manager.do_processes_require_restart())
 
     def test_get_all_available_versions_of_package(self):
         self.runtime.set_legacy_test_type('HappyPath')

--- a/src/extension/src/manifest.xml
+++ b/src/extension/src/manifest.xml
@@ -2,7 +2,7 @@
 <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure">
   <ProviderNameSpace>Microsoft.CPlat.Core</ProviderNameSpace>
   <Type>LinuxPatchExtension</Type>
-  <Version>1.6.12</Version>
+  <Version>1.6.13</Version>
   <Label>Microsoft Azure VM InGuest Patch Extension for Linux Virtual Machines</Label>
   <HostingResources>VmRole</HostingResources>
   <MediaLink></MediaLink>


### PR DESCRIPTION
Logs for a test run on a RHEL 7.9 machine with the bug fix, added in the task: 9114160

Bug: rebootPending was being set to null.

Issue:
InstallPatches operation checks if reboot is required on the VM, which is then set in rebootPending flag. 
YumPackageManager, after checking if reboot is required was not returning any value, if reboot was not required, making the function return 'None', which is why rebootPending was set to null in the status.

Fix: Ensuring the function do_processes_require_restart() always returns a value.