### PR TITLE
Adding telemetry in core

### DIFF
--- a/src/core/src/CoreMain.py
+++ b/src/core/src/CoreMain.py
@@ -26,7 +26,7 @@ class CoreMain(object):
         file_logger = bootstrapper.file_logger
         composite_logger = bootstrapper.composite_logger
         stdout_file_mirror = bootstrapper.stdout_file_mirror
-        lifecycle_manager = telemetry_writer = status_handler = None
+        lifecycle_manager = status_handler = None
 
         # Init operation statuses
         patch_operation_requested = Constants.UNKNOWN
@@ -37,7 +37,7 @@ class CoreMain(object):
             # Level 2 bootstrapping
             composite_logger.log_debug("Building out full container...")
             container = bootstrapper.build_out_container()
-            lifecycle_manager, telemetry_writer, status_handler = bootstrapper.build_core_components(container)
+            lifecycle_manager, status_handler = bootstrapper.build_core_components(container)
             composite_logger.log_debug("Completed building out full container.\n\n")
 
             # Basic environment check
@@ -65,6 +65,7 @@ class CoreMain(object):
                 status_handler.set_current_operation(Constants.INSTALLATION)
                 patch_installer = container.get('patch_installer')
                 patch_installation_successful = patch_installer.start_installation()
+                patch_assessment_successful = False
                 patch_assessment_successful = patch_assessor.start_assessment()
 
         except Exception as error:
@@ -78,8 +79,6 @@ class CoreMain(object):
             composite_logger.log_error('TO TROUBLESHOOT, please save this file before the next invocation: ' + bootstrapper.log_file_path)
 
             composite_logger.log_debug("Safely completing required operations after exception...")
-            if telemetry_writer is not None:
-                telemetry_writer.send_error_info("EXCEPTION: " + repr(error))
             if status_handler is not None:
                 composite_logger.log_debug(' - Status handler pending writes flags [I=' + str(patch_installation_successful) + ', A=' + str(patch_assessment_successful) + ']')
                 if patch_operation_requested == Constants.INSTALLATION.lower() and not patch_installation_successful:
@@ -101,9 +100,6 @@ class CoreMain(object):
         finally:
             if lifecycle_manager is not None:
                 lifecycle_manager.update_core_sequence(completed=True)
-
-            telemetry_writer.send_runbook_state_info("Succeeded.")
-            telemetry_writer.close_transports()
 
             stdout_file_mirror.stop()
             file_logger.close(message_at_close="<End of output>")

--- a/src/core/src/bootstrap/Bootstrapper.py
+++ b/src/core/src/bootstrap/Bootstrapper.py
@@ -46,8 +46,8 @@ class Bootstrapper(object):
         self.file_logger = self.container.get('file_logger')
         if capture_stdout:
             self.stdout_file_mirror = StdOutFileMirror(self.env_layer, self.file_logger)
+        self.telemetry_writer = self.container.get('telemetry_writer')
         self.composite_logger = self.container.get('composite_logger')
-        self.telemetry_writer = None
 
         print("\nCompleted building bootstrap container configuration.\n")
 
@@ -109,11 +109,9 @@ class Bootstrapper(object):
     def build_core_components(self, container):
         self.composite_logger.log_debug(" - Instantiating lifecycle manager.")
         lifecycle_manager = container.get('lifecycle_manager')
-        self.composite_logger.log_debug(" - Instantiating telemetry writer.")
-        telemetry_writer = container.get('telemetry_writer')
         self.composite_logger.log_debug(" - Instantiating progress status writer.")
         status_handler = container.get('status_handler')
-        return lifecycle_manager, telemetry_writer, status_handler
+        return lifecycle_manager, status_handler
 
     def bootstrap_splash_text(self):
         self.composite_logger.log("\n\n[%exec_name%] \t -- \t Copyright (c) Microsoft Corporation. All rights reserved. \nApplication version: 3.0.[%exec_sub_ver%]\n\n")

--- a/src/core/src/bootstrap/ConfigurationFactory.py
+++ b/src/core/src/bootstrap/ConfigurationFactory.py
@@ -119,6 +119,11 @@ class ConfigurationFactory(object):
                     'emulator_enabled': emulator_enabled
                 }
             },
+            'telemetry_writer': {
+                'component': TelemetryWriter,
+                'component_args': [],
+                'component_kwargs': {}
+            },
             'file_logger': {
                 'component': FileLogger,
                 'component_args': ['env_layer'],
@@ -128,7 +133,7 @@ class ConfigurationFactory(object):
             },
             'composite_logger': {
                 'component': CompositeLogger,
-                'component_args': ['env_layer', 'file_logger'],
+                'component_args': ['env_layer', 'file_logger', 'telemetry_writer'],
                 'component_kwargs': {
                     'current_env': config_env
                 }
@@ -148,22 +153,17 @@ class ConfigurationFactory(object):
             'package_manager_name': package_manager_name,
             'lifecycle_manager': {
                 'component': LifecycleManager,
-                'component_args': ['env_layer', 'execution_config', 'composite_logger', 'telemetry_writer'],
+                'component_args': ['env_layer', 'execution_config', 'composite_logger'],
                 'component_kwargs': {}
             },
             'status_handler': {
                 'component': StatusHandler,
-                'component_args': ['env_layer', 'execution_config', 'composite_logger', 'telemetry_writer'],
-                'component_kwargs': {}
-            },
-            'telemetry_writer': {
-                'component': TelemetryWriter,
-                'component_args': ['env_layer', 'execution_config'],
+                'component_args': ['env_layer', 'execution_config', 'composite_logger'],
                 'component_kwargs': {}
             },
             'package_manager': {
                 'component': package_manager_component,
-                'component_args': ['env_layer', 'execution_config', 'composite_logger', 'telemetry_writer', 'status_handler'],
+                'component_args': ['env_layer', 'execution_config', 'composite_logger', 'status_handler'],
                 'component_kwargs': {}
             },
             'reboot_manager': {
@@ -180,12 +180,12 @@ class ConfigurationFactory(object):
             },
             'patch_assessor': {
                 'component': PatchAssessor,
-                'component_args': ['env_layer', 'execution_config', 'composite_logger', 'telemetry_writer', 'status_handler', 'package_manager'],
+                'component_args': ['env_layer', 'execution_config', 'composite_logger', 'status_handler', 'package_manager'],
                 'component_kwargs': {}
             },
             'patch_installer': {
                 'component': PatchInstaller,
-                'component_args': ['env_layer', 'execution_config', 'composite_logger', 'telemetry_writer', 'status_handler', 'lifecycle_manager', 'package_manager', 'package_filter', 'maintenance_window', 'reboot_manager'],
+                'component_args': ['env_layer', 'execution_config', 'composite_logger', 'status_handler', 'lifecycle_manager', 'package_manager', 'package_filter', 'maintenance_window', 'reboot_manager'],
                 'component_kwargs': {}
             },
             'maintenance_window': {

--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -29,6 +29,9 @@ class Constants(object):
     GLOBAL_EXCLUSION_LIST = ""   # if a package needs to be blocked across all of Azure
     UNKNOWN = "Unknown"
 
+    # Extension version (todo: move to a different file)
+    EXT_VERSION = "1.6.12"
+
     # Runtime environments
     TEST = 'Test'
     DEV = 'Dev'
@@ -47,6 +50,7 @@ class Constants(object):
         LOG_FOLDER = "logFolder"
         CONFIG_FOLDER = "configFolder"
         STATUS_FOLDER = "statusFolder"
+        EVENTS_FOLDER = "eventsFolder"
 
     class ConfigSettings(EnumBackport):
         OPERATION = 'operation'
@@ -163,13 +167,23 @@ class Constants(object):
 
     ERROR_ADDED_TO_STATUS = "Error_added_to_status"
 
-    # Telemetry Categories
-    TELEMETRY_OPERATION_STATE = "State"
-    TELEMETRY_CONFIG = "Config"
-    TELEMETRY_PACKAGE = "PackageInfo"
-    TELEMETRY_ERROR = "Error"
-    TELEMETRY_INFO = "Info"
-    TELEMETRY_DEBUG = "Debug"
+    # Telemetry Settings
+    TELEMETRY_MSG_SIZE_LIMIT_IN_BYTES = 3072  # 3KB
+    TELEMETRY_EVENT_SIZE_LIMIT_IN_BYTES = 6144  # 6KB
+    TELEMETRY_EVENT_FILE_SIZE_LIMIT_IN_BYTES = 4194304  # 4MB
+    TELEMETRY_DIR_SIZE_LIMIT_IN_BYTES = 41943040  # 40MB
+    TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_BYTES = 80  # buffer for the bytes dropped text added at the end of the truncated telemetry message
+
+    # Telemetry Event Level
+    class TelemetryEventLevel(EnumBackport):
+        Critical = "Critical"
+        Error = "Error"
+        Warning = "Warning"
+        Verbose = "Verbose"
+        Informational = "Informational"
+        LogAlways = "LogAlways"
+
+    UTC_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
     # EnvLayer Constants
     class EnvLayer(EnumBackport):

--- a/src/core/src/bootstrap/EnvLayer.py
+++ b/src/core/src/bootstrap/EnvLayer.py
@@ -419,7 +419,7 @@ class EnvLayer(object):
 
         try:
             record = {
-                "timestamp": str(timestamp) if timestamp is not None else datetime.datetime.strptime(str(datetime.datetime.utcnow()).split(".")[0], "%Y-%m-%dT%H:%M:%SZ"), #WRONG
+                "timestamp": str(timestamp) if timestamp is not None else datetime.datetime.strptime(str(datetime.datetime.utcnow()).split(".")[0], Constants.UTC_DATETIME_FORMAT), #WRONG
                 "operation": str(operation),
                 "code": int(code),
                 "output": base64.b64encode(str(output)),

--- a/src/core/src/core_logic/ExecutionConfig.py
+++ b/src/core/src/core_logic/ExecutionConfig.py
@@ -41,6 +41,7 @@ class ExecutionConfig(object):
         self.log_folder = self.environment_settings[Constants.EnvSettings.LOG_FOLDER]
         self.config_folder = self.environment_settings[Constants.EnvSettings.CONFIG_FOLDER]
         self.status_folder = self.environment_settings[Constants.EnvSettings.STATUS_FOLDER]
+        self.events_folder = self.environment_settings[Constants.EnvSettings.EVENTS_FOLDER]
 
         # Config Settings
         self.composite_logger.log_debug(" - Parsing configuration settings... [ConfigSettings={0}]".format(str(self.config_settings)))
@@ -58,6 +59,8 @@ class ExecutionConfig(object):
             self.reboot_setting = self.__get_execution_configuration_value_safely(self.config_settings, Constants.ConfigSettings.REBOOT_SETTING, Constants.REBOOT_NEVER)     # safe extension-level default
 
         # Derived Settings
+        self.composite_logger.telemetry_writer.events_folder_path = self.events_folder
+        self.composite_logger.telemetry_writer.set_operation_id(self.activity_id)
         self.composite_logger.log_debug(" - Establishing data publishing paths...")
         self.log_file_path = os.path.join(self.log_folder, str(self.sequence_number) + ".core.log")
         self.composite_logger.log_debug("  -- Core log: " + str(self.log_file_path))

--- a/src/core/src/core_logic/ExecutionConfig.py
+++ b/src/core/src/core_logic/ExecutionConfig.py
@@ -59,8 +59,8 @@ class ExecutionConfig(object):
             self.reboot_setting = self.__get_execution_configuration_value_safely(self.config_settings, Constants.ConfigSettings.REBOOT_SETTING, Constants.REBOOT_NEVER)     # safe extension-level default
 
         # Derived Settings
-        self.composite_logger.telemetry_writer.events_folder_path = self.events_folder
-        self.composite_logger.telemetry_writer.set_operation_id(self.activity_id)
+        # self.composite_logger.telemetry_writer.events_folder_path = self.events_folder
+        # self.composite_logger.telemetry_writer.set_operation_id(self.activity_id)
         self.composite_logger.log_debug(" - Establishing data publishing paths...")
         self.log_file_path = os.path.join(self.log_folder, str(self.sequence_number) + ".core.log")
         self.composite_logger.log_debug("  -- Core log: " + str(self.log_file_path))

--- a/src/core/src/core_logic/PatchAssessor.py
+++ b/src/core/src/core_logic/PatchAssessor.py
@@ -21,12 +21,11 @@ from core.src.bootstrap.Constants import Constants
 
 class PatchAssessor(object):
     """ Wrapper class of a single patch assessment """
-    def __init__(self, env_layer, execution_config, composite_logger, telemetry_writer, status_handler, package_manager):
+    def __init__(self, env_layer, execution_config, composite_logger, status_handler, package_manager):
         self.env_layer = env_layer
         self.execution_config = execution_config
 
         self.composite_logger = composite_logger
-        self.telemetry_writer = telemetry_writer
         self.status_handler = status_handler
 
         self.package_manager = package_manager
@@ -48,10 +47,8 @@ class PatchAssessor(object):
         for i in range(0, Constants.MAX_ASSESSMENT_RETRY_COUNT):
             try:
                 packages, package_versions = self.package_manager.get_all_updates()
-                self.telemetry_writer.send_debug_info("Full assessment: " + str(packages))
                 self.status_handler.set_package_assessment_status(packages, package_versions)
                 sec_packages, sec_package_versions = self.package_manager.get_security_updates()
-                self.telemetry_writer.send_debug_info("Security assessment: " + str(sec_packages))
                 self.status_handler.set_package_assessment_status(sec_packages, sec_package_versions, "Security")
                 self.status_handler.set_assessment_substatus_json(status=Constants.STATUS_SUCCESS)
                 break

--- a/src/core/src/core_logic/PatchAssessor.py
+++ b/src/core/src/core_logic/PatchAssessor.py
@@ -77,11 +77,10 @@ class PatchAssessor(object):
         if self.execution_config.events_folder is None:
             error_msg = "The minimum Azure Linux Agent version prerequisite for Linux patching was not met. Please update the Azure Linux Agent on this machine."
             self.composite_logger.log_error(error_msg)
-            self.status_handler.add_error_to_status(error_msg, Constants.PatchOperationErrorCodes.DEFAULT_ERROR)
-            self.status_handler.set_assessment_substatus_json(status=Constants.STATUS_ERROR)
-            raise Exception(error_msg, "[{0}]".format(Constants.ERROR_ADDED_TO_STATUS))
+            raise Exception(error_msg)
 
-        self.composite_logger.log("The minimum Azure Linux Agent version prerequisite for Linux patching was met.")
         self.composite_logger.telemetry_writer.events_folder_path = self.execution_config.events_folder
         self.composite_logger.telemetry_writer.set_operation_id(self.execution_config.activity_id)
+        self.composite_logger.log("The minimum Azure Linux Agent version prerequisite for Linux patching was met.")
+
 

--- a/src/core/src/local_loggers/CompositeLogger.py
+++ b/src/core/src/local_loggers/CompositeLogger.py
@@ -22,20 +22,26 @@ from core.src.bootstrap.Constants import Constants
 class CompositeLogger(object):
     """ Manages diverting different kinds of output to the right sinks for them. """
 
-    def __init__(self, env_layer=None, file_logger=None, current_env=None):
+    def __init__(self, env_layer=None, file_logger=None, telemetry_writer=None, current_env=None):
         self.env_layer = env_layer
         self.file_logger = file_logger
+        self.telemetry_writer = telemetry_writer
         self.ERROR = "ERROR:"
         self.WARNING = "WARNING:"
         self.DEBUG = "DEBUG:"
         self.VERBOSE = "VERBOSE:"
         self.current_env = current_env
         self.NEWLINE_REPLACE_CHAR = " "
+        self.telemetry_task = "ExtensionCoreLog"
+        self.telemetry_msg_truncated_note = " This message will be truncated in telemetry as it exceeds the size limit."
 
-    def log(self, message):
+    def log(self, message, message_type=Constants.TelemetryEventLevel.Informational):
         """log output"""
         message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
         message = message.strip()
+        if self.telemetry_writer is not None and self.telemetry_writer.events_folder_path is not None:
+            self.telemetry_writer.write_event(self.telemetry_task, message, message_type)
+            message = self.__add_telemetry_error_note(message)
         if self.current_env in (Constants.DEV, Constants.TEST):
             for line in message.splitlines():  # allows the extended file logger to strip unnecessary white space
                 print(line)
@@ -47,26 +53,34 @@ class CompositeLogger(object):
         """log errors"""
         message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
         message = self.ERROR + (self.NEWLINE_REPLACE_CHAR.join(message.split(os.linesep))).strip()
-        self.log(message)
+        self.log(message, message_type=Constants.TelemetryEventLevel.Error)
 
     def log_warning(self, message):
         """log warning"""
         message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
         message = self.WARNING + (self.NEWLINE_REPLACE_CHAR.join(message.split(os.linesep))).strip()
-        self.log(message)
+        self.log(message, message_type=Constants.TelemetryEventLevel.Warning)
 
     def log_debug(self, message):
         """log debug"""
         message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
         message = message.strip()
+        if self.telemetry_writer is not None and self.telemetry_writer.events_folder_path is not None and self.current_env not in (Constants.DEV, Constants.TEST):
+            self.telemetry_writer.write_event(self.telemetry_task, message, Constants.TelemetryEventLevel.Verbose)
+            message = self.__add_telemetry_error_note(message)
+
         if self.current_env in (Constants.DEV, Constants.TEST):
-            self.log(self.current_env + ": " + message)  # send to standard output if dev or test env
+            self.log(self.current_env + ": " + message, Constants.TelemetryEventLevel.Verbose)  # send to standard output if dev or test env
         elif self.file_logger is not None:
             self.file_logger.write("\n\t" + self.DEBUG + " " + "\n\t".join(message.splitlines()).strip())
 
     def log_verbose(self, message):
         """log verbose"""
         message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
+        if self.telemetry_writer is not None and self.telemetry_writer.events_folder_path is not None:
+            self.telemetry_writer.write_event(self.telemetry_task, message, Constants.TelemetryEventLevel.Verbose)
+            message = self.__add_telemetry_error_note(message)
+
         if self.file_logger is not None:
             self.file_logger.write("\n\t" + self.VERBOSE + " " + "\n\t".join(message.strip().splitlines()).strip())
 
@@ -75,5 +89,11 @@ class CompositeLogger(object):
         """Remove substring from a string"""
         if substring in message:
             message = message.replace("[{0}]".format(Constants.ERROR_ADDED_TO_STATUS), "")
+        return message
+
+    def __add_telemetry_error_note(self, message):
+        """ Adding telemetry error messages to the original message, so as to log telemetry errors in other logs """
+        if len(message.encode('utf-8')) > Constants.TELEMETRY_MSG_SIZE_LIMIT_IN_BYTES:
+            message = message + self.telemetry_msg_truncated_note
         return message
 

--- a/src/core/src/package_managers/AptitudePackageManager.py
+++ b/src/core/src/package_managers/AptitudePackageManager.py
@@ -26,8 +26,8 @@ class AptitudePackageManager(PackageManager):
     """Implementation of Debian/Ubuntu based package management operations"""
 
     # For more details, try `man apt-get` on any Debian/Ubuntu based box.
-    def __init__(self, env_layer, execution_config, composite_logger, telemetry_writer, status_handler):
-        super(AptitudePackageManager, self).__init__(env_layer, execution_config, composite_logger, telemetry_writer, status_handler)
+    def __init__(self, env_layer, execution_config, composite_logger, status_handler):
+        super(AptitudePackageManager, self).__init__(env_layer, execution_config, composite_logger, status_handler)
         # Repo refresh
         self.repo_refresh = 'sudo apt-get -q update'
 
@@ -75,7 +75,6 @@ class AptitudePackageManager(PackageManager):
                                             'Patch Management cannot proceed successfully. Before the next Patch Operation, please run the following '
                                             'command and perform any configuration steps necessary on the machine to return it to a healthy state: '
                                             'sudo dpkg --configure -a')
-            self.telemetry_writer.send_execution_error(command, code, out)
             error_msg = 'Package manager on machine is not healthy. To fix, please run: sudo dpkg --configure -a'
             self.status_handler.add_error_to_status(error_msg, Constants.PatchOperationErrorCodes.PACKAGE_MANAGER_FAILURE)
             raise Exception(error_msg, "[{0}]".format(Constants.ERROR_ADDED_TO_STATUS))
@@ -83,7 +82,6 @@ class AptitudePackageManager(PackageManager):
             self.composite_logger.log('[ERROR] Package manager was invoked using: ' + command)
             self.composite_logger.log_warning(" - Return code from package manager: " + str(code))
             self.composite_logger.log_warning(" - Output from package manager: \n|\t" + "\n|\t".join(out.splitlines()))
-            self.telemetry_writer.send_execution_error(command, code, out)
             error_msg = 'Unexpected return code (' + str(code) + ') from package manager on command: ' + command
             self.status_handler.add_error_to_status(error_msg, Constants.PatchOperationErrorCodes.PACKAGE_MANAGER_FAILURE)
             raise Exception(error_msg, "[{0}]".format(Constants.ERROR_ADDED_TO_STATUS))
@@ -242,7 +240,6 @@ class AptitudePackageManager(PackageManager):
                 else:
                     self.composite_logger.log_debug("    - Inapplicable line: " + str(line))
 
-            self.telemetry_writer.send_debug_info("[Installed check] Return code: 1. Unable to verify package not present on the system: " + str(output))
         elif code == 0:  # likely found
             # Sample output format ------------------------------------------
             # Package: mysql-server
@@ -262,33 +259,28 @@ class AptitudePackageManager(PackageManager):
                 if 'Package: ' in line:
                     if package_name in line:
                         composite_found_flag = composite_found_flag | 1
-                    else:  # should never hit for the way this is invoked, hence telemetry
+                    else:  # should never hit for the way this is invoked, hence log
                         self.composite_logger.log_debug("    - Did not match name: " + str(package_name) + " (" + str(line) + ")")
-                        self.telemetry_writer.send_debug_info("[Installed check] Name did not match: " + package_name + " (line=" + str(line) + ")(out=" + str(output) + ")")
                     continue
                 if 'Version: ' in line:
                     if package_version in line:
                         composite_found_flag = composite_found_flag | 2
-                    else:  # should never hit for the way this is invoked, hence telemetry
+                    else:  # should never hit for the way this is invoked, hence log
                         self.composite_logger.log_debug("    - Did not match version: " + str(package_version) + " (" + str(line) + ")")
-                        self.telemetry_writer.send_debug_info("[Installed check] Version did not match: " + str(package_version) + " (line=" + str(line) + ")(out=" + str(output) + ")")
                     continue
                 if 'Status: ' in line:
                     if 'install ok installed' in line:
                         composite_found_flag = composite_found_flag | 4
-                    else:  # should never hit for the way this is invoked, hence telemetry
+                    else:  # should never hit for the way this is invoked, hence log
                         self.composite_logger.log_debug("    - Did not match status: " + str(package_name) + " (" + str(line) + ")")
-                        self.telemetry_writer.send_debug_info("[Installed check] Status did not match: 'install ok installed' (line=" + str(line) + ")(out=" + str(output) + ")")
                     continue
                 if composite_found_flag & 7 == 7:  # whenever this becomes true, the exact package version is installed
                     self.composite_logger.log_debug("    - Package, Version and Status matched. Package is detected as 'Installed'.")
                     return True
                 self.composite_logger.log_debug("    - Inapplicable line: " + str(line))
             self.composite_logger.log_debug("    - Install status check did NOT find the package installed: (composite_found_flag=" + str(composite_found_flag) + ")")
-            self.telemetry_writer.send_debug_info("Install status check did NOT find the package installed: (composite_found_flag=" + str(composite_found_flag) + ")(output=" + output + ")")
-        else:  # This is not expected to execute. If it does, the details will show up in telemetry. Improve this code with that information.
+        else:  # This is not expected to execute. If it does, the details will show up in logs. Improve this code with that information.
             self.composite_logger.log_debug("    - Unexpected return code from dpkg: " + str(code) + ". Output: " + str(output))
-            self.telemetry_writer.send_debug_info("Unexpected return code from dpkg: Cmd=" + str(cmd) + ". Code=" + str(code) + ". Output=" + str(output))
 
         # SECONDARY METHOD - Fallback
         # Sample output format
@@ -316,7 +308,6 @@ class AptitudePackageManager(PackageManager):
                     self.composite_logger.log_debug("      - Did not find status: " + str(package_details[3] + " (" + str(package_details[3]) + ")"))
                     continue
                 self.composite_logger.log_debug("      - Package version specified was determined to be installed.")
-                self.telemetry_writer.send_debug_info("[Installed check] Fallback code disagreed with dpkg.")
                 return True
 
         self.composite_logger.log_debug("   - Package version specified was determined to NOT be installed.")

--- a/src/core/src/package_managers/PackageManager.py
+++ b/src/core/src/package_managers/PackageManager.py
@@ -25,10 +25,9 @@ import time
 class PackageManager(object):
     """Base class of package manager"""
 
-    def __init__(self, env_layer, execution_config, composite_logger, telemetry_writer, status_handler):
+    def __init__(self, env_layer, execution_config, composite_logger, status_handler):
         self.env_layer = env_layer
         self.composite_logger = composite_logger
-        self.telemetry_writer = telemetry_writer
         self.status_handler = status_handler
         self.single_package_upgrade_cmd = ''
         self.single_package_upgrade_simulation_cmd = 'simulate-install'
@@ -261,15 +260,6 @@ class PackageManager(object):
                 self.composite_logger.log_warning(" - [Info] Desired package version was installed, but the package manager returned a non-zero return code: " + str(code) + ". Command used: " + exec_cmd + "\n")
             else:
                 code_path += " > Info, Package installed, zero return. (succeeded)"
-
-        if not simulate:
-            if install_result == Constants.FAILED:
-                error = self.telemetry_writer.send_package_info(package_and_dependencies[0], package_and_dependency_versions[0], package_size, round(time.time() - start_time, 2), install_result, code_path, exec_cmd, str(out))
-            else:
-                error = self.telemetry_writer.send_package_info(package_and_dependencies[0], package_and_dependency_versions[0], package_size, round(time.time() - start_time, 2), install_result, code_path, exec_cmd)
-
-            if error is not None:
-                self.composite_logger.log_debug('\nEXCEPTION writing package telemetry: ' + repr(error))
 
         return install_result
     # endregion

--- a/src/core/src/package_managers/YumPackageManager.py
+++ b/src/core/src/package_managers/YumPackageManager.py
@@ -23,8 +23,8 @@ from core.src.bootstrap.Constants import Constants
 class YumPackageManager(PackageManager):
     """Implementation of Redhat/CentOS package management operations"""
 
-    def __init__(self, env_layer, execution_config, composite_logger, telemetry_writer, status_handler):
-        super(YumPackageManager, self).__init__(env_layer, execution_config, composite_logger, telemetry_writer, status_handler)
+    def __init__(self, env_layer, execution_config, composite_logger, status_handler):
+        super(YumPackageManager, self).__init__(env_layer, execution_config, composite_logger, status_handler)
         # Repo refresh
         # There is no command as this is a no op.
 
@@ -68,7 +68,6 @@ class YumPackageManager(PackageManager):
             self.composite_logger.log('[ERROR] Package manager was invoked using: ' + command)
             self.composite_logger.log_warning(" - Return code from package manager: " + str(code))
             self.composite_logger.log_warning(" - Output from package manager: \n|\t" + "\n|\t".join(out.splitlines()))
-            self.telemetry_writer.send_execution_error(command, code, out)
             error_msg = 'Unexpected return code (' + str(code) + ') from package manager on command: ' + command
             self.status_handler.add_error_to_status(error_msg, Constants.PatchOperationErrorCodes.PACKAGE_MANAGER_FAILURE)
             raise Exception(error_msg, "[{0}]".format(Constants.ERROR_ADDED_TO_STATUS))

--- a/src/core/src/package_managers/ZypperPackageManager.py
+++ b/src/core/src/package_managers/ZypperPackageManager.py
@@ -23,8 +23,8 @@ from core.src.bootstrap.Constants import Constants
 class ZypperPackageManager(PackageManager):
     """Implementation of SUSE package management operations"""
 
-    def __init__(self, env_layer, execution_config, composite_logger, telemetry_writer, status_handler):
-        super(ZypperPackageManager, self).__init__(env_layer, execution_config, composite_logger, telemetry_writer, status_handler)
+    def __init__(self, env_layer, execution_config, composite_logger, status_handler):
+        super(ZypperPackageManager, self).__init__(env_layer, execution_config, composite_logger, status_handler)
         # Repo refresh
         self.repo_clean = 'sudo zypper clean -a'
         self.repo_refresh = 'sudo zypper refresh'
@@ -64,7 +64,6 @@ class ZypperPackageManager(PackageManager):
             self.composite_logger.log('[ERROR] Package manager was invoked using: ' + command)
             self.composite_logger.log_warning(" - Return code from package manager: " + str(code))
             self.composite_logger.log_warning(" - Output from package manager: \n|\t" + "\n|\t".join(out.splitlines()))
-            self.telemetry_writer.send_execution_error(command, code, out)
             error_msg = 'Unexpected return code (' + str(code) + ') from package manager on command: ' + command
             self.status_handler.add_error_to_status(error_msg, Constants.PatchOperationErrorCodes.PACKAGE_MANAGER_FAILURE)
             raise Exception(error_msg, "[{0}]".format(Constants.ERROR_ADDED_TO_STATUS))

--- a/src/core/src/service_interfaces/LifecycleManager.py
+++ b/src/core/src/service_interfaces/LifecycleManager.py
@@ -24,11 +24,10 @@ from core.src.bootstrap.Constants import Constants
 class LifecycleManager(object):
     """Class for managing the core code's lifecycle within the extension wrapper"""
 
-    def __init__(self, env_layer, execution_config, composite_logger, telemetry_writer):
+    def __init__(self, env_layer, execution_config, composite_logger):
         self.env_layer = env_layer
         self.execution_config = execution_config
         self.composite_logger = composite_logger
-        self.telemetry_writer = telemetry_writer
 
         # Handshake file paths
         self.ext_state_file_path = os.path.join(self.execution_config.config_folder, Constants.EXT_STATE_FILE)

--- a/src/core/src/service_interfaces/StatusHandler.py
+++ b/src/core/src/service_interfaces/StatusHandler.py
@@ -25,12 +25,11 @@ from core.src.bootstrap.Constants import Constants
 class StatusHandler(object):
     """Class for managing the core code's lifecycle within the extension wrapper"""
 
-    def __init__(self, env_layer, execution_config, composite_logger, telemetry_writer):
+    def __init__(self, env_layer, execution_config, composite_logger):
         # Map supporting components for operation
         self.env_layer = env_layer
         self.execution_config = execution_config
         self.composite_logger = composite_logger
-        self.telemetry_writer = telemetry_writer    # not used immediately but need to know if there are issues persisting status
         self.status_file_path = self.execution_config.status_file_path
         self.__log_file_path = self.execution_config.log_file_path
 

--- a/src/core/src/service_interfaces/TelemetryWriter.py
+++ b/src/core/src/service_interfaces/TelemetryWriter.py
@@ -14,131 +14,123 @@
 #
 # Requires Python 2.7+
 
+import datetime
 import json
+import os
+import re
+import shutil
+import tempfile
+import time
+
 from core.src.bootstrap.Constants import Constants
 
 
 class TelemetryWriter(object):
-    """Class for writing telemetry data to data transports"""
+    """Class for writing telemetry data to events"""
 
-    def __init__(self, env_layer, execution_config):
-        self.data_transports = []
-        self.env_layer = env_layer
-        self.activity_id = execution_config.activity_id
+    def __init__(self):
+        self.events_folder_path = None
+        self.operation_id = ""
 
-        # Init state report
-        self.send_runbook_state_info('Started Linux patch runbook.')
-        self.send_machine_config_info()
-        self.send_config_info(execution_config.config_settings, 'execution_config')
-
-    # region Primary payloads
-    def send_runbook_state_info(self, state_info):
-        # Expected to send up only pivotal runbook state changes
-        return self.try_send_message(state_info, Constants.TELEMETRY_OPERATION_STATE)
-
-    def send_config_info(self, config_info, config_type='unknown'):
-        # Configuration info
-        payload_json = {
-            'config_type': config_type,
-            'config_value': config_info
+    def __new_event_json(self, task_name, event_level, message):
+        return {
+            "Version": Constants.EXT_VERSION,
+            "Timestamp": str((datetime.datetime.utcnow()).strftime(Constants.UTC_DATETIME_FORMAT)),
+            "TaskName": task_name,
+            "EventLevel": event_level,
+            "Message": self.__ensure_message_restriction_compliance(message),
+            "EventPid": "",
+            "EventTid": "",
+            "OperationId": self.operation_id  # we can provide activity id from config settings here, but currently we only read settings file for enable command
         }
-        return self.try_send_message(payload_json, Constants.TELEMETRY_CONFIG)
 
-    def send_package_info(self, package_name, package_ver, package_size, install_dur, install_result, code_path, install_cmd, output=''):
-        # Package information compiled after the package is attempted to be installed
-        max_output_length = 3072
-        errors = ""
+    @staticmethod
+    def __ensure_message_restriction_compliance(full_message):
+        """ Removes line breaks, tabs and restricts message to a byte limit """
+        message_size_limit_in_bytes = Constants.TELEMETRY_MSG_SIZE_LIMIT_IN_BYTES
+        formatted_message = re.sub(r"\s+", " ", str(full_message))
 
-        # primary payload
-        message = {'package_name': str(package_name), 'package_version': str(package_ver),
-                   'package_size': str(package_size), 'install_duration': str(install_dur),
-                   'install_result': str(install_result), 'code_path': code_path,
-                   'install_cmd': str(install_cmd), 'output': str(output)[0:max_output_length]}
-        errors += self.try_send_message(message, Constants.TELEMETRY_PACKAGE)
+        if len(formatted_message.encode('utf-8')) > message_size_limit_in_bytes:
+            formatted_message = formatted_message.encode('utf-8')
+            bytes_dropped = len(formatted_message) - message_size_limit_in_bytes + Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_BYTES
+            return formatted_message[:message_size_limit_in_bytes - Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_BYTES].decode('utf-8') + '. [{0} bytes dropped]'.format(bytes_dropped)
 
-        # additional message payloads for output continuation only if we need it for specific troubleshooting
-        if len(output) > max_output_length:
-            for i in range(1, int(len(output)/max_output_length) + 1):
-                message = {'install_cmd': str(install_cmd), 'output_continuation': str(output)[(max_output_length*i):(max_output_length*(i+1))]}
-                errors += self.try_send_message(message, Constants.TELEMETRY_PACKAGE)
+        return formatted_message
 
-        return errors  # if any. Nobody consumes this at the time of this writing.
+    def write_event(self, task_name, message, event_level=Constants.TelemetryEventLevel.Informational):
+        """ Creates and writes event to event file after validating none of the telemetry size restrictions are breached """
+        self.__delete_older_events()
 
-    def send_error_info(self, error_info):
-        # Expected to log significant errors or exceptions
-        return self.try_send_message(error_info, Constants.TELEMETRY_ERROR)
-
-    def send_debug_info(self, error_info):
-        # Usually expected to instrument possibly problematic code
-        return self.try_send_message(error_info, Constants.TELEMETRY_DEBUG)
-
-    def send_info(self, info):
-        # Usually expected to be significant runbook output
-        return self.try_send_message(info, Constants.TELEMETRY_INFO)
-    # endregion
-
-    # Composed payload
-    def send_machine_config_info(self):
-        # Machine info - sent only once at the start of the run
-        machine_info = {
-            'platform_name': str(self.env_layer.platform.linux_distribution()[0]),
-            'platform_version': str(self.env_layer.platform.linux_distribution()[1]),
-            'machine_cpu': self.get_machine_processor(),
-            'machine_arch': str(self.env_layer.platform.machine()),
-            'disk_type': self.get_disk_type()
-        }
-        return self.send_config_info(machine_info, 'machine_config')
-
-    def send_execution_error(self, cmd, code, output):
-        # Expected to log any errors from a cmd execution, including package manager execution errors
-        error_payload = {
-            'cmd': str(cmd),
-            'code': str(code),
-            'output': str(output)[0:3072]
-        }
-        return self.send_error_info(error_payload)
-    # endregion
-
-    # region Transport layer
-    def try_send_message(self, message, category=Constants.TELEMETRY_INFO):
-        """ Tries to send a message immediately. Returns None if successful. Error message if not."""
-        try:
-            payload = {'activity_id': str(self.activity_id), 'category': str(category), 'ver': "[%runbook_sub_ver%]", 'message': message}
-            payload = json.dumps(payload)[0:4095]
-            for transport in self.data_transports:
-                transport.write(payload)
-            return ""  # for consistency
-        except Exception as error:
-            return repr(error)  # if the caller cares
-
-    def close_transports(self):
-        """Close data transports"""
-        self.send_runbook_state_info('Closing telemetry channel(s).')
-        for transport in self.data_transports:
-            transport.close()
-    # endregion
-
-    # region Machine config retrieval methods
-    def get_machine_processor(self):
-        """Retrieve machine processor info"""
-        cmd = "cat /proc/cpuinfo | grep name"
-        code, out = self.env_layer.run_command_output(cmd, False, False)
-
-        if out == "" or "not recognized as an internal or external command" in out:
-            return "No information found"
-        # Example output:
-        # model name	: Intel(R) Core(TM) i7-6700 CPU @ 3.40GHz
-        lines = out.split("\n")
-        return lines[0].split(":")[1].lstrip()
-
-    def get_disk_type(self):
-        """ Retrieve disk info """
-        cmd = "cat /sys/block/sda/queue/rotational"
-        code, out = self.env_layer.run_command_output(cmd, False, False)
-        if "1" in out:
-            return "Hard drive"
-        elif "0" in out:
-            return "SSD"
+        event = self.__new_event_json(task_name, event_level, message)
+        if len(json.dumps(event)) > Constants.TELEMETRY_EVENT_SIZE_LIMIT_IN_BYTES:
+            print("Cannot send data to telemetry as it exceeded the acceptable data size. [Data not sent={0}]".format(json.dumps(message)))
         else:
-            return "Unknown"
-    # end region
+            self.write_event_using_temp_file(self.events_folder_path, event)
+
+    def __delete_older_events(self):
+        """ Delete older events until the at least one new event file can be added as per the size restrictions """
+        if self.__get_events_dir_size() < Constants.TELEMETRY_DIR_SIZE_LIMIT_IN_BYTES - Constants.TELEMETRY_EVENT_FILE_SIZE_LIMIT_IN_BYTES:
+            # Not deleting any existing event files as the event directory does not exceed max limit. At least one new event file can be added. Not printing this statement as it will add repetitive logs
+            return
+
+        print("Events directory size exceeds maximum limit. Deleting older event files until at least one new event file can be added.")
+        event_files = [os.path.join(self.events_folder_path, event_file) for event_file in os.listdir(self.events_folder_path) if (event_file.lower().endswith(".json"))]
+        event_files.sort(key=os.path.getmtime, reverse=True)
+
+        for event_file in event_files:
+            try:
+                if self.__get_events_dir_size() < Constants.TELEMETRY_DIR_SIZE_LIMIT_IN_BYTES - Constants.TELEMETRY_EVENT_FILE_SIZE_LIMIT_IN_BYTES:
+                    # Not deleting any more event files as the event directory has sufficient space to add at least one new event file.  Not printing this statement as it will add repetitive logs
+                    break
+
+                if os.path.exists(event_file):
+                    os.remove(event_file)
+                    print("Deleted event file. [File={0}]".format(repr(event_file)))
+            except Exception as e:
+                print("Error deleting event file. [File={0}] [Exception={1}]".format(repr(event_file), repr(e)))
+
+        if self.__get_events_dir_size() >= Constants.TELEMETRY_DIR_SIZE_LIMIT_IN_BYTES:
+            raise Exception("Older event files were not deleted. Current event will not be sent to telemetry as events directory size exceeds maximum limit")
+
+    def write_event_using_temp_file(self, folder_path, data, mode='w'):
+        """ Writes to a temp file in a single operation and then moves/overrides the original file with the temp """
+        file_path = self.__get_event_file_path(folder_path)
+        prev_events = []
+        try:
+            if os.path.exists(file_path):
+                # if file_size exceeds max limit, sleep for 1 second, so the event can be written to a new file
+                file_size = self.get_file_size(file_path)
+                if file_size >= Constants.TELEMETRY_EVENT_FILE_SIZE_LIMIT_IN_BYTES:
+                    time.sleep(1)
+                    file_path = self.__get_event_file_path(folder_path)
+                else:
+                    prev_events = self.__fetch_events_from_previous_file(file_path)
+
+            prev_events.append(data)
+            with tempfile.NamedTemporaryFile(mode, dir=os.path.dirname(file_path), delete=False) as tf:
+                json.dump(prev_events, tf, default=data.__str__())
+                tempname = tf.name
+            shutil.move(tempname, file_path)
+        except Exception as error:
+            raise Exception("Unable to write to {0}. Error: {1}.".format(str(file_path), repr(error)))
+
+    def set_operation_id(self, operation_id):
+        self.operation_id = operation_id
+
+    def __get_events_dir_size(self):
+        return sum([os.path.getsize(os.path.join(self.events_folder_path, f)) for f in os.listdir(self.events_folder_path) if os.path.isfile(os.path.join(self.events_folder_path, f))])
+
+    @staticmethod
+    def __get_event_file_path(folder_path):
+        return os.path.join(folder_path, str(int(round(time.time() * 1000))) + ".json")
+
+    @staticmethod
+    def get_file_size(file_path):
+        return os.path.getsize(file_path)
+
+    @staticmethod
+    def __fetch_events_from_previous_file(file_path):
+        with open(file_path, 'r') as file_handle:
+            file_contents = file_handle.read()
+            return json.loads(file_contents)
+

--- a/src/core/tests/TestCoreMain.py
+++ b/src/core/tests/TestCoreMain.py
@@ -264,8 +264,8 @@ class TestCoreMain(unittest.TestCase):
         self.assertEquals(len(substatus_file_data), 1)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_ERROR.lower())
-        self.assertEqual(len(json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"]), 2)
-        self.assertTrue("The minimum Azure Linux Agent version prerequisite for Linux patching was not met" in json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"][1]["message"])
+        self.assertEqual(len(json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"]), 1)
+        self.assertTrue("The minimum Azure Linux Agent version prerequisite for Linux patching was not met" in json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"][0]["message"])
         runtime.stop()
 
     def test_installation_operation_fail_due_to_no_telemetry(self):
@@ -283,8 +283,8 @@ class TestCoreMain(unittest.TestCase):
         self.assertEquals(len(substatus_file_data), 3)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_ERROR.lower())
-        self.assertEqual(len(json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"]), 2)
-        self.assertTrue("The minimum Azure Linux Agent version prerequisite for Linux patching was not met" in json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"][1]["message"])
+        self.assertEqual(len(json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"]), 1)
+        self.assertTrue("The minimum Azure Linux Agent version prerequisite for Linux patching was not met" in json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"][0]["message"])
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
         self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_ERROR.lower())
         runtime.stop()

--- a/src/core/tests/TestStatusHandler.py
+++ b/src/core/tests/TestStatusHandler.py
@@ -185,14 +185,14 @@ class TestStatusHandler(unittest.TestCase):
     def test_status_file_initial_load(self):
         # for non autopatching request, with Reboot started
         self.runtime.status_handler.set_installation_reboot_status(Constants.RebootStatus.STARTED)
-        status_handler = StatusHandler(self.runtime.env_layer, self.runtime.execution_config, self.runtime.composite_logger, self.runtime.telemetry_writer)
+        status_handler = StatusHandler(self.runtime.env_layer, self.runtime.execution_config, self.runtime.composite_logger)
         self.assertTrue(status_handler is not None)
 
         # for autopatching request, with reboot started
         self.runtime.status_handler.set_installation_reboot_status(Constants.RebootStatus.STARTED)
         self.runtime.status_handler.set_patch_metadata_for_healthstore_substatus_json()
         self.runtime.execution_config.maintenance_run_id = str(datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ"))
-        status_handler = StatusHandler(self.runtime.env_layer, self.runtime.execution_config, self.runtime.composite_logger, self.runtime.telemetry_writer)
+        status_handler = StatusHandler(self.runtime.env_layer, self.runtime.execution_config, self.runtime.composite_logger)
         with self.runtime.env_layer.file_system.open(self.runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
         self.assertTrue(len(substatus_file_data) == 1)
@@ -200,7 +200,7 @@ class TestStatusHandler(unittest.TestCase):
         # for autopatching request, with reboot not started
         self.runtime.status_handler.set_installation_reboot_status(Constants.RebootStatus.COMPLETED)
         self.runtime.execution_config.maintenance_run_id = str(datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ"))
-        status_handler = StatusHandler(self.runtime.env_layer, self.runtime.execution_config, self.runtime.composite_logger, self.runtime.telemetry_writer)
+        status_handler = StatusHandler(self.runtime.env_layer, self.runtime.execution_config, self.runtime.composite_logger)
         with self.runtime.env_layer.file_system.open(self.runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"][0]
         self.assertTrue(status_handler is not None)

--- a/src/core/tests/TestTelemetryWriter.py
+++ b/src/core/tests/TestTelemetryWriter.py
@@ -30,6 +30,8 @@ class TestTelemetryWriter(unittest.TestCase):
     def setUp(self):
         self.runtime = RuntimeCompositor(ArgumentComposer().get_composed_arguments(), True)
         self.container = self.runtime.container
+        self.runtime.composite_logger.telemetry_writer.events_folder_path = self.runtime.execution_config.events_folder
+        self.runtime.composite_logger.telemetry_writer.set_operation_id(self.runtime.execution_config.activity_id)
 
     def tearDown(self):
         self.runtime.stop()
@@ -88,6 +90,7 @@ class TestTelemetryWriter(unittest.TestCase):
 
     def test_write_event_size_limit(self):
         # will not write to telemetry if event size exceeds limit
+        self.runtime.composite_logger.telemetry_writer.write_event("Test Task", "testing telemetry write to file", Constants.TelemetryEventLevel.Error)
         old_events = os.listdir(self.runtime.composite_logger.telemetry_writer.events_folder_path)
         message = "a"*3074
         task_name = "b"*5000
@@ -98,7 +101,7 @@ class TestTelemetryWriter(unittest.TestCase):
         with open(os.path.join(self.runtime.composite_logger.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:
             events = json.load(f)
             self.assertTrue(events is not None)
-            self.assertTrue("Test Task" not in events)
+            self.assertTrue(task_name not in events[0]['TaskName'])
             f.close()
 
     def test_write_to_new_file_if_event_file_limit_reached(self):

--- a/src/core/tests/TestTelemetryWriter.py
+++ b/src/core/tests/TestTelemetryWriter.py
@@ -14,13 +14,19 @@
 #
 # Requires Python 2.7+
 
+import json
+import os
+import re
+import time
 import unittest
+
 from core.src.bootstrap.Constants import Constants
 from core.tests.library.ArgumentComposer import ArgumentComposer
 from core.tests.library.RuntimeCompositor import RuntimeCompositor
 
 
 class TestTelemetryWriter(unittest.TestCase):
+
     def setUp(self):
         self.runtime = RuntimeCompositor(ArgumentComposer().get_composed_arguments(), True)
         self.container = self.runtime.container
@@ -28,9 +34,126 @@ class TestTelemetryWriter(unittest.TestCase):
     def tearDown(self):
         self.runtime.stop()
 
-    def test_something(self):
-        self.assertEqual(True, True)
+    def mock_time(self):
+        return 1234
+
+    def mock_os_remove(self, filepath):
+        raise Exception("File could not be deleted")
+
+    def mock_os_path_exists(self, filepath):
+        return True
+
+    def mock_get_file_size(self, file_path):
+        return Constants.TELEMETRY_EVENT_FILE_SIZE_LIMIT_IN_BYTES + 10
+
+    def test_write_event(self):
+        self.runtime.composite_logger.telemetry_writer.write_event("Test Task", "testing telemetry write to file", Constants.TelemetryEventLevel.Error)
+        latest_event_file = [pos_json for pos_json in os.listdir(self.runtime.composite_logger.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)][-1]
+        with open(os.path.join(self.runtime.composite_logger.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:
+            events = json.load(f)
+            self.assertTrue(events is not None)
+            self.assertEquals(events[-1]["TaskName"], "Test Task")
+            f.close()
+
+        self.runtime.composite_logger.telemetry_writer.write_event("Test Task2", "testing telemetry write to file", Constants.TelemetryEventLevel.Error)
+
+    def test_write_multiple_events_in_same_file(self):
+        time_backup = time.time
+        time.time = self.mock_time
+        self.runtime.composite_logger.telemetry_writer.write_event("Test Task", "testing telemetry write to file", Constants.TelemetryEventLevel.Error)
+        self.runtime.composite_logger.telemetry_writer.write_event("Test Task2", "testing telemetry write to file", Constants.TelemetryEventLevel.Error)
+        latest_event_file = [pos_json for pos_json in os.listdir(self.runtime.composite_logger.telemetry_writer.events_folder_path) if re.search('^'+str(self.mock_time())+'0+.json$', pos_json)][-1]
+        with open(os.path.join(self.runtime.composite_logger.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:
+            events = json.load(f)
+            self.assertTrue(events is not None)
+            self.assertEquals(len(events), 2)
+            self.assertEquals(events[0]["TaskName"], "Test Task")
+            self.assertEquals(events[1]["TaskName"], "Test Task2")
+            f.close()
+        time.time = time_backup
+
+    def test_write_event_msg_size_limit(self):
+        # Assuming 1 char is 1 byte
+        message = "a"*3074
+        self.runtime.composite_logger.telemetry_writer.write_event("Test Task", message, Constants.TelemetryEventLevel.Error)
+        latest_event_file = [pos_json for pos_json in os.listdir(self.runtime.composite_logger.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)][-1]
+        with open(os.path.join(self.runtime.composite_logger.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:
+            events = json.load(f)
+            self.assertTrue(events is not None)
+            self.assertEquals(events[0]["TaskName"], "Test Task")
+            self.assertTrue(len(events[0]["Message"]) < len(message.encode('utf-8')))
+            bytes_dropped = len(message.encode('utf-8')) - Constants.TELEMETRY_MSG_SIZE_LIMIT_IN_BYTES + Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_BYTES
+            self.assertEquals(events[0]["Message"], "a"*(len(message.encode('utf-8')) - bytes_dropped) + ". [{0} bytes dropped]".format(bytes_dropped))
+            f.close()
+
+    def test_write_event_size_limit(self):
+        # will not write to telemetry if event size exceeds limit
+        old_events = os.listdir(self.runtime.composite_logger.telemetry_writer.events_folder_path)
+        message = "a"*3074
+        task_name = "b"*5000
+        self.runtime.composite_logger.telemetry_writer.write_event(task_name, message, Constants.TelemetryEventLevel.Error)
+        new_events = os.listdir(self.runtime.composite_logger.telemetry_writer.events_folder_path)
+        self.assertEquals(old_events, new_events)
+        latest_event_file = [pos_json for pos_json in os.listdir(self.runtime.composite_logger.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)][-1]
+        with open(os.path.join(self.runtime.composite_logger.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:
+            events = json.load(f)
+            self.assertTrue(events is not None)
+            self.assertTrue("Test Task" not in events)
+            f.close()
+
+    def test_write_to_new_file_if_event_file_limit_reached(self):
+        self.runtime.composite_logger.telemetry_writer.write_event("Test Task", "testing telemetry write to file", Constants.TelemetryEventLevel.Error)
+        os_path_exists_backup = os.path.exists
+        os.path.exists = self.mock_os_path_exists
+        telemetry_get_event_file_size_backup = self.runtime.composite_logger.telemetry_writer.get_file_size
+        self.runtime.composite_logger.telemetry_writer.get_file_size = self.mock_get_file_size
+
+        self.runtime.composite_logger.telemetry_writer.write_event("Test Task2", "testing telemetry write to file", Constants.TelemetryEventLevel.Error)
+        events = os.listdir(self.runtime.composite_logger.telemetry_writer.events_folder_path)
+        self.assertTrue(len(events) > 1)
+        os.path.exists = os_path_exists_backup
+        self.runtime.composite_logger.telemetry_writer.get_file_size = telemetry_get_event_file_size_backup
+
+    def test_delete_older_events(self):
+
+        # deleting older event files before adding new one
+        self.runtime.composite_logger.telemetry_writer.write_event("Test Task", "testing telemetry write to file", Constants.TelemetryEventLevel.Error)
+        self.runtime.composite_logger.telemetry_writer.write_event("Test Task2", "testing telemetry write to file", Constants.TelemetryEventLevel.Error)
+        self.runtime.composite_logger.telemetry_writer.write_event("Test Task3", "testing telemetry write to file", Constants.TelemetryEventLevel.Error)
+        old_events = [pos_json for pos_json in os.listdir(self.runtime.composite_logger.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)]
+        telemetry_dir_size_backup = Constants.TELEMETRY_DIR_SIZE_LIMIT_IN_BYTES
+        Constants.TELEMETRY_DIR_SIZE_LIMIT_IN_BYTES = 1030
+        telemetry_event_size_backup = Constants.TELEMETRY_EVENT_FILE_SIZE_LIMIT_IN_BYTES
+        Constants.TELEMETRY_EVENT_FILE_SIZE_LIMIT_IN_BYTES = 1024
+
+        self.runtime.composite_logger.telemetry_writer.write_event("Test Task4", "testing telemetry write to file", Constants.TelemetryEventLevel.Error)
+        new_events = [pos_json for pos_json in os.listdir(self.runtime.composite_logger.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)]
+        self.assertEquals(len(new_events), 1)
+        self.assertTrue(old_events[0] not in new_events)
+        Constants.TELEMETRY_DIR_SIZE_LIMIT_IN_BYTES = telemetry_dir_size_backup
+        Constants.TELEMETRY_EVENT_FILE_SIZE_LIMIT_IN_BYTES = telemetry_event_size_backup
+
+        # error while deleting event files where the directory size exceeds limit even after deletion attempts
+        self.runtime.composite_logger.telemetry_writer.write_event("Test Task", "testing telemetry write to file", Constants.TelemetryEventLevel.Error)
+        self.runtime.composite_logger.telemetry_writer.write_event("Test Task2", "testing telemetry write to file", Constants.TelemetryEventLevel.Error)
+        self.runtime.composite_logger.telemetry_writer.write_event("Test Task3", "testing telemetry write to file", Constants.TelemetryEventLevel.Error)
+        old_events = [pos_json for pos_json in os.listdir(self.runtime.composite_logger.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)]
+        telemetry_dir_size_backup = Constants.TELEMETRY_DIR_SIZE_LIMIT_IN_BYTES
+        Constants.TELEMETRY_DIR_SIZE_LIMIT_IN_BYTES = 500
+        telemetry_event_size_backup = Constants.TELEMETRY_EVENT_FILE_SIZE_LIMIT_IN_BYTES
+        Constants.TELEMETRY_EVENT_FILE_SIZE_LIMIT_IN_BYTES = 400
+        os_remove_backup = os.remove
+        os.remove = self.mock_os_remove
+
+        self.assertRaises(Exception, lambda: self.runtime.composite_logger.telemetry_writer.write_event("Test Task4", "testing telemetry write to file", Constants.TelemetryEventLevel.Error))
+
+        Constants.TELEMETRY_DIR_SIZE_LIMIT_IN_BYTES = telemetry_dir_size_backup
+        Constants.TELEMETRY_EVENT_FILE_SIZE_LIMIT_IN_BYTES = telemetry_event_size_backup
+        os.remove = os_remove_backup
 
 
 if __name__ == '__main__':
-    unittest.main()
+    SUITE = unittest.TestLoader().loadTestsFromTestCase(TestTelemetryWriter)
+    unittest.TextTestRunner(verbosity=2).run(SUITE)
+
+

--- a/src/core/tests/TestYumPackageManager.py
+++ b/src/core/tests/TestYumPackageManager.py
@@ -97,9 +97,6 @@ class TestYumPackageManager(unittest.TestCase):
         size = package_manager.get_package_size(out)
         self.assertEqual(size, "735 k")
 
-        telemetry_writer = self.container.get('telemetry_writer')
-        telemetry_writer.close_transports()
-
         # test for all available versions
         package_versions = package_manager.get_all_available_versions_of_package("kernel")
         self.assertEqual(len(package_versions), 7)

--- a/src/core/tests/TestZypperPackageManager.py
+++ b/src/core/tests/TestZypperPackageManager.py
@@ -105,9 +105,6 @@ class TestZypperPackageManager(unittest.TestCase):
         size = package_manager.get_package_size(out)
         self.assertEqual(size, "810.9 KiB")
 
-        telemetry_writer = self.container.get('telemetry_writer')
-        telemetry_writer.close_transports()
-
         # test for get_dependent_list
         # legacy_test_type ='Happy Path'
         dependent_list = package_manager.get_dependent_list("man")

--- a/src/core/tests/library/ArgumentComposer.py
+++ b/src/core/tests/library/ArgumentComposer.py
@@ -36,7 +36,7 @@ class ArgumentComposer(object):
         self.sequence_number = 1
 
         # environment settings
-        self.__log_folder = self.__config_folder = self.__status_folder = self.__get_scratch_folder()
+        self.__log_folder = self.__config_folder = self.__status_folder = self.__events_folder = self.__get_scratch_folder()
 
         # config settings
         self.operation = Constants.INSTALLATION
@@ -57,7 +57,8 @@ class ArgumentComposer(object):
         environment_settings = {
             "logFolder": self.__log_folder,
             "configFolder": self.__config_folder,
-            "statusFolder": self.__status_folder
+            "statusFolder": self.__status_folder,
+            "eventsFolder": self.__events_folder
         }
 
         config_settings = {

--- a/src/core/tests/library/RuntimeCompositor.py
+++ b/src/core/tests/library/RuntimeCompositor.py
@@ -47,7 +47,7 @@ class RuntimeCompositor(object):
         self.container = bootstrapper.build_out_container()
         self.file_logger = bootstrapper.file_logger
         self.composite_logger = bootstrapper.composite_logger
-        self.lifecycle_manager, self.telemetry_writer, self.status_handler = bootstrapper.build_core_components(self.container)
+        self.lifecycle_manager, self.status_handler = bootstrapper.build_core_components(self.container)
 
         # Business logic components
         self.execution_config = self.container.get('execution_config')
@@ -63,7 +63,6 @@ class RuntimeCompositor(object):
         self.write_ext_state_file(self.lifecycle_manager.ext_state_file_path, self.execution_config.sequence_number, datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ"), self.execution_config.operation)
 
     def stop(self):
-        self.telemetry_writer.close_transports()
         self.file_logger.close(message_at_close="<Runtime stopped>")
         self.container.reset()
 


### PR DESCRIPTION
Basic telemetry guidelines to consider:

Write events (i.e. logs) to json file/s
Event is a json structure
One file can have multiple events. There can be multiple event files. It is up to the extension on how to write event and event files. We are creating new event files/ms
Size restrictions as defined in Constants.py. Agent will check for these limitations, but good to check them at our end as well.
Agent will pick up the latest event files/5 mins. (Latest to avoid missing recent data in case the events exceed limit and some have to be deleted)

Includes:

- Adding telemetry to core
- Telemetry enabled checked within Patch Assessment and execution stopped in case it is not enabled with the corresponding error message added to status blob (validation performed within Patch Assessment since it is the first action for all requests) 