### PR TITLE
Core fails if telemetry is missing at agent

### DIFF
--- a/src/core/src/CoreMain.py
+++ b/src/core/src/CoreMain.py
@@ -65,6 +65,7 @@ class CoreMain(object):
                 status_handler.set_current_operation(Constants.INSTALLATION)
                 patch_installer = container.get('patch_installer')
                 patch_installation_successful = patch_installer.start_installation()
+                patch_assessment_successful = False
                 patch_assessment_successful = patch_assessor.start_assessment()
 
         except Exception as error:

--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -47,6 +47,7 @@ class Constants(object):
         LOG_FOLDER = "logFolder"
         CONFIG_FOLDER = "configFolder"
         STATUS_FOLDER = "statusFolder"
+        EVENTS_FOLDER = "eventsFolder"
 
     class ConfigSettings(EnumBackport):
         OPERATION = 'operation'
@@ -170,6 +171,8 @@ class Constants(object):
     TELEMETRY_ERROR = "Error"
     TELEMETRY_INFO = "Info"
     TELEMETRY_DEBUG = "Debug"
+
+    UTC_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
     # EnvLayer Constants
     class EnvLayer(EnumBackport):

--- a/src/core/src/bootstrap/EnvLayer.py
+++ b/src/core/src/bootstrap/EnvLayer.py
@@ -419,7 +419,7 @@ class EnvLayer(object):
 
         try:
             record = {
-                "timestamp": str(timestamp) if timestamp is not None else datetime.datetime.strptime(str(datetime.datetime.utcnow()).split(".")[0], "%Y-%m-%dT%H:%M:%SZ"), #WRONG
+                "timestamp": str(timestamp) if timestamp is not None else datetime.datetime.strptime(str(datetime.datetime.utcnow()).split(".")[0], Constants.UTC_DATETIME_FORMAT), #WRONG
                 "operation": str(operation),
                 "code": int(code),
                 "output": base64.b64encode(str(output)),

--- a/src/core/src/core_logic/ExecutionConfig.py
+++ b/src/core/src/core_logic/ExecutionConfig.py
@@ -41,6 +41,7 @@ class ExecutionConfig(object):
         self.log_folder = self.environment_settings[Constants.EnvSettings.LOG_FOLDER]
         self.config_folder = self.environment_settings[Constants.EnvSettings.CONFIG_FOLDER]
         self.status_folder = self.environment_settings[Constants.EnvSettings.STATUS_FOLDER]
+        self.events_folder = self.environment_settings[Constants.EnvSettings.EVENTS_FOLDER]
 
         # Config Settings
         self.composite_logger.log_debug(" - Parsing configuration settings... [ConfigSettings={0}]".format(str(self.config_settings)))

--- a/src/core/src/core_logic/PatchAssessor.py
+++ b/src/core/src/core_logic/PatchAssessor.py
@@ -33,8 +33,10 @@ class PatchAssessor(object):
 
     def start_assessment(self):
         """ Start an update assessment """
-        self.composite_logger.log('\nStarting patch assessment...')
         self.status_handler.set_current_operation(Constants.ASSESSMENT)
+        self.telemetry_setup()
+
+        self.composite_logger.log('\nStarting patch assessment...')
 
         self.status_handler.set_assessment_substatus_json(status=Constants.STATUS_TRANSITIONING)
         self.composite_logger.log("\nMachine Id: " + self.env_layer.platform.node())
@@ -72,3 +74,14 @@ class PatchAssessor(object):
 
         self.composite_logger.log("\nPatch assessment completed.\n")
         return True
+
+    def telemetry_setup(self):
+        """ Verifies if telemetry is available. Stops execution is not available """
+        if self.execution_config.events_folder is None:
+            error_msg = "The minimum Azure Linux Agent version prerequisite for Linux patching was not met. Please update the Azure Linux Agent on this machine."
+            self.composite_logger.log_error(error_msg)
+            raise Exception(error_msg)
+
+        #ToDo: Ensure telemetry is setup correctly at this point
+        self.composite_logger.log("The minimum Azure Linux Agent version prerequisite for Linux patching was met.")
+

--- a/src/core/tests/library/ArgumentComposer.py
+++ b/src/core/tests/library/ArgumentComposer.py
@@ -36,7 +36,7 @@ class ArgumentComposer(object):
         self.sequence_number = 1
 
         # environment settings
-        self.__log_folder = self.__config_folder = self.__status_folder = self.__get_scratch_folder()
+        self.__log_folder = self.__config_folder = self.__status_folder = self.__events_folder = self.__get_scratch_folder()
 
         # config settings
         self.operation = Constants.INSTALLATION
@@ -57,7 +57,8 @@ class ArgumentComposer(object):
         environment_settings = {
             "logFolder": self.__log_folder,
             "configFolder": self.__config_folder,
-            "statusFolder": self.__status_folder
+            "statusFolder": self.__status_folder,
+            "eventsFolder": self.__events_folder
         }
 
         config_settings = {


### PR DESCRIPTION
Includes: (Changes only in core)

- Telemetry availability from agent is checked within Patch Assessment and execution stopped in case telemetry is not available with the corresponding error message added to status blob (validation performed within Patch Assessment since it is the first action for all requests)
- Defining UTC Date format in Constants and using this constant everywhere