### PR TITLE
Refactoring telemetry integration in handler

### DIFF
--- a/src/extension/src/ActionHandler.py
+++ b/src/extension/src/ActionHandler.py
@@ -125,10 +125,8 @@ class ActionHandler(object):
             new_version_config_folder = self.ext_env_handler.config_folder
             extension_pardir = os.path.abspath(os.path.join(new_version_config_folder, os.path.pardir, os.path.pardir))
             self.logger.log("Parent directory for all extension version artifacts [Directory={0}]".format(str(extension_pardir)))
-
             paths_to_all_versions = self.get_all_versions(extension_pardir)
             self.logger.log("List of all extension versions found on the machine. [All Versions={0}]".format(paths_to_all_versions))
-
             if len(paths_to_all_versions) <= 1:
                 # Extension Update action called when
                 # a) artifacts for the preceding version do not exist on the machine, or
@@ -138,22 +136,18 @@ class ActionHandler(object):
 
             # identify the version preceding current
             self.logger.log("Fetching the extension version preceding current from all available versions...")
-
             paths_to_all_versions.sort(reverse=True, key=LooseVersion)
             preceding_version_path = paths_to_all_versions[1]
-
             if preceding_version_path is None or preceding_version_path == "" or not os.path.exists(preceding_version_path):
                 self.logger.log_error("Could not find path where preceding extension version artifacts are stored. Hence, cannot copy the required artifacts to the latest version. "
                                       "[Preceding extension version path={0}]".format(str(preceding_version_path)))
                 return Constants.ExitCode.HandlerFailed
-
             self.logger.log("Preceding version path. [Path={0}]".format(str(preceding_version_path)))
 
             # copy all required files from preceding version to current
             self.copy_config_files(preceding_version_path, new_version_config_folder)
 
             self.logger.log("All update actions from extension handler completed.")
-
             return Constants.ExitCode.Okay
 
         except Exception as error:

--- a/src/extension/src/ActionHandler.py
+++ b/src/extension/src/ActionHandler.py
@@ -44,6 +44,7 @@ class ActionHandler(object):
         self.cmd_exec_start_time = cmd_exec_start_time
         self.stdout_file_mirror = None
         self.file_logger = None
+        self.timestamp_for_telemetry = str((datetime.datetime.utcnow()).strftime(Constants.UTC_DATETIME_FORMAT))
 
     def determine_operation(self, command):
         switcher = {
@@ -92,6 +93,9 @@ class ActionHandler(object):
         else:
             self.logger.log("The minimum Azure Linux Agent version prerequisite for Linux patching was met.")
             self.telemetry_writer.events_folder_path = events_folder
+            # As this is a common function used by all handler actions, setting operation_id such that it will be the same timestamp for all handler actions, which can be used for identifying all events for an operation.
+            # NOTE: Enable handler action will set operation_id to activity_id from config settings. And the same will be used in Core.
+            self.telemetry_writer.set_operation_id(self.timestamp_for_telemetry)
 
     def install(self):
         try:

--- a/src/extension/src/ActionHandler.py
+++ b/src/extension/src/ActionHandler.py
@@ -44,7 +44,7 @@ class ActionHandler(object):
         self.cmd_exec_start_time = cmd_exec_start_time
         self.stdout_file_mirror = None
         self.file_logger = None
-        self.timestamp_for_telemetry = str((datetime.datetime.utcnow()).strftime(Constants.UTC_DATETIME_FORMAT))
+        self.operation_id_substitute_for_all_actions_in_telemetry = str((datetime.datetime.utcnow()).strftime(Constants.UTC_DATETIME_FORMAT))
 
     def determine_operation(self, command):
         switcher = {
@@ -95,7 +95,7 @@ class ActionHandler(object):
             self.telemetry_writer.events_folder_path = events_folder
             # As this is a common function used by all handler actions, setting operation_id such that it will be the same timestamp for all handler actions, which can be used for identifying all events for an operation.
             # NOTE: Enable handler action will set operation_id to activity_id from config settings. And the same will be used in Core.
-            self.telemetry_writer.set_operation_id(self.timestamp_for_telemetry)
+            self.telemetry_writer.set_operation_id(self.operation_id_substitute_for_all_actions_in_telemetry)
 
     def install(self):
         try:

--- a/src/extension/src/Constants.py
+++ b/src/extension/src/Constants.py
@@ -83,6 +83,8 @@ class Constants(object):
         Informational = "Informational"
         LogAlways = "LogAlways"
 
+    TELEMETRY_TASK_NAME = "HandlerLog"
+
     UTC_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
     # Re-try limit for file operations

--- a/src/extension/src/Constants.py
+++ b/src/extension/src/Constants.py
@@ -58,21 +58,14 @@ class Constants(object):
     ENABLE_MAX_RUNTIME = 3
     DISABLE_MAX_RUNTIME = 13
 
-    #ToDo: kept for future reference incase we need these categories. Should be decided in the next PR
-    # Telemetry Categories
-    # TelemetryExtState = "State"
-    # TelemetryConfig = "Config"
-    # TelemetryError = "Error"
-    # TelemetryWarning = "Warning"
-    # TelemetryInfo = "Info"
-    # TelemetryDebug = "Debug"
-
     # Telemetry Settings
     TELEMETRY_MSG_SIZE_LIMIT_IN_BYTES = 3072  # 3KB
     TELEMETRY_EVENT_SIZE_LIMIT_IN_BYTES = 6144  # 6KB
     TELEMETRY_EVENT_FILE_SIZE_LIMIT_IN_BYTES = 4194304  # 4MB
     TELEMETRY_DIR_SIZE_LIMIT_IN_BYTES = 41943040  # 40MB
     TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_BYTES = 80  # buffer for the bytes dropped text added at the end of the truncated telemetry message
+
+    TELEMETRY_ENABLED_AT_EXTENSION = True
 
     # Telemetry Event Level
     class TelemetryEventLevel(EnumBackport):

--- a/src/extension/src/Constants.py
+++ b/src/extension/src/Constants.py
@@ -28,7 +28,7 @@ class Constants(object):
                         yield item
 
     # Extension version (todo: move to a different file)
-    EXT_VERSION = "1.6.12"
+    EXT_VERSION = "1.6.15"
 
     # Runtime environments
     TEST = 'Test'

--- a/src/extension/src/EnableCommandHandler.py
+++ b/src/extension/src/EnableCommandHandler.py
@@ -43,9 +43,7 @@ class EnableCommandHandler(object):
             # fetch seq_no
             self.seq_no = self.ext_config_settings_handler.get_seq_no(is_enable_request=True)
             if self.seq_no is None:
-                seq_not_found_msg = "Sequence number for current operation not found"
-                self.logger.log_error(seq_not_found_msg)
-                self.telemetry_writer.write_event(seq_not_found_msg, Constants.TelemetryEventLevel.Error)
+                self.logger.log_error("Sequence number for current operation not found")
                 exit(Constants.ExitCode.MissingConfig)
 
             # read status file, to load any preserve existing context
@@ -61,9 +59,7 @@ class EnableCommandHandler(object):
 
             # Allow only certain operations
             if operation not in [Constants.NOOPERATION, Constants.ASSESSMENT, Constants.INSTALLATION, Constants.CONFIGURE_PATCHING]:
-                request_not_supported_msg = "Requested operation is not supported by the extension"
-                self.logger.log_error(request_not_supported_msg)
-                self.telemetry_writer.write_event(request_not_supported_msg, Constants.TelemetryEventLevel.Error)
+                self.logger.log_error("Requested operation is not supported by the extension")
                 exit(Constants.ExitCode.InvalidConfigSettingPropertyValue)
 
             prev_patch_max_end_time = self.cmd_exec_start_time + datetime.timedelta(hours=0, minutes=Constants.ENABLE_MAX_RUNTIME)
@@ -72,9 +68,7 @@ class EnableCommandHandler(object):
 
             # If ConfigurePatching is requested, do nothing, will be implemented in future
             if operation == Constants.CONFIGURE_PATCHING:
-                configure_patching_request_msg = "Received a configure patching request, no action will be taken as it is not supported for now. [Operation Sequence={0}]".format(str(self.seq_no))
-                self.logger.log(configure_patching_request_msg)
-                self.telemetry_writer.write_event(configure_patching_request_msg, Constants.TelemetryEventLevel.Informational)
+                self.logger.log("Received a configure patching request, no action will be taken as it is not supported for now. [Operation Sequence={0}]".format(str(self.seq_no)))
                 exit(Constants.ExitCode.Okay)
 
             # if NoOperation is requested, terminate all running processes from previous operation and update status file
@@ -84,9 +78,7 @@ class EnableCommandHandler(object):
                 # if any of the other operations are requested, verify if request is a new request or a re-enable, by comparing sequence number from the prev request and current one
                 if core_state_content is None or core_state_content.__getattribute__(self.core_state_fields.number) is None:
                     # first patch request for the VM
-                    prev_patch_state_not_found_msg = "No state information was found for any previous patch operation. Launching a new patch operation."
-                    self.logger.log(prev_patch_state_not_found_msg)
-                    self.telemetry_writer.write_event(prev_patch_state_not_found_msg, Constants.TelemetryEventLevel.Informational)
+                    self.logger.log("No state information was found for any previous patch operation. Launching a new patch operation.")
                     self.launch_new_process(config_settings, create_status_output_file=True)
                 else:
                     if int(core_state_content.__getattribute__(self.core_state_fields.number)) != int(self.seq_no):
@@ -97,44 +89,32 @@ class EnableCommandHandler(object):
                         self.process_reenable_request(config_settings, core_state_content)
 
         except Exception as error:
-            enable_error_msg = "Failed to execute enable. [Exception={0}]".format(repr(error))
-            self.logger.log_error(enable_error_msg)
-            self.telemetry_writer.write_event(enable_error_msg, Constants.TelemetryEventLevel.Error)
+            self.logger.log_error("Failed to execute enable. [Exception={0}]".format(repr(error)))
             raise
 
     def process_enable_request(self, config_settings, prev_patch_max_end_time, core_state_content):
         """ Called when the current request is different from the one before. Identifies and waits for the previous request action to complete, if required before addressing the current request """
-        terminating_older_operation_msg = "Terminating older patch operation, if still in progress, as per it's completion duration and triggering the new requested patch operation."
-        self.logger.log(terminating_older_operation_msg)
-        self.telemetry_writer.write_event(terminating_older_operation_msg, Constants.TelemetryEventLevel.Informational)
+        self.logger.log("Terminating older patch operation, if still in progress, as per it's completion duration and triggering the new requested patch operation.")
         self.runtime_context_handler.process_previous_patch_operation(self.core_state_handler, self.process_handler, prev_patch_max_end_time, core_state_content)
         self.utility.delete_file(self.core_state_handler.dir_path, self.core_state_handler.file)
         self.launch_new_process(config_settings, create_status_output_file=True)
 
     def process_reenable_request(self, config_settings, core_state_content):
         """ Called when the current request has the same config as the one before it. Restarts the operation if the previous request has errors, no action otherwise """
-        reenable_request_msg = "This is the same request as the previous patch operation. Checking previous request's status"
-        self.logger.log(reenable_request_msg)
-        self.telemetry_writer.write_event(reenable_request_msg, Constants.TelemetryEventLevel.Informational)
+        self.logger.log("This is the same request as the previous patch operation. Checking previous request's status")
 
         if core_state_content.__getattribute__(self.core_state_fields.completed).lower() == 'false':
             running_process_ids = self.process_handler.identify_running_processes(core_state_content.__getattribute__(self.core_state_fields.process_ids))
             if len(running_process_ids) == 0:
-                restart_patch_msg = "Re-triggering the patch operation as the previous patch operation was not running and hadn't marked completion either."
-                self.logger.log(restart_patch_msg)
-                self.telemetry_writer.write_event(restart_patch_msg, Constants.TelemetryEventLevel.Informational)
+                self.logger.log("Re-triggering the patch operation as the previous patch operation was not running and hadn't marked completion either.")
                 self.utility.delete_file(self.core_state_handler.dir_path, self.core_state_handler.file)
                 self.launch_new_process(config_settings, create_status_output_file=False)
             else:
-                prev_patch_in_progress_msg = "Patch operation is in progress from the previous request. [Operation={0}]".format(config_settings.__getattribute__(self.config_public_settings.operation))
-                self.logger.log(prev_patch_in_progress_msg)
-                self.telemetry_writer.write_event(prev_patch_in_progress_msg, Constants.TelemetryEventLevel.Informational)
+                self.logger.log("Patch operation is in progress from the previous request. [Operation={0}]".format(config_settings.__getattribute__(self.config_public_settings.operation)))
                 exit(Constants.ExitCode.Okay)
 
         else:
-            patch_complete_msg = "Patch operation already completed in the previous request. [Operation={0}]".format(config_settings.__getattribute__(self.config_public_settings.operation))
-            self.logger.log(patch_complete_msg)
-            self.telemetry_writer.write_event(patch_complete_msg, Constants.TelemetryEventLevel.Informational)
+            self.logger.log("Patch operation already completed in the previous request. [Operation={0}]".format(config_settings.__getattribute__(self.config_public_settings.operation)))
             exit(Constants.ExitCode.Okay)
 
     def launch_new_process(self, config_settings, create_status_output_file):
@@ -146,15 +126,11 @@ class EnableCommandHandler(object):
             self.ext_output_status_handler.update_file(self.seq_no, self.ext_env_handler.status_folder)
         # launch core code in a process and exit extension handler
         process = self.process_handler.start_daemon(self.seq_no, config_settings, self.ext_env_handler)
-        handler_exit_msg = "exiting extension handler"
-        self.logger.log(handler_exit_msg)
-        self.telemetry_writer.write_event(handler_exit_msg, Constants.TelemetryEventLevel.Informational)
+        self.logger.log("exiting extension handler")
         exit(Constants.ExitCode.Okay)
 
     def process_nooperation(self, config_settings, core_state_content):
-        nooperation_request_msg = "NoOperation requested. Terminating older patch operation, if still in progress."
-        self.logger.log(nooperation_request_msg)
-        self.telemetry_writer.write_event(nooperation_request_msg, Constants.TelemetryEventLevel.Informational)
+        self.logger.log("NoOperation requested. Terminating older patch operation, if still in progress.")
         self.ext_output_status_handler.set_current_operation(Constants.NOOPERATION)
         activity_id = config_settings.__getattribute__(self.config_public_settings.activity_id)
         operation = config_settings.__getattribute__(self.config_public_settings.operation)
@@ -165,18 +141,14 @@ class EnableCommandHandler(object):
             self.utility.delete_file(self.core_state_handler.dir_path, self.core_state_handler.file, raise_if_not_found=False)
             # ToDo: log prev activity id later
             self.ext_output_status_handler.set_nooperation_substatus_json(operation, activity_id, start_time, seq_no=self.seq_no, status=Constants.Status.Success)
-            handler_exit_msg = "exiting extension handler"
-            self.logger.log(handler_exit_msg)
-            self.telemetry_writer.write_event(handler_exit_msg, Constants.TelemetryEventLevel.Informational)
+            self.logger.log("exiting extension handler")
             exit(Constants.ExitCode.Okay)
         except Exception as error:
             error_msg = "Error executing NoOperation: " + repr(error)
             self.logger.log(error_msg)
-            self.telemetry_writer.write_event(error_msg, Constants.TelemetryEventLevel.Informational)
             if Constants.ERROR_ADDED_TO_STATUS not in repr(error):
                 self.ext_output_status_handler.add_error_to_status(error_msg, Constants.PatchOperationErrorCodes.OPERATION_FAILED)
             else:
                 self.ext_output_status_handler.add_error_to_status("Error executing NoOperation due to last reported error.", Constants.PatchOperationErrorCodes.OPERATION_FAILED)
             self.ext_output_status_handler.set_nooperation_substatus_json(operation, activity_id, start_time, seq_no=self.seq_no, status=Constants.Status.Error)
-
 

--- a/src/extension/src/EnableCommandHandler.py
+++ b/src/extension/src/EnableCommandHandler.py
@@ -20,8 +20,9 @@ from extension.src.Constants import Constants
 
 class EnableCommandHandler(object):
     """ Responsible for executing the action for enable command """
-    def __init__(self, logger, utility, runtime_context_handler, ext_env_handler, ext_config_settings_handler, core_state_handler, ext_state_handler, ext_output_status_handler, process_handler, cmd_exec_start_time):
+    def __init__(self, logger, telemetry_writer, utility, runtime_context_handler, ext_env_handler, ext_config_settings_handler, core_state_handler, ext_state_handler, ext_output_status_handler, process_handler, cmd_exec_start_time):
         self.logger = logger
+        self.telemetry_writer = telemetry_writer
         self.utility = utility
         self.runtime_context_handler = runtime_context_handler
         self.ext_env_handler = ext_env_handler
@@ -42,7 +43,9 @@ class EnableCommandHandler(object):
             # fetch seq_no
             self.seq_no = self.ext_config_settings_handler.get_seq_no(is_enable_request=True)
             if self.seq_no is None:
-                self.logger.log_error("Sequence number for current operation not found")
+                seq_not_found_msg = "Sequence number for current operation not found"
+                self.logger.log_error(seq_not_found_msg)
+                self.telemetry_writer.write_event(seq_not_found_msg, Constants.TelemetryEventLevel.Error)
                 exit(Constants.ExitCode.MissingConfig)
 
             # read status file, to load any preserve existing context
@@ -51,14 +54,16 @@ class EnableCommandHandler(object):
             config_settings = self.ext_config_settings_handler.read_file(self.seq_no)
 
             # set activity_id in telemetry
-            if self.logger.telemetry_writer is not None:
-                self.logger.telemetry_writer.set_operation_id(config_settings.__getattribute__(self.config_public_settings.activity_id))
+            if self.telemetry_writer is not None:
+                self.telemetry_writer.set_operation_id(config_settings.__getattribute__(self.config_public_settings.activity_id))
 
             operation = config_settings.__getattribute__(self.config_public_settings.operation)
 
             # Allow only certain operations
             if operation not in [Constants.NOOPERATION, Constants.ASSESSMENT, Constants.INSTALLATION, Constants.CONFIGURE_PATCHING]:
-                self.logger.log_error("Requested operation is not supported by the extension")
+                request_not_supported_msg = "Requested operation is not supported by the extension"
+                self.logger.log_error(request_not_supported_msg)
+                self.telemetry_writer.write_event(request_not_supported_msg, Constants.TelemetryEventLevel.Error)
                 exit(Constants.ExitCode.InvalidConfigSettingPropertyValue)
 
             prev_patch_max_end_time = self.cmd_exec_start_time + datetime.timedelta(hours=0, minutes=Constants.ENABLE_MAX_RUNTIME)
@@ -67,7 +72,9 @@ class EnableCommandHandler(object):
 
             # If ConfigurePatching is requested, do nothing, will be implemented in future
             if operation == Constants.CONFIGURE_PATCHING:
-                self.logger.log("Received a configure patching request, no action will be taken as it is not supported for now. [Operation Sequence={0}]".format(str(self.seq_no)))
+                configure_patching_request_msg = "Received a configure patching request, no action will be taken as it is not supported for now. [Operation Sequence={0}]".format(str(self.seq_no))
+                self.logger.log(configure_patching_request_msg)
+                self.telemetry_writer.write_event(configure_patching_request_msg, Constants.TelemetryEventLevel.Informational)
                 exit(Constants.ExitCode.Okay)
 
             # if NoOperation is requested, terminate all running processes from previous operation and update status file
@@ -77,7 +84,9 @@ class EnableCommandHandler(object):
                 # if any of the other operations are requested, verify if request is a new request or a re-enable, by comparing sequence number from the prev request and current one
                 if core_state_content is None or core_state_content.__getattribute__(self.core_state_fields.number) is None:
                     # first patch request for the VM
-                    self.logger.log("No state information was found for any previous patch operation. Launching a new patch operation.")
+                    prev_patch_state_not_found_msg = "No state information was found for any previous patch operation. Launching a new patch operation."
+                    self.logger.log(prev_patch_state_not_found_msg)
+                    self.telemetry_writer.write_event(prev_patch_state_not_found_msg, Constants.TelemetryEventLevel.Informational)
                     self.launch_new_process(config_settings, create_status_output_file=True)
                 else:
                     if int(core_state_content.__getattribute__(self.core_state_fields.number)) != int(self.seq_no):
@@ -88,31 +97,44 @@ class EnableCommandHandler(object):
                         self.process_reenable_request(config_settings, core_state_content)
 
         except Exception as error:
-            self.logger.log_error("Failed to execute enable. [Exception={0}]".format(repr(error)))
+            enable_error_msg = "Failed to execute enable. [Exception={0}]".format(repr(error))
+            self.logger.log_error(enable_error_msg)
+            self.telemetry_writer.write_event(enable_error_msg, Constants.TelemetryEventLevel.Error)
             raise
 
     def process_enable_request(self, config_settings, prev_patch_max_end_time, core_state_content):
         """ Called when the current request is different from the one before. Identifies and waits for the previous request action to complete, if required before addressing the current request """
-        self.logger.log("Terminating older patch operation, if still in progress, as per it's completion duration and triggering the new requested patch operation.")
+        terminating_older_operation_msg = "Terminating older patch operation, if still in progress, as per it's completion duration and triggering the new requested patch operation."
+        self.logger.log(terminating_older_operation_msg)
+        self.telemetry_writer.write_event(terminating_older_operation_msg, Constants.TelemetryEventLevel.Informational)
         self.runtime_context_handler.process_previous_patch_operation(self.core_state_handler, self.process_handler, prev_patch_max_end_time, core_state_content)
         self.utility.delete_file(self.core_state_handler.dir_path, self.core_state_handler.file)
         self.launch_new_process(config_settings, create_status_output_file=True)
 
     def process_reenable_request(self, config_settings, core_state_content):
         """ Called when the current request has the same config as the one before it. Restarts the operation if the previous request has errors, no action otherwise """
-        self.logger.log("This is the same request as the previous patch operation. Checking previous request's status")
+        reenable_request_msg = "This is the same request as the previous patch operation. Checking previous request's status"
+        self.logger.log(reenable_request_msg)
+        self.telemetry_writer.write_event(reenable_request_msg, Constants.TelemetryEventLevel.Informational)
+
         if core_state_content.__getattribute__(self.core_state_fields.completed).lower() == 'false':
             running_process_ids = self.process_handler.identify_running_processes(core_state_content.__getattribute__(self.core_state_fields.process_ids))
             if len(running_process_ids) == 0:
-                self.logger.log("Re-triggering the patch operation as the previous patch operation was not running and hadn't marked completion either.")
+                restart_patch_msg = "Re-triggering the patch operation as the previous patch operation was not running and hadn't marked completion either."
+                self.logger.log(restart_patch_msg)
+                self.telemetry_writer.write_event(restart_patch_msg, Constants.TelemetryEventLevel.Informational)
                 self.utility.delete_file(self.core_state_handler.dir_path, self.core_state_handler.file)
                 self.launch_new_process(config_settings, create_status_output_file=False)
             else:
-                self.logger.log("Patch operation is in progress from the previous request. [Operation={0}]".format(config_settings.__getattribute__(self.config_public_settings.operation)))
+                prev_patch_in_progress_msg = "Patch operation is in progress from the previous request. [Operation={0}]".format(config_settings.__getattribute__(self.config_public_settings.operation))
+                self.logger.log(prev_patch_in_progress_msg)
+                self.telemetry_writer.write_event(prev_patch_in_progress_msg, Constants.TelemetryEventLevel.Informational)
                 exit(Constants.ExitCode.Okay)
 
         else:
-            self.logger.log("Patch operation already completed in the previous request. [Operation={0}]".format(config_settings.__getattribute__(self.config_public_settings.operation)))
+            patch_complete_msg = "Patch operation already completed in the previous request. [Operation={0}]".format(config_settings.__getattribute__(self.config_public_settings.operation))
+            self.logger.log(patch_complete_msg)
+            self.telemetry_writer.write_event(patch_complete_msg, Constants.TelemetryEventLevel.Informational)
             exit(Constants.ExitCode.Okay)
 
     def launch_new_process(self, config_settings, create_status_output_file):
@@ -124,11 +146,15 @@ class EnableCommandHandler(object):
             self.ext_output_status_handler.update_file(self.seq_no, self.ext_env_handler.status_folder)
         # launch core code in a process and exit extension handler
         process = self.process_handler.start_daemon(self.seq_no, config_settings, self.ext_env_handler)
-        self.logger.log("exiting extension handler")
+        handler_exit_msg = "exiting extension handler"
+        self.logger.log(handler_exit_msg)
+        self.telemetry_writer.write_event(handler_exit_msg, Constants.TelemetryEventLevel.Informational)
         exit(Constants.ExitCode.Okay)
 
     def process_nooperation(self, config_settings, core_state_content):
-        self.logger.log("NoOperation requested. Terminating older patch operation, if still in progress.")
+        nooperation_request_msg = "NoOperation requested. Terminating older patch operation, if still in progress."
+        self.logger.log(nooperation_request_msg)
+        self.telemetry_writer.write_event(nooperation_request_msg, Constants.TelemetryEventLevel.Informational)
         self.ext_output_status_handler.set_current_operation(Constants.NOOPERATION)
         activity_id = config_settings.__getattribute__(self.config_public_settings.activity_id)
         operation = config_settings.__getattribute__(self.config_public_settings.operation)
@@ -139,11 +165,14 @@ class EnableCommandHandler(object):
             self.utility.delete_file(self.core_state_handler.dir_path, self.core_state_handler.file, raise_if_not_found=False)
             # ToDo: log prev activity id later
             self.ext_output_status_handler.set_nooperation_substatus_json(operation, activity_id, start_time, seq_no=self.seq_no, status=Constants.Status.Success)
-            self.logger.log("exiting extension handler")
+            handler_exit_msg = "exiting extension handler"
+            self.logger.log(handler_exit_msg)
+            self.telemetry_writer.write_event(handler_exit_msg, Constants.TelemetryEventLevel.Informational)
             exit(Constants.ExitCode.Okay)
         except Exception as error:
             error_msg = "Error executing NoOperation: " + repr(error)
             self.logger.log(error_msg)
+            self.telemetry_writer.write_event(error_msg, Constants.TelemetryEventLevel.Informational)
             if Constants.ERROR_ADDED_TO_STATUS not in repr(error):
                 self.ext_output_status_handler.add_error_to_status(error_msg, Constants.PatchOperationErrorCodes.OPERATION_FAILED)
             else:

--- a/src/extension/src/EnableCommandHandler.py
+++ b/src/extension/src/EnableCommandHandler.py
@@ -102,7 +102,6 @@ class EnableCommandHandler(object):
     def process_reenable_request(self, config_settings, core_state_content):
         """ Called when the current request has the same config as the one before it. Restarts the operation if the previous request has errors, no action otherwise """
         self.logger.log("This is the same request as the previous patch operation. Checking previous request's status")
-
         if core_state_content.__getattribute__(self.core_state_fields.completed).lower() == 'false':
             running_process_ids = self.process_handler.identify_running_processes(core_state_content.__getattribute__(self.core_state_fields.process_ids))
             if len(running_process_ids) == 0:

--- a/src/extension/src/InstallCommandHandler.py
+++ b/src/extension/src/InstallCommandHandler.py
@@ -20,27 +20,21 @@ from extension.src.Constants import Constants
 
 class InstallCommandHandler(object):
 
-    def __init__(self, logger, telemetry_writer, ext_env_handler):
+    def __init__(self, logger, ext_env_handler):
         self.logger = logger
-        self.telemetry_writer = telemetry_writer
         self.ext_env_handler = ext_env_handler
 
     def execute_handler_action(self):
         self.validate_os_type()
         self.validate_environment()
-        install_complete_msg = "Install Command Completed"
-        self.logger.log(install_complete_msg)
-        self.telemetry_writer.write_event(install_complete_msg, Constants.TelemetryEventLevel.Informational)
+        self.logger.log("Install Command Completed")
         return Constants.ExitCode.Okay
 
     def validate_os_type(self):
         os_type = sys.platform
-        validating_os_msg = "Validating OS. [Platform={0}]".format(os_type)
-        self.logger.log(validating_os_msg)
-        self.telemetry_writer.write_event(validating_os_msg, Constants.TelemetryEventLevel.Informational)
+        self.logger.log("Validating OS. [Platform={0}]".format(os_type))
         if not os_type.__contains__('linux'):
             error_msg = "Incompatible system: This update is for Linux OS"
-            self.telemetry_writer.write_event(error_msg, Constants.TelemetryEventLevel.Error)
             self.logger.log_error_and_raise_new_exception(error_msg, Exception)
         return True
 
@@ -48,26 +42,20 @@ class InstallCommandHandler(object):
         file = Constants.HANDLER_ENVIRONMENT_FILE
         env_settings_fields = Constants.EnvSettingsFields
         config_type = env_settings_fields.settings_parent_key
-        validating_file_msg = "Validating file. [File={0}]".format(file)
-        self.logger.log(validating_file_msg)
-        self.telemetry_writer.write_event(validating_file_msg, Constants.TelemetryEventLevel.Informational)
+        self.logger.log("Validating file. [File={0}]".format(file))
 
         if self.ext_env_handler.handler_environment_json is not None and self.ext_env_handler.handler_environment_json is not Exception:
             if len(self.ext_env_handler.handler_environment_json) != 1:
                 error_msg = "Incorrect file format. [File={0}]".format(file)
-                self.telemetry_writer.write_event(error_msg, Constants.TelemetryEventLevel.Error)
                 self.logger.log_error_and_raise_new_exception(error_msg, Exception)
 
             self.validate_key(config_type, self.ext_env_handler.handler_environment_json[0], 'dict', True, file)
             self.validate_key(env_settings_fields.log_folder, self.ext_env_handler.handler_environment_json[0][config_type], ['str', 'unicode'], True, file)
             self.validate_key(env_settings_fields.config_folder, self.ext_env_handler.handler_environment_json[0][config_type], ['str', 'unicode'], True, file)
             self.validate_key(env_settings_fields.status_folder, self.ext_env_handler.handler_environment_json[0][config_type], ['str', 'unicode'], True, file)
-            validate_success_msg = "Handler Environment validated"
-            self.logger.log(validate_success_msg)
-            self.telemetry_writer.write_event(validate_success_msg, Constants.TelemetryEventLevel.Informational)
+            self.logger.log("Handler Environment validated")
         else:
             error_msg = "No content in file. [File={0}]".format(file)
-            self.telemetry_writer.write_event(error_msg, Constants.TelemetryEventLevel.Error)
             self.logger.log_error_and_raise_new_exception(error_msg, Exception)
 
     """ Validates json files for required key/value pairs """
@@ -76,22 +64,18 @@ class InstallCommandHandler(object):
             # Required key doesn't exist in config file
             if key not in config_type:
                 error_msg = "Config not found in file. [Config={0}] [File={1}]".format(key, file)
-                self.telemetry_writer.write_event(error_msg, Constants.TelemetryEventLevel.Error)
                 self.logger.log_error_and_raise_new_exception(error_msg, Exception)
             # Required key doesn't have value
             elif data_type is not bool and not config_type[key]:
                 error_msg = "Empty value error. [Config={0}]".format(key)
-                self.telemetry_writer.write_event(error_msg, Constants.TelemetryEventLevel.Error)
                 self.logger.log_error_and_raise_new_exception(error_msg, Exception)
             # Required key does not have value of expected datatype
             elif type(config_type[key]).__name__  not in data_type:
                 error_msg = "Unexpected data type. [config={0}] in [file={1}]".format(key, file)
-                self.telemetry_writer.write_event(error_msg, Constants.TelemetryEventLevel.Error)
                 self.logger.log_error_and_raise_new_exception(error_msg, Exception)
         else:
             # Expected data type for an optional key
             if key in config_type and config_type[key] and type(config_type[key]).__name__  not in data_type:
                 error_msg = "Unexpected data type. [config={0}] in [file={1}]".format(key, file)
-                self.telemetry_writer.write_event(error_msg, Constants.TelemetryEventLevel.Error)
                 self.logger.log_error_and_raise_new_exception(error_msg, Exception)
 

--- a/src/extension/src/ProcessHandler.py
+++ b/src/extension/src/ProcessHandler.py
@@ -71,7 +71,6 @@ class ProcessHandler(object):
 
         # Verify the python version available on the machine to use
         self.logger.log("Python version: " + " ".join(sys.version.splitlines()))
-
         python_cmd = self.get_python_cmd()
         if python_cmd == Constants.PYTHON_NOT_FOUND:
             self.logger.log("Cannot execute patch operation due to error. [Error={0}]".format(Constants.PYTHON_NOT_FOUND))
@@ -79,13 +78,11 @@ class ProcessHandler(object):
 
         command = [python_cmd + " " + exec_path + " " + args]
         self.logger.log("Launching process. [command={0}]".format(str(command)))
-
         process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         if process.pid is not None:
             self.logger.log("New shell process launched successfully. [Process ID (PID)={0}]".format(str(process.pid)))
             did_process_start = self.__check_process_state(process, seq_no)
             return process if did_process_start else None
-
         self.logger.log_error("Error launching process for given sequence. [sequence={0}]".format(seq_no))
 
     def get_python_cmd(self):
@@ -199,7 +196,6 @@ class ProcessHandler(object):
                 process_id = int(process_id)
                 if self.is_process_running(process_id):
                     running_process_ids.append(process_id)
-
         self.logger.log("Processes still running from the previous request: [PIDs={0}]".format(str(running_process_ids)))
         return running_process_ids
 
@@ -225,11 +221,9 @@ class ProcessHandler(object):
             if self.is_process_running(pid):
                 self.logger.log("Terminating process: [PID={0}]".format(str(pid)))
                 os.kill(pid, signal.SIGTERM)
-
         except OSError as error:
             self.logger.log_error("Error terminating process. [Process ID={0}] [Error={1}]".format(pid, repr(error)))
             self.ext_output_status_handler.add_error_to_status("Error terminating process. [Process ID={0}] [Error={1}]".format(pid, repr(error)), Constants.PatchOperationErrorCodes.DEFAULT_ERROR)
-
             if Constants.ERROR_ADDED_TO_STATUS not in repr(error):
                 error.args = (error.args, "[{0}]".format(Constants.ERROR_ADDED_TO_STATUS))
             raise

--- a/src/extension/src/RuntimeContextHandler.py
+++ b/src/extension/src/RuntimeContextHandler.py
@@ -20,21 +20,15 @@ from extension.src.Constants import Constants
 
 
 class RuntimeContextHandler(object):
-    def __init__(self, logger, telemetry_writer):
+    def __init__(self, logger):
         self.logger = logger
-        self.telemetry_writer = telemetry_writer
         self.core_state_fields = Constants.CoreStateFields
 
     def terminate_processes_from_previous_operation(self, process_handler, core_state_content):
         """ Terminates all running processes from the previous request """
-        patch_progress_check = "Verifying if previous patch operation is still in progress"
-        self.logger.log(patch_progress_check)
-        self.telemetry_writer.write_event(patch_progress_check, Constants.TelemetryEventLevel.Informational)
-
+        self.logger.log("Verifying if previous patch operation is still in progress")
         if core_state_content is None or core_state_content.__getattribute__(self.core_state_fields.completed).lower() == 'true':
-            prev_request_complete = "Previous request is complete"
-            self.logger.log(prev_request_complete)
-            self.telemetry_writer.write_event(prev_request_complete, Constants.TelemetryEventLevel.Informational)
+            self.logger.log("Previous request is complete")
             return
 
         # verify if processes from prev request are running
@@ -45,31 +39,20 @@ class RuntimeContextHandler(object):
 
     def process_previous_patch_operation(self, core_state_handler, process_handler, prev_patch_max_end_time, core_state_content):
         """ Waits for the previous request action to complete for a specific time, terminates previous process if it goes over that time """
-        patch_progress_check = "Verifying if previous patch operation is still in progress"
-        self.logger.log(patch_progress_check)
-        self.telemetry_writer.write_event(patch_progress_check, Constants.TelemetryEventLevel.Informational)
-
+        self.logger.log("Verifying if previous patch operation is still in progress")
         core_state_content = core_state_handler.read_file() if core_state_content is None else core_state_content
         if core_state_content is None or core_state_content.__getattribute__(self.core_state_fields.completed).lower() == 'true':
-            prev_request_complete = "Previous request is complete"
-            self.logger.log(prev_request_complete)
-            self.telemetry_writer.write_event(prev_request_complete, Constants.TelemetryEventLevel.Informational)
+            self.logger.log("Previous request is complete")
             return
-
         # verify if processes from prev request are running
         running_process_ids = process_handler.identify_running_processes(core_state_content.__getattribute__(self.core_state_fields.process_ids))
         if len(running_process_ids) != 0:
             is_patch_complete = self.check_if_patch_completes_in_time(prev_patch_max_end_time, core_state_content.__getattribute__(self.core_state_fields.last_heartbeat), core_state_handler)
             if is_patch_complete:
-                prev_request_complete = "Previous request is complete"
-                self.logger.log(prev_request_complete)
-                self.telemetry_writer.write_event(prev_request_complete, Constants.TelemetryEventLevel.Informational)
+                self.logger.log("Previous request is complete")
                 return
-
             for pid in running_process_ids:
-                prev_request_pending = "Previous request did not complete in time. Terminating all of it's running processes."
-                self.logger.log(prev_request_pending)
-                self.telemetry_writer.write_event(prev_request_pending, Constants.TelemetryEventLevel.Informational)
+                self.logger.log("Previous request did not complete in time. Terminating all of it's running processes.")
                 process_handler.kill_process(pid)
 
     def check_if_patch_completes_in_time(self, time_for_prev_patch_to_complete, core_state_last_heartbeat, core_state_handler):
@@ -83,12 +66,7 @@ class RuntimeContextHandler(object):
         while remaining_wait_time > 0:
             next_wait_time_in_seconds = max_wait_interval_in_seconds if remaining_wait_time > max_wait_interval_in_seconds else remaining_wait_time
             core_state_last_heartbeat = core_state_last_heartbeat if core_state_content is None else core_state_content.__getattribute__(self.core_state_fields.last_heartbeat)
-
-            patch_in_progress = "Previous patch operation is still in progress with last status update at {0}. Waiting for a maximum of {1} seconds for it to complete with intermittent status change checks. Next check will be performed after {2} seconds."\
-                .format(str(core_state_last_heartbeat), str(remaining_wait_time), str(next_wait_time_in_seconds))
-            self.logger.log(patch_in_progress)
-            self.telemetry_writer.write_event(patch_in_progress, Constants.TelemetryEventLevel.Informational)
-
+            self.logger.log("Previous patch operation is still in progress with last status update at {0}. Waiting for a maximum of {1} seconds for it to complete with intermittent status change checks. Next check will be performed after {2} seconds.".format(str(core_state_last_heartbeat), str(remaining_wait_time), str(next_wait_time_in_seconds)))
             time.sleep(next_wait_time_in_seconds)
             remaining_wait_time = (time_for_prev_patch_to_complete - datetime.datetime.utcnow()).total_seconds()
             # read CoreState.json file again, to verify if the previous processes is completed

--- a/src/extension/src/RuntimeContextHandler.py
+++ b/src/extension/src/RuntimeContextHandler.py
@@ -20,16 +20,23 @@ from extension.src.Constants import Constants
 
 
 class RuntimeContextHandler(object):
-    def __init__(self, logger):
+    def __init__(self, logger, telemetry_writer):
         self.logger = logger
+        self.telemetry_writer = telemetry_writer
         self.core_state_fields = Constants.CoreStateFields
 
     def terminate_processes_from_previous_operation(self, process_handler, core_state_content):
         """ Terminates all running processes from the previous request """
-        self.logger.log("Verifying if previous patch operation is still in progress")
+        patch_progress_check = "Verifying if previous patch operation is still in progress"
+        self.logger.log(patch_progress_check)
+        self.telemetry_writer.write_event(patch_progress_check, Constants.TelemetryEventLevel.Informational)
+
         if core_state_content is None or core_state_content.__getattribute__(self.core_state_fields.completed).lower() == 'true':
-            self.logger.log("Previous request is complete")
+            prev_request_complete = "Previous request is complete"
+            self.logger.log(prev_request_complete)
+            self.telemetry_writer.write_event(prev_request_complete, Constants.TelemetryEventLevel.Informational)
             return
+
         # verify if processes from prev request are running
         running_process_ids = process_handler.identify_running_processes(core_state_content.__getattribute__(self.core_state_fields.process_ids))
         if len(running_process_ids) != 0:
@@ -38,20 +45,31 @@ class RuntimeContextHandler(object):
 
     def process_previous_patch_operation(self, core_state_handler, process_handler, prev_patch_max_end_time, core_state_content):
         """ Waits for the previous request action to complete for a specific time, terminates previous process if it goes over that time """
-        self.logger.log("Verifying if previous patch operation is still in progress")
+        patch_progress_check = "Verifying if previous patch operation is still in progress"
+        self.logger.log(patch_progress_check)
+        self.telemetry_writer.write_event(patch_progress_check, Constants.TelemetryEventLevel.Informational)
+
         core_state_content = core_state_handler.read_file() if core_state_content is None else core_state_content
         if core_state_content is None or core_state_content.__getattribute__(self.core_state_fields.completed).lower() == 'true':
-            self.logger.log("Previous request is complete")
+            prev_request_complete = "Previous request is complete"
+            self.logger.log(prev_request_complete)
+            self.telemetry_writer.write_event(prev_request_complete, Constants.TelemetryEventLevel.Informational)
             return
+
         # verify if processes from prev request are running
         running_process_ids = process_handler.identify_running_processes(core_state_content.__getattribute__(self.core_state_fields.process_ids))
         if len(running_process_ids) != 0:
             is_patch_complete = self.check_if_patch_completes_in_time(prev_patch_max_end_time, core_state_content.__getattribute__(self.core_state_fields.last_heartbeat), core_state_handler)
             if is_patch_complete:
-                self.logger.log("Previous request is complete")
+                prev_request_complete = "Previous request is complete"
+                self.logger.log(prev_request_complete)
+                self.telemetry_writer.write_event(prev_request_complete, Constants.TelemetryEventLevel.Informational)
                 return
+
             for pid in running_process_ids:
-                self.logger.log("Previous request did not complete in time. Terminating all of it's running processes.")
+                prev_request_pending = "Previous request did not complete in time. Terminating all of it's running processes."
+                self.logger.log(prev_request_pending)
+                self.telemetry_writer.write_event(prev_request_pending, Constants.TelemetryEventLevel.Informational)
                 process_handler.kill_process(pid)
 
     def check_if_patch_completes_in_time(self, time_for_prev_patch_to_complete, core_state_last_heartbeat, core_state_handler):
@@ -65,7 +83,12 @@ class RuntimeContextHandler(object):
         while remaining_wait_time > 0:
             next_wait_time_in_seconds = max_wait_interval_in_seconds if remaining_wait_time > max_wait_interval_in_seconds else remaining_wait_time
             core_state_last_heartbeat = core_state_last_heartbeat if core_state_content is None else core_state_content.__getattribute__(self.core_state_fields.last_heartbeat)
-            self.logger.log("Previous patch operation is still in progress with last status update at {0}. Waiting for a maximum of {1} seconds for it to complete with intermittent status change checks. Next check will be performed after {2} seconds.".format(str(core_state_last_heartbeat), str(remaining_wait_time), str(next_wait_time_in_seconds)))
+
+            patch_in_progress = "Previous patch operation is still in progress with last status update at {0}. Waiting for a maximum of {1} seconds for it to complete with intermittent status change checks. Next check will be performed after {2} seconds."\
+                .format(str(core_state_last_heartbeat), str(remaining_wait_time), str(next_wait_time_in_seconds))
+            self.logger.log(patch_in_progress)
+            self.telemetry_writer.write_event(patch_in_progress, Constants.TelemetryEventLevel.Informational)
+
             time.sleep(next_wait_time_in_seconds)
             remaining_wait_time = (time_for_prev_patch_to_complete - datetime.datetime.utcnow()).total_seconds()
             # read CoreState.json file again, to verify if the previous processes is completed

--- a/src/extension/src/RuntimeContextHandler.py
+++ b/src/extension/src/RuntimeContextHandler.py
@@ -30,7 +30,6 @@ class RuntimeContextHandler(object):
         if core_state_content is None or core_state_content.__getattribute__(self.core_state_fields.completed).lower() == 'true':
             self.logger.log("Previous request is complete")
             return
-
         # verify if processes from prev request are running
         running_process_ids = process_handler.identify_running_processes(core_state_content.__getattribute__(self.core_state_fields.process_ids))
         if len(running_process_ids) != 0:

--- a/src/extension/src/TelemetryWriter.py
+++ b/src/extension/src/TelemetryWriter.py
@@ -35,7 +35,7 @@ class TelemetryWriter(object):
     def __new_event_json(self, event_level, message, task_name):
         return {
             "Version": Constants.EXT_VERSION,
-            "Timestamp": str((datetime.datetime.utcnow()).strftime(Constants.UTC_DATETIME_FORMAT)),
+            "Timestamp": str(datetime.datetime.utcnow()),
             "TaskName": task_name,
             "EventLevel": event_level,
             "Message": self.__ensure_message_restriction_compliance(message),
@@ -50,7 +50,7 @@ class TelemetryWriter(object):
         formatted_message = re.sub(r"\s+", " ", str(full_message))
 
         if len(formatted_message.encode('utf-8')) > message_size_limit_in_bytes:
-            self.logger.log_telemetry("Data sent to telemetry will be truncated as it exceeds size limit. [Message={0}]".format(str(formatted_message)))
+            self.logger.log_telemetry_module("Data sent to telemetry will be truncated as it exceeds size limit. [Message={0}]".format(str(formatted_message)))
             formatted_message = formatted_message.encode('utf-8')
             bytes_dropped = len(formatted_message) - message_size_limit_in_bytes + Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_BYTES
             return formatted_message[:message_size_limit_in_bytes - Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_BYTES].decode('utf-8') + '. [{0} bytes dropped]'.format(bytes_dropped)
@@ -66,8 +66,7 @@ class TelemetryWriter(object):
 
         event = self.__new_event_json(event_level, message, task_name)
         if len(json.dumps(event)) > Constants.TELEMETRY_EVENT_SIZE_LIMIT_IN_BYTES:
-            self.logger.log_telemetry_error("Cannot send data to telemetry as it exceeded the acceptable data size. [Data not sent={0}]".format(json.dumps(message)))
-            # print("Cannot send data to telemetry as it exceeded the acceptable data size. [Data not sent={0}]".format(json.dumps(message)))
+            self.logger.log_telemetry_module_error("Cannot send data to telemetry as it exceeded the acceptable data size. [Data not sent={0}]".format(json.dumps(message)))
         else:
             self.write_event_using_temp_file(self.events_folder_path, event)
 
@@ -77,7 +76,7 @@ class TelemetryWriter(object):
             # Not deleting any existing event files as the event directory does not exceed max limit. At least one new event file can be added. Not printing this statement as it will add repetitive logs
             return
 
-        self.logger.log_telemetry("Events directory size exceeds maximum limit. Deleting older event files until at least one new event file can be added.")
+        self.logger.log_telemetry_module("Events directory size exceeds maximum limit. Deleting older event files until at least one new event file can be added.")
         event_files = [os.path.join(self.events_folder_path, event_file) for event_file in os.listdir(self.events_folder_path) if (event_file.lower().endswith(".json"))]
         event_files.sort(key=os.path.getmtime, reverse=True)
 
@@ -89,9 +88,9 @@ class TelemetryWriter(object):
 
                 if os.path.exists(event_file):
                     os.remove(event_file)
-                    self.logger.log_telemetry("Deleted event file. [File={0}]".format(repr(event_file)))
+                    self.logger.log_telemetry_module("Deleted event file. [File={0}]".format(repr(event_file)))
             except Exception as e:
-                self.logger.log_telemetry_error("Error deleting event file. [File={0}] [Exception={1}]".format(repr(event_file), repr(e)))
+                self.logger.log_telemetry_module_error("Error deleting event file. [File={0}] [Exception={1}]".format(repr(event_file), repr(e)))
 
         if self.__get_events_dir_size() >= Constants.TELEMETRY_DIR_SIZE_LIMIT_IN_BYTES:
             raise Exception("Older event files were not deleted. Current event will not be sent to telemetry as events directory size exceeds maximum limit")

--- a/src/extension/src/TelemetryWriter.py
+++ b/src/extension/src/TelemetryWriter.py
@@ -59,7 +59,7 @@ class TelemetryWriter(object):
 
     def write_event(self, message, event_level=Constants.TelemetryEventLevel.Informational, task_name=Constants.TELEMETRY_TASK_NAME):
         """ Creates and writes event to event file after validating none of the telemetry size restrictions are breached """
-        if self.events_folder_path is None or not os.path.exists(self.events_folder_path):
+        if self.events_folder_path is None or not os.path.exists(self.events_folder_path) or not Constants.TELEMETRY_ENABLED_AT_EXTENSION:
             return
 
         self.__delete_older_events()

--- a/src/extension/src/TelemetryWriter.py
+++ b/src/extension/src/TelemetryWriter.py
@@ -30,7 +30,7 @@ class TelemetryWriter(object):
     def __init__(self, logger):
         self.logger = logger
         self.events_folder_path = None
-        self.operation_id = ""
+        self.__operation_id = ""
 
     def __new_event_json(self, event_level, message, task_name):
         return {
@@ -41,7 +41,7 @@ class TelemetryWriter(object):
             "Message": self.__ensure_message_restriction_compliance(message),
             "EventPid": "",
             "EventTid": "",
-            "OperationId": self.operation_id  # we can provide activity id from config settings here, but currently we only read settings file for enable command
+            "OperationId": self.__operation_id  # This should have activity id from from config settings, but since we only read settings file for enable command, enable command will have activity id set here and all non-enable commands will have this as a timestamp
         }
 
     def __ensure_message_restriction_compliance(self, full_message):
@@ -119,7 +119,7 @@ class TelemetryWriter(object):
             raise Exception("Unable to write to telemetry. [Event File={0}] [Error={1}].".format(str(file_path), repr(error)))
 
     def set_operation_id(self, operation_id):
-        self.operation_id = operation_id
+        self.__operation_id = operation_id
 
     def __get_events_dir_size(self):
         return sum([os.path.getsize(os.path.join(self.events_folder_path, f)) for f in os.listdir(self.events_folder_path) if os.path.isfile(os.path.join(self.events_folder_path, f))])

--- a/src/extension/src/TelemetryWriter.py
+++ b/src/extension/src/TelemetryWriter.py
@@ -27,11 +27,12 @@ from extension.src.Constants import Constants
 class TelemetryWriter(object):
     """Class for writing telemetry data to events"""
 
-    def __init__(self):
+    def __init__(self, logger):
+        self.logger = logger
         self.events_folder_path = None
         self.operation_id = ""
 
-    def __new_event_json(self, task_name, event_level, message):
+    def __new_event_json(self, event_level, message, task_name):
         return {
             "Version": Constants.EXT_VERSION,
             "Timestamp": str((datetime.datetime.utcnow()).strftime(Constants.UTC_DATETIME_FORMAT)),
@@ -43,26 +44,30 @@ class TelemetryWriter(object):
             "OperationId": self.operation_id  # we can provide activity id from config settings here, but currently we only read settings file for enable command
         }
 
-    @staticmethod
-    def __ensure_message_restriction_compliance(full_message):
+    def __ensure_message_restriction_compliance(self, full_message):
         """ Removes line breaks, tabs and restricts message to a byte limit """
         message_size_limit_in_bytes = Constants.TELEMETRY_MSG_SIZE_LIMIT_IN_BYTES
         formatted_message = re.sub(r"\s+", " ", str(full_message))
 
         if len(formatted_message.encode('utf-8')) > message_size_limit_in_bytes:
+            self.logger.log_telemetry("Data sent to telemetry will be truncated as it exceeds size limit. [Message={0}]".format(str(formatted_message)))
             formatted_message = formatted_message.encode('utf-8')
             bytes_dropped = len(formatted_message) - message_size_limit_in_bytes + Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_BYTES
             return formatted_message[:message_size_limit_in_bytes - Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_BYTES].decode('utf-8') + '. [{0} bytes dropped]'.format(bytes_dropped)
 
         return formatted_message
 
-    def write_event(self, task_name, message, event_level=Constants.TelemetryEventLevel.Informational):
+    def write_event(self, message, event_level=Constants.TelemetryEventLevel.Informational, task_name=Constants.TELEMETRY_TASK_NAME):
         """ Creates and writes event to event file after validating none of the telemetry size restrictions are breached """
+        if self.events_folder_path is None or not os.path.exists(self.events_folder_path):
+            return
+
         self.__delete_older_events()
 
-        event = self.__new_event_json(task_name, event_level, message)
+        event = self.__new_event_json(event_level, message, task_name)
         if len(json.dumps(event)) > Constants.TELEMETRY_EVENT_SIZE_LIMIT_IN_BYTES:
-            print("Cannot send data to telemetry as it exceeded the acceptable data size. [Data not sent={0}]".format(json.dumps(message)))
+            self.logger.log_telemetry_error("Cannot send data to telemetry as it exceeded the acceptable data size. [Data not sent={0}]".format(json.dumps(message)))
+            # print("Cannot send data to telemetry as it exceeded the acceptable data size. [Data not sent={0}]".format(json.dumps(message)))
         else:
             self.write_event_using_temp_file(self.events_folder_path, event)
 
@@ -72,7 +77,7 @@ class TelemetryWriter(object):
             # Not deleting any existing event files as the event directory does not exceed max limit. At least one new event file can be added. Not printing this statement as it will add repetitive logs
             return
 
-        print("Events directory size exceeds maximum limit. Deleting older event files until at least one new event file can be added.")
+        self.logger.log_telemetry("Events directory size exceeds maximum limit. Deleting older event files until at least one new event file can be added.")
         event_files = [os.path.join(self.events_folder_path, event_file) for event_file in os.listdir(self.events_folder_path) if (event_file.lower().endswith(".json"))]
         event_files.sort(key=os.path.getmtime, reverse=True)
 
@@ -84,9 +89,9 @@ class TelemetryWriter(object):
 
                 if os.path.exists(event_file):
                     os.remove(event_file)
-                    print("Deleted event file. [File={0}]".format(repr(event_file)))
+                    self.logger.log_telemetry("Deleted event file. [File={0}]".format(repr(event_file)))
             except Exception as e:
-                print("Error deleting event file. [File={0}] [Exception={1}]".format(repr(event_file), repr(e)))
+                self.logger.log_telemetry_error("Error deleting event file. [File={0}] [Exception={1}]".format(repr(event_file), repr(e)))
 
         if self.__get_events_dir_size() >= Constants.TELEMETRY_DIR_SIZE_LIMIT_IN_BYTES:
             raise Exception("Older event files were not deleted. Current event will not be sent to telemetry as events directory size exceeds maximum limit")
@@ -111,7 +116,7 @@ class TelemetryWriter(object):
                 tempname = tf.name
             shutil.move(tempname, file_path)
         except Exception as error:
-            raise Exception("Unable to write to {0}. Error: {1}.".format(str(file_path), repr(error)))
+            raise Exception("Unable to write to telemetry. [Event File={0}] [Error={1}].".format(str(file_path), repr(error)))
 
     def set_operation_id(self, operation_id):
         self.operation_id = operation_id

--- a/src/extension/src/Utility.py
+++ b/src/extension/src/Utility.py
@@ -22,16 +22,13 @@ from extension.src.local_loggers.FileLogger import FileLogger
 
 
 class Utility(object):
-    def __init__(self, logger, telemetry_writer):
+    def __init__(self, logger):
         self.logger = logger
-        self.telemetry_writer = telemetry_writer
         self.retry_count = Constants.MAX_IO_RETRIES
 
     def delete_file(self, dir_path, file, raise_if_not_found=True):
         """ Retries delete operation for a set number of times before failing """
-        message = "Deleting file. [File={0}]".format(file)
-        self.logger.log(message)
-        self.telemetry_writer.write_event(message, Constants.TelemetryEventLevel.Informational)
+        self.logger.log("Deleting file. [File={0}]".format(file))
         file_path = os.path.join(dir_path, file)
         error_msg = ""
         if os.path.exists(file_path) and os.path.isfile(file_path):
@@ -43,15 +40,12 @@ class Utility(object):
                 except Exception as e:
                     error_msg = "Trial {0}: Could not delete file. [File={1}] [Exception={2}]".format(retry+1, file, repr(e))
                     self.logger.log_warning(error_msg)
-                    self.telemetry_writer.write_event(error_msg, Constants.TelemetryEventLevel.Warning)
 
             error_msg = "Failed to delete file after {0} tries. [File={1}] [Exception={2}]".format(self.retry_count, file, error_msg)
             self.logger.log_error(error_msg)
-            self.telemetry_writer.write_event(error_msg, Constants.TelemetryEventLevel.Error)
         else:
             error_msg = "File Not Found: [File={0}] in [path={1}]".format(file, dir_path)
             self.logger.log_error(error_msg)
-            self.telemetry_writer.write_event(error_msg, Constants.TelemetryEventLevel.Error)
         if raise_if_not_found:
             raise Exception(error_msg)
 
@@ -59,14 +53,10 @@ class Utility(object):
         """ Creates <file_name>.ext.log file under the path for logFolder provided in HandlerEnvironment """
         file_path = file_name + str(".ext") + Constants.LOG_FILE_EXTENSION
         if file_name is not None and os.path.exists(log_folder):
-            message = "Creating log file. [File={0}]".format(file_path)
-            self.logger.log(message)
-            self.telemetry_writer.write_event(message, Constants.TelemetryEventLevel.Informational)
+            self.logger.log("Creating log file. [File={0}]".format(file_path))
             return FileLogger(log_folder, file_path)
         else:
-            error_msg = "File creation error: [File={0}]".format(file_path)
-            self.logger.log_error(error_msg)
-            self.telemetry_writer.write_event(error_msg, Constants.TelemetryEventLevel.Error)
+            self.logger.log_error("File creation error: [File={0}]".format(file_path))
             return None
 
     @staticmethod

--- a/src/extension/src/Utility.py
+++ b/src/extension/src/Utility.py
@@ -22,13 +22,16 @@ from extension.src.local_loggers.FileLogger import FileLogger
 
 
 class Utility(object):
-    def __init__(self, logger):
+    def __init__(self, logger, telemetry_writer):
         self.logger = logger
+        self.telemetry_writer = telemetry_writer
         self.retry_count = Constants.MAX_IO_RETRIES
 
     def delete_file(self, dir_path, file, raise_if_not_found=True):
         """ Retries delete operation for a set number of times before failing """
-        self.logger.log("Deleting file. [File={0}]".format(file))
+        message = "Deleting file. [File={0}]".format(file)
+        self.logger.log(message)
+        self.telemetry_writer.write_event(message, Constants.TelemetryEventLevel.Informational)
         file_path = os.path.join(dir_path, file)
         error_msg = ""
         if os.path.exists(file_path) and os.path.isfile(file_path):
@@ -40,12 +43,15 @@ class Utility(object):
                 except Exception as e:
                     error_msg = "Trial {0}: Could not delete file. [File={1}] [Exception={2}]".format(retry+1, file, repr(e))
                     self.logger.log_warning(error_msg)
+                    self.telemetry_writer.write_event(error_msg, Constants.TelemetryEventLevel.Warning)
 
             error_msg = "Failed to delete file after {0} tries. [File={1}] [Exception={2}]".format(self.retry_count, file, error_msg)
             self.logger.log_error(error_msg)
+            self.telemetry_writer.write_event(error_msg, Constants.TelemetryEventLevel.Error)
         else:
             error_msg = "File Not Found: [File={0}] in [path={1}]".format(file, dir_path)
             self.logger.log_error(error_msg)
+            self.telemetry_writer.write_event(error_msg, Constants.TelemetryEventLevel.Error)
         if raise_if_not_found:
             raise Exception(error_msg)
 
@@ -53,14 +59,21 @@ class Utility(object):
         """ Creates <file_name>.ext.log file under the path for logFolder provided in HandlerEnvironment """
         file_path = file_name + str(".ext") + Constants.LOG_FILE_EXTENSION
         if file_name is not None and os.path.exists(log_folder):
-            self.logger.log("Creating log file. [File={0}]".format(file_path))
+            message = "Creating log file. [File={0}]".format(file_path)
+            self.logger.log(message)
+            self.telemetry_writer.write_event(message, Constants.TelemetryEventLevel.Informational)
             return FileLogger(log_folder, file_path)
         else:
-            self.logger.log_error("File creation error: [File={0}]".format(file_path))
+            error_msg = "File creation error: [File={0}]".format(file_path)
+            self.logger.log_error(error_msg)
+            self.telemetry_writer.write_event(error_msg, Constants.TelemetryEventLevel.Error)
             return None
 
-    def get_datetime_from_str(self, date_str):
+    @staticmethod
+    def get_datetime_from_str(date_str):
         return datetime.datetime.strptime(date_str, Constants.UTC_DATETIME_FORMAT)
 
-    def get_str_from_datetime(self, date):
+    @staticmethod
+    def get_str_from_datetime(date):
         return date.strftime(Constants.UTC_DATETIME_FORMAT)
+

--- a/src/extension/src/__main__.py
+++ b/src/extension/src/__main__.py
@@ -42,9 +42,9 @@ def main(argv):
         # initializing action handler
         # args will have values install, uninstall, etc, as given in MsftLinuxPatchExtShim.sh in the operation var
         cmd_exec_start_time = datetime.datetime.utcnow()
-        utility = Utility(logger, telemetry_writer)
-        runtime_context_handler = RuntimeContextHandler(logger, telemetry_writer)
-        json_file_handler = JsonFileHandler(logger, telemetry_writer)
+        utility = Utility(logger)
+        runtime_context_handler = RuntimeContextHandler(logger)
+        json_file_handler = JsonFileHandler(logger)
         ext_env_handler = ExtEnvHandler(json_file_handler)
 
         if ext_env_handler.handler_environment_json is not None and ext_env_handler.config_folder is not None:
@@ -53,11 +53,11 @@ def main(argv):
                 logger.log_error("Config folder not found at [{0}].".format(repr(config_folder)))
                 exit(Constants.ExitCode.MissingConfig)
 
-            ext_config_settings_handler = ExtConfigSettingsHandler(logger, telemetry_writer, json_file_handler, config_folder)
+            ext_config_settings_handler = ExtConfigSettingsHandler(logger, json_file_handler, config_folder)
             core_state_handler = CoreStateHandler(config_folder, json_file_handler)
             ext_state_handler = ExtStateHandler(config_folder, utility, json_file_handler)
-            ext_output_status_handler = ExtOutputStatusHandler(logger, telemetry_writer, utility, json_file_handler, ext_env_handler.status_folder)
-            process_handler = ProcessHandler(logger, telemetry_writer, ext_output_status_handler)
+            ext_output_status_handler = ExtOutputStatusHandler(logger, utility, json_file_handler, ext_env_handler.status_folder)
+            process_handler = ProcessHandler(logger, ext_output_status_handler)
             action_handler = ActionHandler(logger, telemetry_writer, utility, runtime_context_handler, json_file_handler, ext_env_handler, ext_config_settings_handler, core_state_handler, ext_state_handler, ext_output_status_handler, process_handler, cmd_exec_start_time)
             action_handler.determine_operation(argv[1])
         else:

--- a/src/extension/src/__main__.py
+++ b/src/extension/src/__main__.py
@@ -46,7 +46,6 @@ def main(argv):
         runtime_context_handler = RuntimeContextHandler(logger)
         json_file_handler = JsonFileHandler(logger)
         ext_env_handler = ExtEnvHandler(json_file_handler)
-
         if ext_env_handler.handler_environment_json is not None and ext_env_handler.config_folder is not None:
             config_folder = ext_env_handler.config_folder
             if config_folder is None or not os.path.exists(config_folder):

--- a/src/extension/src/__main__.py
+++ b/src/extension/src/__main__.py
@@ -37,6 +37,7 @@ def main(argv):
     file_logger = None
     logger = Logger()
     telemetry_writer = TelemetryWriter(logger)
+    logger.telemetry_writer = telemetry_writer  # Need to set telemetry_writer within logger to enable sending all logs to telemetry
     try:
         # initializing action handler
         # args will have values install, uninstall, etc, as given in MsftLinuxPatchExtShim.sh in the operation var

--- a/src/extension/src/file_handlers/ExtConfigSettingsHandler.py
+++ b/src/extension/src/file_handlers/ExtConfigSettingsHandler.py
@@ -137,7 +137,6 @@ class ExtConfigSettingsHandler(object):
             else:
                 config_invalid_due_to = "no content found in the file" if config_settings_json is None else "settings not in expected format"
                 raise Exception("Config Settings json file invalid due to " + config_invalid_due_to)
-
         except Exception as error:
             error_msg = "Error processing config settings file. [Sequence Number={0}] [Exception= {1}]".format(seq_no, repr(error))
             self.logger.log_error(error_msg)

--- a/src/extension/src/file_handlers/ExtConfigSettingsHandler.py
+++ b/src/extension/src/file_handlers/ExtConfigSettingsHandler.py
@@ -23,9 +23,10 @@ from extension.src.Constants import Constants
 
 class ExtConfigSettingsHandler(object):
     """ Responsible for managing any operations with <Sequence Number>.settings file """
-    def __init__(self, logger, json_file_handler, config_folder):
+    def __init__(self, logger, telemetry_writer, json_file_handler, config_folder):
         self.config_folder = config_folder
         self.logger = logger
+        self.telemetry_writer = telemetry_writer
         self.json_file_handler = json_file_handler
         self.file_ext = Constants.CONFIG_SETTINGS_FILE_EXTENSION
         self.runtime_settings_key = Constants.RUNTIME_SETTINGS
@@ -41,43 +42,62 @@ class ExtConfigSettingsHandler(object):
 
             if seq_no is None:
                 if is_enable_request:
-                    self.logger.log_warning("Since sequence number is not provided in the environment variable, will try to fetch from the most recent settings file")
+                    seq_no_not_in_env_var = "Since sequence number is not provided in the environment variable, will try to fetch from the most recent settings file"
+                    self.logger.log_warning(seq_no_not_in_env_var)
+                    self.telemetry_writer.write_event(seq_no_not_in_env_var, Constants.TelemetryEventLevel.Warning)
                     # get seq no from settings file
                     return self.__get_seq_no_from_config_settings()
                 else:
-                    self.logger.log_error("Sequence number not provided.")
+                    seq_no_not_provided = "Sequence number not provided."
+                    self.logger.log_error(seq_no_not_provided)
+                    self.telemetry_writer.write_event(seq_no_not_provided, Constants.TelemetryEventLevel.Error)
                     return None
 
             # verify if config settings file exists for the seq_no
             if not self.__verify_config_settings_file_exists(seq_no):
-                self.logger.log_error("Could not verify sequence number found in environment variable with any configuration settings files on the machine")
+                invalid_seq = "Could not verify sequence number found in environment variable with any configuration settings files on the machine"
+                self.logger.log_error(invalid_seq)
+                self.telemetry_writer.write_event(invalid_seq, Constants.TelemetryEventLevel.Error)
                 return None
 
             return seq_no
 
         except Exception as error:
-            self.logger.log_error("Error occurred while fetching sequence number. [Exception={0}]".format(repr(error)))
+            error_msg = "Error occurred while fetching sequence number. [Exception={0}]".format(repr(error))
+            self.logger.log_error(error_msg)
+            self.telemetry_writer.write_event(error_msg, Constants.TelemetryEventLevel.Error)
             raise
 
     def __get_seq_no_from_env_var(self):
         """ Queries the environment variable to get seq_no and verifies if the corresponding <seq_no>.settings file exists """
-        self.logger.log("Fetching and validating sequence number from the environment variable")
+        validate_seq = "Fetching and validating sequence number from the environment variable"
+        self.logger.log(validate_seq)
+        self.telemetry_writer.write_event(validate_seq, Constants.TelemetryEventLevel.Informational)
+
         seq_no = os.getenv(Constants.SEQ_NO_ENVIRONMENT_VAR)
 
         if seq_no is None:
-            self.logger.log_warning("Sequence number not found in the environment variable.")
+            seq_not_found = "Sequence number not found in the environment variable."
+            self.logger.log_warning(seq_not_found)
+            self.telemetry_writer.write_event(seq_not_found, Constants.TelemetryEventLevel.Warning)
             return None
 
-        self.logger.log("Sequence number set in environment variable. [Sequence No={0}]".format(str(seq_no)))
+        seq_in_env_var = "Sequence number set in environment variable. [Sequence No={0}]".format(str(seq_no))
+        self.logger.log(seq_in_env_var)
+        self.telemetry_writer.write_event(seq_in_env_var, Constants.TelemetryEventLevel.Informational)
         return seq_no
 
     def __verify_config_settings_file_exists(self, seq_no):
         settings_file_path = os.path.join(self.config_folder, str(seq_no) + self.file_ext)
         if os.path.exists(settings_file_path) and os.path.isfile(settings_file_path):
-            self.logger.log("Configuration settings file exists for the current sequence number. [Sequence No={0}]".format(str(seq_no)))
+            config_exists_for_seq = "Configuration settings file exists for the current sequence number. [Sequence No={0}]".format(str(seq_no))
+            self.logger.log(config_exists_for_seq)
+            self.telemetry_writer.write_event(config_exists_for_seq, Constants.TelemetryEventLevel.Informational)
             return True
 
-        self.logger.log_error("Configuration settings file not found, for the current sequence number. [Sequence No={0}]".format(str(seq_no)))
+        config_not_found = "Configuration settings file not found, for the current sequence number. [Sequence No={0}]".format(str(seq_no))
+        self.logger.log_error(config_not_found)
+        self.telemetry_writer.write_event(config_not_found, Constants.TelemetryEventLevel.Error)
         return False
 
     def __get_seq_no_from_config_settings(self):
@@ -92,7 +112,11 @@ class ExtConfigSettingsHandler(object):
                     if re.match('^\d+' + self.file_ext + '$', file):
                         cur_seq_no = int(os.path.basename(file).split('.')[0])
                         file_modified_time = os.path.getmtime(os.path.join(self.config_folder, file))
-                        self.logger.log("Sequence number being considered and the corresponding file modified time. [Sequence No={0}] [Modified={1}]".format(str(cur_seq_no), str(file_modified_time)))
+
+                        seq_no_in_consideration = "Sequence number being considered and the corresponding file modified time. [Sequence No={0}] [Modified={1}]".format(str(cur_seq_no), str(file_modified_time))
+                        self.logger.log(seq_no_in_consideration)
+                        self.telemetry_writer.write_event(seq_no_in_consideration, Constants.TelemetryEventLevel.Informational)
+
                         if freshest_time is None:
                             freshest_time = file_modified_time
                             seq_no = cur_seq_no
@@ -104,16 +128,21 @@ class ExtConfigSettingsHandler(object):
                 except ValueError:
                     continue
         if seq_no is None:
-            self.logger.log("Could not find sequence number from the config folder")
+            seq_not_found_in_config = "Could not find sequence number from the config folder"
+            self.logger.log(seq_not_found_in_config)
+            self.telemetry_writer.write_event(seq_not_found_in_config, Constants.TelemetryEventLevel.Informational)
         else:
-            self.logger.log("Most recent sequence number found from config settings is [Sequence No={0}]".format(str(seq_no)))
+            seq_found_in_config = "Most recent sequence number found from config settings is [Sequence No={0}]".format(str(seq_no))
+            self.logger.log(seq_found_in_config)
+            self.telemetry_writer.write_event(seq_found_in_config, Constants.TelemetryEventLevel.Informational)
+
         return seq_no
 
     def read_file(self, seq_no):
         """ Fetches config from <seq_no>.settings file in <self.config_folder>. Raises an exception if no content/file found/errors processing file """
         try:
-            file = str(seq_no) + self.file_ext
-            config_settings_json = self.json_file_handler.get_json_file_content(file, self.config_folder, raise_if_not_found=True)
+            file_name = str(seq_no) + self.file_ext
+            config_settings_json = self.json_file_handler.get_json_file_content(file_name, self.config_folder, raise_if_not_found=True)
             if config_settings_json is not None and self.are_config_settings_valid(config_settings_json):
                 operation = self.get_ext_config_value_safely(config_settings_json, self.public_settings_all_keys.operation)
                 activity_id = self.get_ext_config_value_safely(config_settings_json, self.public_settings_all_keys.activity_id)
@@ -135,32 +164,45 @@ class ExtConfigSettingsHandler(object):
                                                                                     self.public_settings_all_keys.maintenance_run_id])
                 return config_settings_values(operation, activity_id, start_time, max_duration, reboot_setting, include_classifications, include_patches, exclude_patches, internal_settings, maintenance_run_id)
             else:
-                #ToDo log which of the 2 conditions failed, similar to this logs in other multiple condition checks
-                raise Exception("Config Settings json file invalid")
+                config_invalid_due_to = "no content found in the file" if config_settings_json is None else "settings not in expected format"
+                raise Exception("Config Settings json file invalid due to " + config_invalid_due_to)
+
         except Exception as error:
             error_msg = "Error processing config settings file. [Sequence Number={0}] [Exception= {1}]".format(seq_no, repr(error))
             self.logger.log_error(error_msg)
+            self.telemetry_writer.write_event(error_msg, Constants.TelemetryEventLevel.Error)
             raise
 
     def are_config_settings_valid(self, config_settings_json):
         """ Validates all the configs in <seq_no>.settings file. Raises an exception if any issues found """
         try:
             if config_settings_json is None or type(config_settings_json) is not dict or not bool(config_settings_json):
-                self.logger.log_error("Configuration settings not of expected format")
+                config_settings_error = "Configuration settings not of expected format"
+                self.logger.log_error(config_settings_error)
+                self.telemetry_writer.write_event(config_settings_error, Constants.TelemetryEventLevel.Error)
                 return False
+
             # file contains "runtimeSettings"
             if self.runtime_settings_key not in config_settings_json or type(config_settings_json[self.runtime_settings_key]) != list or config_settings_json[self.runtime_settings_key] is None or len(config_settings_json[self.runtime_settings_key]) == 0:
-                self.logger.log_error("runtimeSettings not of expected format")
+                runtime_settings_error = "runtimeSettings not of expected format"
+                self.logger.log_error(runtime_settings_error)
+                self.telemetry_writer.write_event(runtime_settings_error, Constants.TelemetryEventLevel.Error)
                 return False
+
             # file contains "handlerSettings"
             if self.handler_settings_key not in config_settings_json[self.runtime_settings_key][0] or type(config_settings_json[self.runtime_settings_key][0][self.handler_settings_key]) is not dict \
                     or config_settings_json[self.runtime_settings_key][0][self.handler_settings_key] is None or not bool(config_settings_json[self.runtime_settings_key][0][self.handler_settings_key]):
-                self.logger.log_error("handlerSettings not of expected format")
+                handler_settings_error = "handlerSettings not of expected format"
+                self.logger.log_error(handler_settings_error)
+                self.telemetry_writer.write_event(handler_settings_error, Constants.TelemetryEventLevel.Error)
                 return False
+
             # file contains "publicSettings"
             if self.public_settings_key not in config_settings_json[self.runtime_settings_key][0][self.handler_settings_key] or type(config_settings_json[self.runtime_settings_key][0][self.handler_settings_key][self.public_settings_key]) is not dict \
                     or config_settings_json[self.runtime_settings_key][0][self.handler_settings_key][self.public_settings_key] is None or not bool(config_settings_json[self.runtime_settings_key][0][self.handler_settings_key][self.public_settings_key]):
-                self.logger.log_error("publicSettings not of expected format")
+                public_settings_error = "publicSettings not of expected format"
+                self.logger.log_error(public_settings_error)
+                self.telemetry_writer.write_event(public_settings_error, Constants.TelemetryEventLevel.Error)
                 return False
 
             # verifying Configuration settings contain all the mandatory keys
@@ -168,7 +210,9 @@ class ExtConfigSettingsHandler(object):
                 if public_setting in config_settings_json[self.runtime_settings_key][0][self.handler_settings_key][self.public_settings_key] and config_settings_json[self.runtime_settings_key][0][self.handler_settings_key][self.public_settings_key][public_setting]:
                     continue
                 else:
-                    self.logger.log_error("Mandatory key missing in publicSettings section of the configuration settings: " + str(public_setting))
+                    key_missing_error = "Mandatory key missing in publicSettings section of the configuration settings: " + str(public_setting)
+                    self.logger.log_error(key_missing_error)
+                    self.telemetry_writer.write_event(key_missing_error, Constants.TelemetryEventLevel.Error)
                     return False
             return True
         except Exception as error:

--- a/src/extension/src/file_handlers/ExtOutputStatusHandler.py
+++ b/src/extension/src/file_handlers/ExtOutputStatusHandler.py
@@ -41,8 +41,9 @@ For the extension wrapper, the status structure is simply the following (no subs
 
 class ExtOutputStatusHandler(object):
     """ Responsible for managing <sequence number>.status file in the status folder path given in HandlerEnvironment.json """
-    def __init__(self, logger, utility, json_file_handler, dir_path):
+    def __init__(self, logger, telemetry_writer, utility, json_file_handler, dir_path):
         self.logger = logger
+        self.telemetry_writer = telemetry_writer
         self.utility = utility
         self.json_file_handler = json_file_handler
         self.__dir_path = dir_path
@@ -63,7 +64,10 @@ class ExtOutputStatusHandler(object):
         # self.read_file()
 
     def write_status_file(self, operation, seq_no, status=Constants.Status.Transitioning.lower()):
-        self.logger.log("Writing status file to provide patch management data for [Sequence={0}]".format(str(seq_no)))
+        write_status = "Writing status file to provide patch management data for [Sequence={0}]".format(str(seq_no))
+        self.logger.log(write_status)
+        self.telemetry_writer.write_event(write_status, Constants.TelemetryEventLevel.Informational)
+
         file_name = self.__get_status_file_name(seq_no)
         status_file_payload = self.__new_basic_status_json(operation, status)
 
@@ -122,25 +126,36 @@ class ExtOutputStatusHandler(object):
                 if parent_key in status_json[0]:
                     status_json[0].get(parent_key).update({key: value_to_update})
                 else:
-                    self.logger.log_error("Error updating config value in status file. [Config={0}]".format(key))
+                    error_msg = "Error updating config value in status file. [Config={0}]".format(key)
+                    self.logger.log_error(error_msg)
+                    self.telemetry_writer.write_event(error_msg, Constants.TelemetryEventLevel.Error)
 
     def update_file(self, seq_no, dir_path):
         """ Reseting status=Transitioning and code=0 with latest timestamp, while retaining all other values"""
         try:
             file_name = self.__get_status_file_name(seq_no)
-            self.logger.log("Updating file. [File={0}]".format(file_name))
+
+            update_file = "Updating file. [File={0}]".format(file_name)
+            self.logger.log(update_file)
+            self.telemetry_writer.write_event(update_file, Constants.TelemetryEventLevel.Informational)
+
             status_json = self.read_file(seq_no)
 
             if status_json is None:
-                self.logger.log_error("Error processing file. [File={0}]".format(file_name))
+                error_processing_file = "Error processing file. [File={0}]".format(file_name)
+                self.logger.log_error(error_processing_file)
+                self.telemetry_writer.write_event(error_processing_file, Constants.TelemetryEventLevel.Error)
                 return
+
             self.update_key_value_safely(status_json, self.file_keys.status_status, self.status.Transitioning.lower(), self.file_keys.status_status)
             self.update_key_value_safely(status_json, self.file_keys.status_code, 0, self.file_keys.status_status)
             self.update_key_value_safely(status_json, self.file_keys.timestamp_utc, str(datetime.datetime.utcnow().strftime(Constants.UTC_DATETIME_FORMAT)))
             self.json_file_handler.write_to_json_file(dir_path, file_name, status_json)
+
         except Exception as error:
             error_message = "Error in status file creation: " + repr(error)
             self.logger.log_error(error_message)
+            self.telemetry_writer.write_event(error_message, Constants.TelemetryEventLevel.Error)
             raise
 
     def __get_status_file_name(self, seq_no):
@@ -189,7 +204,9 @@ class ExtOutputStatusHandler(object):
         try:
             return int(re.search('(.+?) error/s reported.', error_message).group(1))
         except AttributeError:
-            self.logger.log("Unable to fetch error count from error message reported in status. Attempted to read [Message={0}]".format(error_message))
+            error_count_not_found = "Unable to fetch error count from error message reported in status. Attempted to read [Message={0}]".format(error_message)
+            self.logger.log(error_count_not_found)
+            self.telemetry_writer.write_event(error_count_not_found, Constants.TelemetryEventLevel.Informational)
             return 0
 
     def add_error_to_status(self, message, error_code=Constants.PatchOperationErrorCodes.DEFAULT_ERROR):
@@ -237,3 +254,4 @@ class ExtOutputStatusHandler(object):
             "message": message
         }
     # endregion
+

--- a/src/extension/src/file_handlers/JsonFileHandler.py
+++ b/src/extension/src/file_handlers/JsonFileHandler.py
@@ -22,15 +22,18 @@ from extension.src.Constants import Constants
 
 
 class JsonFileHandler(object):
-    def __init__(self, logger):
+    def __init__(self, logger, telemetry_writer):
         self.logger = logger
+        self.telemetry_writer = telemetry_writer
         self.retry_count = Constants.MAX_IO_RETRIES
 
-    def get_json_file_content(self, file, dir_path, raise_if_not_found=False):
+    def get_json_file_content(self, file_name, dir_path, raise_if_not_found=False):
         """ Returns content read from the given json file under the directory/path. Re-tries the operation a certain number of times and raises an exception if it still fails """
-        file_path = os.path.join(dir_path, file)
+        file_path = os.path.join(dir_path, file_name)
         error_msg = ""
-        self.logger.log("Reading file. [File={0}]".format(file))
+        reading_file_message = "Reading file. [File={0}]".format(file_name)
+        self.logger.log(reading_file_message)
+        self.telemetry_writer.write_event(reading_file_message, Constants.TelemetryEventLevel.Informational)
         for retry in range(0, self.retry_count):
             try:
                 time.sleep(retry)
@@ -38,20 +41,30 @@ class JsonFileHandler(object):
                     file_contents = file_handle.read()
                     return json.loads(file_contents)
             except ValueError as e:
-                error_msg = "Incorrect file format. [File={0}] [Location={1}] [Exception={2}]".format(file, str(file_path), repr(e))
+                error_msg = "Incorrect file format. [File={0}] [Location={1}] [Exception={2}]".format(file_name, str(file_path), repr(e))
                 self.logger.log_warning(error_msg)
+                self.telemetry_writer.write_event(error_msg, Constants.TelemetryEventLevel.Warning)
             except Exception as e:
-                error_msg = "Trial {0}: Could not read file. [File={1}] [Location={2}] [Exception={3}]".format(retry + 1, file, str(file_path), repr(e))
+                error_msg = "Trial {0}: Could not read file. [File={1}] [Location={2}] [Exception={3}]".format(retry + 1, file_name, str(file_path), repr(e))
                 self.logger.log_warning(error_msg)
+                self.telemetry_writer.write_event(error_msg, Constants.TelemetryEventLevel.Warning)
 
-        error_msg = "Failed to read file after {0} tries. [File={1}] [Location={2}] [Exception={3}]".format(self.retry_count, file, str(file_path), error_msg)
+        error_msg = "Failed to read file after {0} tries. [File={1}] [Location={2}] [Exception={3}]".format(self.retry_count, file_name, str(file_path), error_msg)
         self.logger.log_warning(error_msg)
-        if raise_if_not_found:
-            self.logger.log_error("Extension cannot continue without this file. [File={0}]".format(file))
-            raise Exception(error_msg)
-        self.logger.log("Extension can continue without the file. [File={0}]".format(file))
+        self.telemetry_writer.write_event(error_msg, Constants.TelemetryEventLevel.Warning)
 
-    def get_json_config_value_safely(self, handler_json, key, parent_key, raise_if_not_found=True):
+        if raise_if_not_found:
+            extension_error_msg = "Extension cannot continue without this file. [File={0}]".format(file_name)
+            self.logger.log_error(extension_error_msg)
+            self.telemetry_writer.write_event(extension_error_msg, Constants.TelemetryEventLevel.Warning)
+            raise Exception(error_msg)
+
+        extension_error_msg = "Extension can continue without the file. [File={0}]".format(file_name)
+        self.logger.log(extension_error_msg)
+        self.telemetry_writer.write_event(extension_error_msg, Constants.TelemetryEventLevel.Informational)
+
+    @staticmethod
+    def get_json_config_value_safely(handler_json, key, parent_key, raise_if_not_found=True):
         """ Allows a update deployment configuration value to be queried safely with a fall-back default (optional). An exception will be raised if default_value is not explicitly set when called (considered by-design). """
         if handler_json is not None and len(handler_json) != 0:
             if key in handler_json[parent_key]:
@@ -62,12 +75,12 @@ class JsonFileHandler(object):
                     raise Exception("Value not found for given config. [Config={0}]".format(key))
         return None
 
-    def write_to_json_file(self, dir_path, file, content):
+    def write_to_json_file(self, dir_path, file_name, content):
         """ Retries create operation for a set number of times before failing """
         if os.path.exists(dir_path):
-            file_path = os.path.join(dir_path, file)
+            file_path = os.path.join(dir_path, file_name)
             error_message = ""
-            self.logger.log("Writing file. [File={0}]".format(file))
+            self.logger.log("Writing file. [File={0}]".format(file_name))
             for retry in range(0, self.retry_count):
                 try:
                     time.sleep(retry)
@@ -75,14 +88,16 @@ class JsonFileHandler(object):
                         json.dump(content, json_file, default=self.json_default_converter)
                         return
                 except Exception as error:
-                    error_message = "Trial {0}: Could not write to file. [File={1}] [Location={2}] [Exception={3}]".format(retry+1, file, str(file_path), error)
+                    error_message = "Trial {0}: Could not write to file. [File={1}] [Location={2}] [Exception={3}]".format(retry+1, file_name, str(file_path), error)
                     self.logger.log_warning(error_message)
 
-            error_msg = "Failed to write to file after {0} tries. [File={1}] [Location={2}] [Exception={3}]".format(self.retry_count, file, str(file_path), error_message)
+            error_msg = "Failed to write to file after {0} tries. [File={1}] [Location={2}] [Exception={3}]".format(self.retry_count, file_name, str(file_path), error_message)
             self.logger.log_error_and_raise_new_exception(error_msg, Exception)
         else:
             error_msg = "Directory Not Found: [Directory={0}]".format(dir_path)
             self.logger.log_error_and_raise_new_exception(error_msg, Exception)
 
-    def json_default_converter(self, value):
+    @staticmethod
+    def json_default_converter(value):
         return value.__str__()
+

--- a/src/extension/src/local_loggers/Logger.py
+++ b/src/extension/src/local_loggers/Logger.py
@@ -20,7 +20,6 @@ from extension.src.Constants import Constants
 
 
 class Logger(object):
-    # def __init__(self, file_logger=None, current_env=None, telemetry_writer=None):
     def __init__(self, file_logger=None, current_env=None):
         self.file_logger = file_logger
         self.ERROR = "ERROR:"
@@ -31,16 +30,10 @@ class Logger(object):
         self.TELEMETRY_LOG = "TELEMETRY_LOG:"
         self.current_env = current_env
         self.NEWLINE_REPLACE_CHAR = " "
-        # self.telemetry_writer = telemetry_writer
-        # self.telemetry_task = "HandlerLog"
-        # self.telemetry_msg_truncated_note = " This message will be truncated in telemetry as it exceeds the size limit."
 
     def log(self, message):
         """log output"""
         message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
-        # if self.telemetry_writer is not None and self.telemetry_writer.events_folder_path is not None:
-        #     self.telemetry_writer.write_event(self.telemetry_task, message, Constants.TelemetryEventLevel.Informational)
-        #     message = self.__add_telemetry_error_note(message)
         for line in message.splitlines():  # allows the extended file logger to strip unnecessary white space
             if self.file_logger is not None:
                 self.file_logger.write("\n" + line)
@@ -51,9 +44,6 @@ class Logger(object):
         """log errors"""
         message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
         message = (self.NEWLINE_REPLACE_CHAR.join(message.split(os.linesep))).strip()
-        # if self.telemetry_writer is not None and self.telemetry_writer.events_folder_path is not None:
-        #     self.telemetry_writer.write_event(self.telemetry_task, message, Constants.TelemetryEventLevel.Error)
-        #     message = self.__add_telemetry_error_note(message)
         if self.file_logger is not None:
             self.file_logger.write("\n" + self.ERROR + " " + message)
         else:
@@ -69,9 +59,6 @@ class Logger(object):
         """log warning"""
         message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
         message = (self.NEWLINE_REPLACE_CHAR.join(message.split(os.linesep))).strip()
-        # if self.telemetry_writer is not None and self.telemetry_writer.events_folder_path is not None:
-        #     self.telemetry_writer.write_event(self.telemetry_task, message, Constants.TelemetryEventLevel.Warning)
-        #     message = self.__add_telemetry_error_note(message)
         if self.file_logger is not None:
             self.file_logger.write("\n" + self.WARNING + " " + message)
         else:
@@ -81,9 +68,6 @@ class Logger(object):
         """log debug"""
         message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
         message = message.strip()
-        # if self.telemetry_writer is not None and self.telemetry_writer.events_folder_path is not None:
-        #     self.telemetry_writer.write_event(self.telemetry_task, message, Constants.TelemetryEventLevel.Verbose)
-        #     message = self.__add_telemetry_error_note(message)
         if self.current_env in (Constants.DEV, Constants.TEST):
             print(self.current_env + ": " + message)  # send to standard output if dev or test env
         if self.file_logger is not None:
@@ -92,9 +76,6 @@ class Logger(object):
     def log_verbose(self, message):
         """log verbose"""
         message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
-        # if self.telemetry_writer is not None and self.telemetry_writer.events_folder_path is not None:
-        #     self.telemetry_writer.write_event(self.telemetry_task, message, Constants.TelemetryEventLevel.Verbose)
-        #     message = self.__add_telemetry_error_note(message)
         if self.file_logger is not None:
             self.file_logger.write("\n" + self.VERBOSE + " " + "\n\t".join(message.strip().splitlines()).strip())
 
@@ -122,10 +103,4 @@ class Logger(object):
         if substring in message:
             message = message.replace("[{0}]".format(Constants.ERROR_ADDED_TO_STATUS), "")
         return message
-
-    # def __add_telemetry_error_note(self, message):
-    #     """ Adding telemetry error messages to the original message, so as to log telemetry errors in other logs """
-    #     if len(message.encode('utf-8')) > Constants.TELEMETRY_MSG_SIZE_LIMIT_IN_BYTES:
-    #         message = message + self.telemetry_msg_truncated_note
-    #     return message
 

--- a/src/extension/src/local_loggers/Logger.py
+++ b/src/extension/src/local_loggers/Logger.py
@@ -20,24 +20,27 @@ from extension.src.Constants import Constants
 
 
 class Logger(object):
-    def __init__(self, file_logger=None, current_env=None, telemetry_writer=None):
+    # def __init__(self, file_logger=None, current_env=None, telemetry_writer=None):
+    def __init__(self, file_logger=None, current_env=None):
         self.file_logger = file_logger
         self.ERROR = "ERROR:"
         self.WARNING = "WARNING:"
         self.DEBUG = "DEBUG:"
         self.VERBOSE = "VERBOSE:"
+        self.TELEMETRY_ERROR = "TELEMETRY_ERROR:"
+        self.TELEMETRY_LOG = "TELEMETRY_LOG:"
         self.current_env = current_env
         self.NEWLINE_REPLACE_CHAR = " "
-        self.telemetry_writer = telemetry_writer
-        self.telemetry_task = "HandlerLog"
-        self.telemetry_msg_truncated_note = " This message will be truncated in telemetry as it exceeds the size limit."
+        # self.telemetry_writer = telemetry_writer
+        # self.telemetry_task = "HandlerLog"
+        # self.telemetry_msg_truncated_note = " This message will be truncated in telemetry as it exceeds the size limit."
 
     def log(self, message):
         """log output"""
         message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
-        if self.telemetry_writer is not None and self.telemetry_writer.events_folder_path is not None:
-            self.telemetry_writer.write_event(self.telemetry_task, message, Constants.TelemetryEventLevel.Informational)
-            message = self.__add_telemetry_error_note(message)
+        # if self.telemetry_writer is not None and self.telemetry_writer.events_folder_path is not None:
+        #     self.telemetry_writer.write_event(self.telemetry_task, message, Constants.TelemetryEventLevel.Informational)
+        #     message = self.__add_telemetry_error_note(message)
         for line in message.splitlines():  # allows the extended file logger to strip unnecessary white space
             if self.file_logger is not None:
                 self.file_logger.write("\n" + line)
@@ -48,9 +51,9 @@ class Logger(object):
         """log errors"""
         message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
         message = (self.NEWLINE_REPLACE_CHAR.join(message.split(os.linesep))).strip()
-        if self.telemetry_writer is not None and self.telemetry_writer.events_folder_path is not None:
-            self.telemetry_writer.write_event(self.telemetry_task, message, Constants.TelemetryEventLevel.Error)
-            message = self.__add_telemetry_error_note(message)
+        # if self.telemetry_writer is not None and self.telemetry_writer.events_folder_path is not None:
+        #     self.telemetry_writer.write_event(self.telemetry_task, message, Constants.TelemetryEventLevel.Error)
+        #     message = self.__add_telemetry_error_note(message)
         if self.file_logger is not None:
             self.file_logger.write("\n" + self.ERROR + " " + message)
         else:
@@ -66,9 +69,9 @@ class Logger(object):
         """log warning"""
         message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
         message = (self.NEWLINE_REPLACE_CHAR.join(message.split(os.linesep))).strip()
-        if self.telemetry_writer is not None and self.telemetry_writer.events_folder_path is not None:
-            self.telemetry_writer.write_event(self.telemetry_task, message, Constants.TelemetryEventLevel.Warning)
-            message = self.__add_telemetry_error_note(message)
+        # if self.telemetry_writer is not None and self.telemetry_writer.events_folder_path is not None:
+        #     self.telemetry_writer.write_event(self.telemetry_task, message, Constants.TelemetryEventLevel.Warning)
+        #     message = self.__add_telemetry_error_note(message)
         if self.file_logger is not None:
             self.file_logger.write("\n" + self.WARNING + " " + message)
         else:
@@ -78,9 +81,9 @@ class Logger(object):
         """log debug"""
         message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
         message = message.strip()
-        if self.telemetry_writer is not None and self.telemetry_writer.events_folder_path is not None:
-            self.telemetry_writer.write_event(self.telemetry_task, message, Constants.TelemetryEventLevel.Verbose)
-            message = self.__add_telemetry_error_note(message)
+        # if self.telemetry_writer is not None and self.telemetry_writer.events_folder_path is not None:
+        #     self.telemetry_writer.write_event(self.telemetry_task, message, Constants.TelemetryEventLevel.Verbose)
+        #     message = self.__add_telemetry_error_note(message)
         if self.current_env in (Constants.DEV, Constants.TEST):
             print(self.current_env + ": " + message)  # send to standard output if dev or test env
         if self.file_logger is not None:
@@ -89,11 +92,29 @@ class Logger(object):
     def log_verbose(self, message):
         """log verbose"""
         message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
-        if self.telemetry_writer is not None and self.telemetry_writer.events_folder_path is not None:
-            self.telemetry_writer.write_event(self.telemetry_task, message, Constants.TelemetryEventLevel.Verbose)
-            message = self.__add_telemetry_error_note(message)
+        # if self.telemetry_writer is not None and self.telemetry_writer.events_folder_path is not None:
+        #     self.telemetry_writer.write_event(self.telemetry_task, message, Constants.TelemetryEventLevel.Verbose)
+        #     message = self.__add_telemetry_error_note(message)
         if self.file_logger is not None:
             self.file_logger.write("\n" + self.VERBOSE + " " + "\n\t".join(message.strip().splitlines()).strip())
+
+    def log_telemetry_error(self, message):
+        """Log telemetry error"""
+        message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
+        message = (self.NEWLINE_REPLACE_CHAR.join(message.split(os.linesep))).strip()
+        if self.file_logger is not None:
+            self.file_logger.write("\n" + self.TELEMETRY_ERROR + " " + message)
+        else:
+            print(self.TELEMETRY_ERROR + " " + message)
+
+    def log_telemetry(self, message):
+        """Log telemetry"""
+        message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
+        message = (self.NEWLINE_REPLACE_CHAR.join(message.split(os.linesep))).strip()
+        if self.file_logger is not None:
+            self.file_logger.write("\n" + self.TELEMETRY_LOG + " " + message)
+        else:
+            print(self.TELEMETRY_LOG + " " + message)
 
     @staticmethod
     def __remove_substring_from_message(message, substring=Constants.ERROR_ADDED_TO_STATUS):
@@ -102,9 +123,9 @@ class Logger(object):
             message = message.replace("[{0}]".format(Constants.ERROR_ADDED_TO_STATUS), "")
         return message
 
-    def __add_telemetry_error_note(self, message):
-        """ Adding telemetry error messages to the original message, so as to log telemetry errors in other logs """
-        if len(message.encode('utf-8')) > Constants.TELEMETRY_MSG_SIZE_LIMIT_IN_BYTES:
-            message = message + self.telemetry_msg_truncated_note
-        return message
+    # def __add_telemetry_error_note(self, message):
+    #     """ Adding telemetry error messages to the original message, so as to log telemetry errors in other logs """
+    #     if len(message.encode('utf-8')) > Constants.TELEMETRY_MSG_SIZE_LIMIT_IN_BYTES:
+    #         message = message + self.telemetry_msg_truncated_note
+    #     return message
 

--- a/src/extension/tests/TestActionHandler.py
+++ b/src/extension/tests/TestActionHandler.py
@@ -35,14 +35,14 @@ class TestActionHandler(unittest.TestCase):
     def setUp(self):
         VirtualTerminal().print_lowlight("\n----------------- setup test runner -----------------")
         self.runtime = RuntimeComposer()
-        runtime_context_handler = RuntimeContextHandler(self.runtime.logger)
+        runtime_context_handler = RuntimeContextHandler(self.runtime.logger, self.runtime.telemetry_writer)
         ext_env_handler = ExtEnvHandler(self.runtime.json_file_handler, handler_env_file_path=os.path.join(os.path.pardir, "tests", "helpers"))
-        ext_config_settings_handler = ExtConfigSettingsHandler(self.runtime.logger, self.runtime.json_file_handler, ext_env_handler.config_folder)
+        ext_config_settings_handler = ExtConfigSettingsHandler(self.runtime.logger, self.runtime.telemetry_writer, self.runtime.json_file_handler, ext_env_handler.config_folder)
         core_state_handler = CoreStateHandler(ext_env_handler.config_folder, self.runtime.json_file_handler)
         ext_state_handler = ExtStateHandler(ext_env_handler.config_folder, self.runtime.utility, self.runtime.json_file_handler)
-        ext_output_status_handler = ExtOutputStatusHandler(self.runtime.logger, self.runtime.utility, self.runtime.json_file_handler, ext_env_handler.status_folder)
-        process_handler = ProcessHandler(self.runtime.logger, ext_output_status_handler)
-        self.action_handler = ActionHandler(self.runtime.logger, self.runtime.utility, runtime_context_handler, self.runtime.json_file_handler, ext_env_handler,
+        ext_output_status_handler = ExtOutputStatusHandler(self.runtime.logger, self.runtime.telemetry_writer, self.runtime.utility, self.runtime.json_file_handler, ext_env_handler.status_folder)
+        process_handler = ProcessHandler(self.runtime.logger, self.runtime.telemetry_writer, ext_output_status_handler)
+        self.action_handler = ActionHandler(self.runtime.logger, self.runtime.telemetry_writer, self.runtime.utility, runtime_context_handler, self.runtime.json_file_handler, ext_env_handler,
                                             ext_config_settings_handler, core_state_handler, ext_state_handler, ext_output_status_handler, process_handler, "2020-09-02T13:40:54.8862542Z")
 
     def tearDown(self):
@@ -95,7 +95,7 @@ class TestActionHandler(unittest.TestCase):
         self.assertTrue(os.path.exists(os.path.join(new_version_config_folder, 'backup.bak')))
         self.assertFalse(os.path.exists(os.path.join(new_version_config_folder, 'test.txt')))
         self.action_handler.ext_env_handler.events_folder = events_folder_path_backup
-        self.runtime.logger.telemetry_writer.events_folder_path = None
+        self.runtime.telemetry_writer.events_folder_path = None
         # Remove the directory after the test
         shutil.rmtree(test_dir)
 
@@ -115,7 +115,7 @@ class TestActionHandler(unittest.TestCase):
         self.assertTrue(os.path.exists(os.path.join(new_version_config_folder, 'backup.bak')))
         self.assertFalse(os.path.exists(os.path.join(new_version_config_folder, 'test.txt')))
         self.action_handler.ext_env_handler.events_folder = events_folder_path_backup
-        self.runtime.logger.telemetry_writer.events_folder_path = None
+        self.runtime.telemetry_writer.events_folder_path = None
         # Remove the directory after the test
         shutil.rmtree(test_dir)
 
@@ -135,7 +135,7 @@ class TestActionHandler(unittest.TestCase):
         self.assertTrue(os.path.exists(os.path.join(new_version_config_folder, 'backup.bak')))
         self.assertFalse(os.path.exists(os.path.join(new_version_config_folder, 'test.txt')))
         self.action_handler.ext_env_handler.events_folder = events_folder_path_backup
-        self.runtime.logger.telemetry_writer.events_folder_path = None
+        self.runtime.telemetry_writer.events_folder_path = None
         # Remove the directory after the test
         shutil.rmtree(test_dir)
 
@@ -155,7 +155,7 @@ class TestActionHandler(unittest.TestCase):
         self.assertTrue(os.path.exists(os.path.join(new_version_config_folder, 'backup.bak')))
         self.assertFalse(os.path.exists(os.path.join(new_version_config_folder, 'test.txt')))
         self.action_handler.ext_env_handler.events_folder = events_folder_path_backup
-        self.runtime.logger.telemetry_writer.events_folder_path = None
+        self.runtime.telemetry_writer.events_folder_path = None
         # Remove the directory after the test
         shutil.rmtree(test_dir)
 
@@ -167,7 +167,7 @@ class TestActionHandler(unittest.TestCase):
         self.action_handler.ext_env_handler.config_folder = '/test/config'
         self.assertTrue(self.action_handler.update() == Constants.ExitCode.HandlerFailed)
         self.action_handler.ext_env_handler.events_folder = events_folder_path_backup
-        self.runtime.logger.telemetry_writer.events_folder_path = None
+        self.runtime.telemetry_writer.events_folder_path = None
         # Remove the directory after the test
         shutil.rmtree(test_dir)
 
@@ -183,7 +183,7 @@ class TestActionHandler(unittest.TestCase):
         self.action_handler.ext_env_handler.events_folder = test_dir
         self.assertTrue(self.action_handler.update() == Constants.ExitCode.HandlerFailed)
         self.action_handler.ext_env_handler.events_folder = events_folder_path_backup
-        self.runtime.logger.telemetry_writer.events_folder_path = None
+        self.runtime.telemetry_writer.events_folder_path = None
         # Remove the directory after the test
         shutil.rmtree(test_dir)
 
@@ -198,7 +198,7 @@ class TestActionHandler(unittest.TestCase):
         self.action_handler.ext_env_handler.events_folder = test_dir
         self.assertTrue(self.action_handler.update() == Constants.ExitCode.HandlerFailed)
         self.action_handler.ext_env_handler.events_folder = events_folder_path_backup
-        self.runtime.logger.telemetry_writer.events_folder_path = None
+        self.runtime.telemetry_writer.events_folder_path = None
         # Remove the directory after the test
         shutil.rmtree(test_dir)
 

--- a/src/extension/tests/TestActionHandler.py
+++ b/src/extension/tests/TestActionHandler.py
@@ -36,13 +36,13 @@ class TestActionHandler(unittest.TestCase):
     def setUp(self):
         VirtualTerminal().print_lowlight("\n----------------- setup test runner -----------------")
         self.runtime = RuntimeComposer()
-        runtime_context_handler = RuntimeContextHandler(self.runtime.logger, self.runtime.telemetry_writer)
+        runtime_context_handler = RuntimeContextHandler(self.runtime.logger)
         ext_env_handler = ExtEnvHandler(self.runtime.json_file_handler, handler_env_file_path=os.path.join(os.path.pardir, "tests", "helpers"))
-        ext_config_settings_handler = ExtConfigSettingsHandler(self.runtime.logger, self.runtime.telemetry_writer, self.runtime.json_file_handler, ext_env_handler.config_folder)
+        ext_config_settings_handler = ExtConfigSettingsHandler(self.runtime.logger, self.runtime.json_file_handler, ext_env_handler.config_folder)
         core_state_handler = CoreStateHandler(ext_env_handler.config_folder, self.runtime.json_file_handler)
         ext_state_handler = ExtStateHandler(ext_env_handler.config_folder, self.runtime.utility, self.runtime.json_file_handler)
-        ext_output_status_handler = ExtOutputStatusHandler(self.runtime.logger, self.runtime.telemetry_writer, self.runtime.utility, self.runtime.json_file_handler, ext_env_handler.status_folder)
-        process_handler = ProcessHandler(self.runtime.logger, self.runtime.telemetry_writer, ext_output_status_handler)
+        ext_output_status_handler = ExtOutputStatusHandler(self.runtime.logger, self.runtime.utility, self.runtime.json_file_handler, ext_env_handler.status_folder)
+        process_handler = ProcessHandler(self.runtime.logger, ext_output_status_handler)
         self.action_handler = ActionHandler(self.runtime.logger, self.runtime.telemetry_writer, self.runtime.utility, runtime_context_handler, self.runtime.json_file_handler, ext_env_handler,
                                             ext_config_settings_handler, core_state_handler, ext_state_handler, ext_output_status_handler, process_handler, "2020-09-02T13:40:54.8862542Z")
 

--- a/src/extension/tests/TestActionHandler.py
+++ b/src/extension/tests/TestActionHandler.py
@@ -235,7 +235,7 @@ class TestActionHandler(unittest.TestCase):
         for event_file in event_files:
             with open(os.path.join(self.action_handler.telemetry_writer.events_folder_path, event_file), 'r+') as f:
                 events = json.load(f)
-                self.assertEquals(events[0]["OperationId"], self.action_handler.timestamp_for_telemetry)
+                self.assertEquals(events[0]["OperationId"], self.action_handler.operation_id_substitute_for_all_actions_in_telemetry)
 
         # Remove the directory after the test
         shutil.rmtree(test_dir)

--- a/src/extension/tests/TestEnableCommandHandler.py
+++ b/src/extension/tests/TestEnableCommandHandler.py
@@ -42,17 +42,18 @@ class TestEnableCommandHandler(unittest.TestCase):
         self.temp_dir = tempfile.mkdtemp()
         runtime = RuntimeComposer()
         self.logger = runtime.logger
+        self.telemetry_writer = runtime.telemetry_writer
         self.utility = runtime.utility
         self.json_file_handler = runtime.json_file_handler
-        self.runtime_context_handler = RuntimeContextHandler(self.logger)
+        self.runtime_context_handler = RuntimeContextHandler(self.logger, self.telemetry_writer)
         self.ext_env_handler = ExtEnvHandler(self.json_file_handler, handler_env_file_path=os.path.join(os.path.pardir, "tests", "helpers"))
         self.config_folder = self.ext_env_handler.config_folder
-        self.ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.json_file_handler, self.config_folder)
+        self.ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.telemetry_writer, self.json_file_handler, self.config_folder)
         self.core_state_handler = CoreStateHandler(self.config_folder, self.json_file_handler)
         self.ext_state_handler = ExtStateHandler(self.config_folder, self.utility, self.json_file_handler)
-        self.ext_output_status_handler = ExtOutputStatusHandler(self.logger, self.utility, self.json_file_handler, self.temp_dir)
-        self.process_handler = ProcessHandler(self.logger, self.ext_output_status_handler)
-        self.enable_command_handler = EnableCommandHandler(self.logger, self.utility, self.runtime_context_handler, self.ext_env_handler, self.ext_config_settings_handler, self.core_state_handler, self.ext_state_handler, self.ext_output_status_handler, self.process_handler, datetime.utcnow())
+        self.ext_output_status_handler = ExtOutputStatusHandler(self.logger, self.telemetry_writer, self.utility, self.json_file_handler, self.temp_dir)
+        self.process_handler = ProcessHandler(self.logger, self.telemetry_writer, self.ext_output_status_handler)
+        self.enable_command_handler = EnableCommandHandler(self.logger, self.telemetry_writer, self.utility, self.runtime_context_handler, self.ext_env_handler, self.ext_config_settings_handler, self.core_state_handler, self.ext_state_handler, self.ext_output_status_handler, self.process_handler, datetime.utcnow())
         self.constants = Constants
         self.start_daemon_backup = ProcessHandler.start_daemon
         ProcessHandler.start_daemon = self.mock_start_daemon_to_return_true
@@ -105,7 +106,7 @@ class TestEnableCommandHandler(unittest.TestCase):
         new_settings_file = self.create_helpers_for_enable_request(config_folder_path)
 
         prev_ext_state_json = self.json_file_handler.get_json_file_content(self.constants.EXT_STATE_FILE, config_folder_path)
-        enable_command_handler = EnableCommandHandler(self.logger, self.utility, self.runtime_context_handler, self.ext_env_handler, self.ext_config_settings_handler, self.core_state_handler, self.ext_state_handler, self.ext_output_status_handler, self.process_handler, datetime.utcnow())
+        enable_command_handler = EnableCommandHandler(self.logger, self.telemetry_writer, self.utility, self.runtime_context_handler, self.ext_env_handler, self.ext_config_settings_handler, self.core_state_handler, self.ext_state_handler, self.ext_output_status_handler, self.process_handler, datetime.utcnow())
         with self.assertRaises(SystemExit) as sys_exit:
             enable_command_handler.execute_handler_action()
 
@@ -130,7 +131,7 @@ class TestEnableCommandHandler(unittest.TestCase):
             f.close()
 
         prev_ext_state_json = self.json_file_handler.get_json_file_content(self.constants.EXT_STATE_FILE, config_folder_path)
-        enable_command_handler = EnableCommandHandler(self.logger, self.utility, self.runtime_context_handler, self.ext_env_handler, self.ext_config_settings_handler, self.core_state_handler, self.ext_state_handler, self.ext_output_status_handler, self.process_handler, datetime.utcnow())
+        enable_command_handler = EnableCommandHandler(self.logger, self.telemetry_writer, self.utility, self.runtime_context_handler, self.ext_env_handler, self.ext_config_settings_handler, self.core_state_handler, self.ext_state_handler, self.ext_output_status_handler, self.process_handler, datetime.utcnow())
         with self.assertRaises(SystemExit) as sys_exit:
             enable_command_handler.execute_handler_action()
         self.assertEqual(sys_exit.exception.code, Constants.ExitCode.Okay)
@@ -153,7 +154,7 @@ class TestEnableCommandHandler(unittest.TestCase):
             json.dump(config_settings, f)
             f.truncate()
             f.close()
-        enable_command_handler = EnableCommandHandler(self.logger, self.utility, self.runtime_context_handler, self.ext_env_handler, self.ext_config_settings_handler, self.core_state_handler, self.ext_state_handler, self.ext_output_status_handler, self.process_handler, datetime.utcnow())
+        enable_command_handler = EnableCommandHandler(self.logger, self.telemetry_writer, self.utility, self.runtime_context_handler, self.ext_env_handler, self.ext_config_settings_handler, self.core_state_handler, self.ext_state_handler, self.ext_output_status_handler, self.process_handler, datetime.utcnow())
         with self.assertRaises(SystemExit) as sys_exit:
             enable_command_handler.execute_handler_action()
         self.assertEqual(sys_exit.exception.code, Constants.ExitCode.Okay)
@@ -171,7 +172,7 @@ class TestEnableCommandHandler(unittest.TestCase):
             json.dump(config_settings, f)
             f.truncate()
             f.close()
-        enable_command_handler = EnableCommandHandler(self.logger, self.utility, self.runtime_context_handler, self.ext_env_handler, self.ext_config_settings_handler, self.core_state_handler, self.ext_state_handler, self.ext_output_status_handler, self.process_handler, datetime.utcnow())
+        enable_command_handler = EnableCommandHandler(self.logger, self.telemetry_writer, self.utility, self.runtime_context_handler, self.ext_env_handler, self.ext_config_settings_handler, self.core_state_handler, self.ext_state_handler, self.ext_output_status_handler, self.process_handler, datetime.utcnow())
         with self.assertRaises(SystemExit) as sys_exit:
             enable_command_handler.execute_handler_action()
         self.assertEqual(sys_exit.exception.code, Constants.ExitCode.InvalidConfigSettingPropertyValue)
@@ -260,7 +261,7 @@ class TestEnableCommandHandler(unittest.TestCase):
             events_folder_complete_path = os.path.join(dir_path, events_folder)
             os.mkdir(events_folder_complete_path)
             self.ext_env_handler.events_folder = events_folder_complete_path
-            self.logger.telemetry_writer.events_folder_path = events_folder_complete_path
+            self.telemetry_writer.events_folder_path = events_folder_complete_path
 
         self.ext_config_settings_handler.config_folder = config_folder_complete_path
         self.core_state_handler.dir_path = config_folder_complete_path

--- a/src/extension/tests/TestEnableCommandHandler.py
+++ b/src/extension/tests/TestEnableCommandHandler.py
@@ -43,16 +43,17 @@ class TestEnableCommandHandler(unittest.TestCase):
         runtime = RuntimeComposer()
         self.logger = runtime.logger
         self.telemetry_writer = runtime.telemetry_writer
+        self.logger.telemetry_writer = self.telemetry_writer
         self.utility = runtime.utility
         self.json_file_handler = runtime.json_file_handler
-        self.runtime_context_handler = RuntimeContextHandler(self.logger, self.telemetry_writer)
+        self.runtime_context_handler = RuntimeContextHandler(self.logger)
         self.ext_env_handler = ExtEnvHandler(self.json_file_handler, handler_env_file_path=os.path.join(os.path.pardir, "tests", "helpers"))
         self.config_folder = self.ext_env_handler.config_folder
-        self.ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.telemetry_writer, self.json_file_handler, self.config_folder)
+        self.ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.json_file_handler, self.config_folder)
         self.core_state_handler = CoreStateHandler(self.config_folder, self.json_file_handler)
         self.ext_state_handler = ExtStateHandler(self.config_folder, self.utility, self.json_file_handler)
-        self.ext_output_status_handler = ExtOutputStatusHandler(self.logger, self.telemetry_writer, self.utility, self.json_file_handler, self.temp_dir)
-        self.process_handler = ProcessHandler(self.logger, self.telemetry_writer, self.ext_output_status_handler)
+        self.ext_output_status_handler = ExtOutputStatusHandler(self.logger, self.utility, self.json_file_handler, self.temp_dir)
+        self.process_handler = ProcessHandler(self.logger, self.ext_output_status_handler)
         self.enable_command_handler = EnableCommandHandler(self.logger, self.telemetry_writer, self.utility, self.runtime_context_handler, self.ext_env_handler, self.ext_config_settings_handler, self.core_state_handler, self.ext_state_handler, self.ext_output_status_handler, self.process_handler, datetime.utcnow())
         self.constants = Constants
         self.start_daemon_backup = ProcessHandler.start_daemon

--- a/src/extension/tests/TestExtConfigSettingsHandler.py
+++ b/src/extension/tests/TestExtConfigSettingsHandler.py
@@ -34,6 +34,7 @@ class TestExtConfigSettingsHandler(unittest.TestCase):
         self.runtime = RuntimeComposer()
         self.logger = self.runtime.logger
         self.telemetry_writer = self.runtime.telemetry_writer
+        self.logger.telemetry_writer = self.telemetry_writer
         self.json_file_handler = self.runtime.json_file_handler
         self.config_public_settings_fields = Constants.ConfigPublicSettingsFields
 
@@ -49,7 +50,7 @@ class TestExtConfigSettingsHandler(unittest.TestCase):
         os.getenv = self.mock_getenv
 
         self.runtime.create_temp_file(test_dir, "1234.settings", content=None)
-        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.telemetry_writer, self.json_file_handler, test_dir)
+        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.json_file_handler, test_dir)
         seq_no = ext_config_settings_handler.get_seq_no(is_enable_request=True)
         self.assertTrue(seq_no is not None)
         self.assertEqual(seq_no, 1234)
@@ -63,7 +64,7 @@ class TestExtConfigSettingsHandler(unittest.TestCase):
         os.getenv = self.mock_getenv
 
         self.runtime.create_temp_file(test_dir, "1234.settings", content=None)
-        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.telemetry_writer, self.json_file_handler, test_dir)
+        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.json_file_handler, test_dir)
         seq_no = ext_config_settings_handler.get_seq_no(is_enable_request=False)
         self.assertTrue(seq_no is not None)
         self.assertEqual(seq_no, 1234)
@@ -75,7 +76,7 @@ class TestExtConfigSettingsHandler(unittest.TestCase):
         # not set in env var
         test_dir = tempfile.mkdtemp()
         self.runtime.create_temp_file(test_dir, "1234.settings", content=None)
-        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.telemetry_writer, self.json_file_handler, test_dir)
+        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.json_file_handler, test_dir)
         seq_no = ext_config_settings_handler.get_seq_no(is_enable_request=False)
         self.assertTrue(seq_no is None)
         shutil.rmtree(test_dir)
@@ -84,7 +85,7 @@ class TestExtConfigSettingsHandler(unittest.TestCase):
         test_dir = tempfile.mkdtemp()
         os_getenv_backup = os.getenv
         os.getenv = self.mock_getenv
-        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.telemetry_writer, self.json_file_handler, test_dir)
+        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.json_file_handler, test_dir)
         seq_no = ext_config_settings_handler.get_seq_no(is_enable_request=False)
         self.assertTrue(seq_no is None)
         os.getenv = os_getenv_backup
@@ -95,7 +96,7 @@ class TestExtConfigSettingsHandler(unittest.TestCase):
         test_dir = tempfile.mkdtemp()
         os_getenv_backup = os.getenv
         os.getenv = self.mock_getenv
-        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.telemetry_writer, self.json_file_handler, test_dir)
+        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.json_file_handler, test_dir)
         seq_no = ext_config_settings_handler.get_seq_no(is_enable_request=True)
         self.assertTrue(seq_no is None)
         os.getenv = os_getenv_backup
@@ -104,7 +105,7 @@ class TestExtConfigSettingsHandler(unittest.TestCase):
         # not set in env var, seq_no fetched from config settings file
         test_dir = tempfile.mkdtemp()
         self.runtime.create_temp_file(test_dir, "1234.settings", content=None)
-        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.telemetry_writer, self.json_file_handler, test_dir)
+        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.json_file_handler, test_dir)
         seq_no = ext_config_settings_handler.get_seq_no(is_enable_request=True)
         self.assertTrue(seq_no is not None)
         self.assertEqual(seq_no, 1234)
@@ -140,20 +141,20 @@ class TestExtConfigSettingsHandler(unittest.TestCase):
                 timestamp = time.mktime(datetime.strptime(file["lastModified"], Constants.UTC_DATETIME_FORMAT).timetuple())
                 os.utime(file_path, (timestamp, timestamp))
                 f.close()
-        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.telemetry_writer, self.json_file_handler, test_dir)
+        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.json_file_handler, test_dir)
         seq_no = ext_config_settings_handler.get_seq_no(is_enable_request=True)
         self.assertEqual(122, seq_no)
         shutil.rmtree(test_dir)
 
     def test_seq_no_from_empty_config_folder(self):
         test_dir = tempfile.mkdtemp()
-        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.telemetry_writer, self.json_file_handler, test_dir)
+        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.json_file_handler, test_dir)
         seq_no = ext_config_settings_handler.get_seq_no(is_enable_request=True)
         self.assertEqual(None, seq_no)
         shutil.rmtree(test_dir)
 
     def test_are_config_settings_valid(self):
-        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.telemetry_writer, self.json_file_handler, "mockConfig")
+        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.json_file_handler, "mockConfig")
 
         runtime_settings_key = Constants.RUNTIME_SETTINGS
         handler_settings_key = Constants.HANDLER_SETTINGS
@@ -252,14 +253,14 @@ class TestExtConfigSettingsHandler(unittest.TestCase):
         self.assertTrue(ext_config_settings_handler.are_config_settings_valid(config_settings_json))
 
     def test_read_file_success(self):
-        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.telemetry_writer, self.json_file_handler, os.path.join(os.path.pardir, "tests", "helpers"))
+        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.json_file_handler, os.path.join(os.path.pardir, "tests", "helpers"))
         seq_no = "1234"
         config_values = ext_config_settings_handler.read_file(seq_no)
         self.assertEqual(config_values.__getattribute__(self.config_public_settings_fields.operation), "Installation")
         self.assertEqual(config_values.__getattribute__(self.config_public_settings_fields.reboot_setting), "IfRequired")
 
     def test_read_file_failures(self):
-        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.telemetry_writer, self.json_file_handler, os.path.join(os.path.pardir, "tests", "helpers"))
+        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.json_file_handler, os.path.join(os.path.pardir, "tests", "helpers"))
         # Seq_no invalid, none, -1, empty
         seq_no = None
         self.assertRaises(Exception, ext_config_settings_handler.read_file, seq_no)
@@ -276,7 +277,7 @@ class TestExtConfigSettingsHandler(unittest.TestCase):
         test_dir = tempfile.mkdtemp()
         file_name = "123.settings"
         self.runtime.create_temp_file(test_dir, file_name, content=None)
-        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.telemetry_writer, self.json_file_handler, test_dir)
+        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.json_file_handler, test_dir)
         seq_no = "123"
         self.assertRaises(Exception, ext_config_settings_handler.read_file, seq_no)
         shutil.rmtree(test_dir)
@@ -285,7 +286,7 @@ class TestExtConfigSettingsHandler(unittest.TestCase):
         test_dir = tempfile.mkdtemp()
         file_name = "1237.settings"
         self.runtime.create_temp_file(test_dir, file_name, content="{}")
-        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.telemetry_writer, self.json_file_handler, test_dir)
+        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.json_file_handler, test_dir)
         seq_no = "1237"
         self.assertRaises(Exception, ext_config_settings_handler.read_file, seq_no)
         shutil.rmtree(test_dir)
@@ -295,12 +296,12 @@ class TestExtConfigSettingsHandler(unittest.TestCase):
         seq_no = "1237"
         file_name = seq_no + ".settings"
         self.runtime.create_temp_file(test_dir, file_name, content='{"runtimeSettings": []}')
-        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.telemetry_writer, self.json_file_handler, test_dir)
+        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.json_file_handler, test_dir)
         self.assertRaises(Exception, ext_config_settings_handler.read_file, seq_no)
         shutil.rmtree(test_dir)
 
     def test_read_all_config_settings_from_file(self):
-        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.telemetry_writer, self.json_file_handler, os.path.join(os.path.pardir, "tests", "helpers"))
+        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.json_file_handler, os.path.join(os.path.pardir, "tests", "helpers"))
         seq_no = ext_config_settings_handler.get_seq_no(is_enable_request=True)
         config_settings = ext_config_settings_handler.read_file(seq_no)
 
@@ -348,7 +349,7 @@ class TestExtConfigSettingsHandler(unittest.TestCase):
 
         # verify patchRolloutId is read successfully if maintenanceRunId is not available
         # todo: remove this test and patch_rollout_id_bak_compat_test.settings file, once patch rollout id is removed
-        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.telemetry_writer, self.json_file_handler, os.path.join(os.path.pardir, "tests", "helpers"))
+        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.json_file_handler, os.path.join(os.path.pardir, "tests", "helpers"))
         config_settings = ext_config_settings_handler.read_file("patch_rollout_id_bak_compat_test")
         self.assertNotEqual(config_settings.__getattribute__(self.config_public_settings_fields.maintenance_run_id), None)
         self.assertEqual(config_settings.__getattribute__(self.config_public_settings_fields.maintenance_run_id), "2019-07-22T12:12:14Z")

--- a/src/extension/tests/TestExtConfigSettingsHandler.py
+++ b/src/extension/tests/TestExtConfigSettingsHandler.py
@@ -33,6 +33,7 @@ class TestExtConfigSettingsHandler(unittest.TestCase):
         VirtualTerminal().print_lowlight("\n----------------- setup test runner -----------------")
         self.runtime = RuntimeComposer()
         self.logger = self.runtime.logger
+        self.telemetry_writer = self.runtime.telemetry_writer
         self.json_file_handler = self.runtime.json_file_handler
         self.config_public_settings_fields = Constants.ConfigPublicSettingsFields
 
@@ -48,7 +49,7 @@ class TestExtConfigSettingsHandler(unittest.TestCase):
         os.getenv = self.mock_getenv
 
         self.runtime.create_temp_file(test_dir, "1234.settings", content=None)
-        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.json_file_handler, test_dir)
+        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.telemetry_writer, self.json_file_handler, test_dir)
         seq_no = ext_config_settings_handler.get_seq_no(is_enable_request=True)
         self.assertTrue(seq_no is not None)
         self.assertEqual(seq_no, 1234)
@@ -62,7 +63,7 @@ class TestExtConfigSettingsHandler(unittest.TestCase):
         os.getenv = self.mock_getenv
 
         self.runtime.create_temp_file(test_dir, "1234.settings", content=None)
-        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.json_file_handler, test_dir)
+        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.telemetry_writer, self.json_file_handler, test_dir)
         seq_no = ext_config_settings_handler.get_seq_no(is_enable_request=False)
         self.assertTrue(seq_no is not None)
         self.assertEqual(seq_no, 1234)
@@ -74,7 +75,7 @@ class TestExtConfigSettingsHandler(unittest.TestCase):
         # not set in env var
         test_dir = tempfile.mkdtemp()
         self.runtime.create_temp_file(test_dir, "1234.settings", content=None)
-        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.json_file_handler, test_dir)
+        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.telemetry_writer, self.json_file_handler, test_dir)
         seq_no = ext_config_settings_handler.get_seq_no(is_enable_request=False)
         self.assertTrue(seq_no is None)
         shutil.rmtree(test_dir)
@@ -83,7 +84,7 @@ class TestExtConfigSettingsHandler(unittest.TestCase):
         test_dir = tempfile.mkdtemp()
         os_getenv_backup = os.getenv
         os.getenv = self.mock_getenv
-        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.json_file_handler, test_dir)
+        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.telemetry_writer, self.json_file_handler, test_dir)
         seq_no = ext_config_settings_handler.get_seq_no(is_enable_request=False)
         self.assertTrue(seq_no is None)
         os.getenv = os_getenv_backup
@@ -94,7 +95,7 @@ class TestExtConfigSettingsHandler(unittest.TestCase):
         test_dir = tempfile.mkdtemp()
         os_getenv_backup = os.getenv
         os.getenv = self.mock_getenv
-        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.json_file_handler, test_dir)
+        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.telemetry_writer, self.json_file_handler, test_dir)
         seq_no = ext_config_settings_handler.get_seq_no(is_enable_request=True)
         self.assertTrue(seq_no is None)
         os.getenv = os_getenv_backup
@@ -103,7 +104,7 @@ class TestExtConfigSettingsHandler(unittest.TestCase):
         # not set in env var, seq_no fetched from config settings file
         test_dir = tempfile.mkdtemp()
         self.runtime.create_temp_file(test_dir, "1234.settings", content=None)
-        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.json_file_handler, test_dir)
+        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.telemetry_writer, self.json_file_handler, test_dir)
         seq_no = ext_config_settings_handler.get_seq_no(is_enable_request=True)
         self.assertTrue(seq_no is not None)
         self.assertEqual(seq_no, 1234)
@@ -139,20 +140,20 @@ class TestExtConfigSettingsHandler(unittest.TestCase):
                 timestamp = time.mktime(datetime.strptime(file["lastModified"], Constants.UTC_DATETIME_FORMAT).timetuple())
                 os.utime(file_path, (timestamp, timestamp))
                 f.close()
-        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.json_file_handler, test_dir)
+        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.telemetry_writer, self.json_file_handler, test_dir)
         seq_no = ext_config_settings_handler.get_seq_no(is_enable_request=True)
         self.assertEqual(122, seq_no)
         shutil.rmtree(test_dir)
 
     def test_seq_no_from_empty_config_folder(self):
         test_dir = tempfile.mkdtemp()
-        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.json_file_handler, test_dir)
+        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.telemetry_writer, self.json_file_handler, test_dir)
         seq_no = ext_config_settings_handler.get_seq_no(is_enable_request=True)
         self.assertEqual(None, seq_no)
         shutil.rmtree(test_dir)
 
     def test_are_config_settings_valid(self):
-        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.json_file_handler, "mockConfig")
+        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.telemetry_writer, self.json_file_handler, "mockConfig")
 
         runtime_settings_key = Constants.RUNTIME_SETTINGS
         handler_settings_key = Constants.HANDLER_SETTINGS
@@ -251,14 +252,14 @@ class TestExtConfigSettingsHandler(unittest.TestCase):
         self.assertTrue(ext_config_settings_handler.are_config_settings_valid(config_settings_json))
 
     def test_read_file_success(self):
-        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.json_file_handler, os.path.join(os.path.pardir, "tests", "helpers"))
+        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.telemetry_writer, self.json_file_handler, os.path.join(os.path.pardir, "tests", "helpers"))
         seq_no = "1234"
         config_values = ext_config_settings_handler.read_file(seq_no)
         self.assertEqual(config_values.__getattribute__(self.config_public_settings_fields.operation), "Installation")
         self.assertEqual(config_values.__getattribute__(self.config_public_settings_fields.reboot_setting), "IfRequired")
 
     def test_read_file_failures(self):
-        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.json_file_handler, os.path.join(os.path.pardir, "tests", "helpers"))
+        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.telemetry_writer, self.json_file_handler, os.path.join(os.path.pardir, "tests", "helpers"))
         # Seq_no invalid, none, -1, empty
         seq_no = None
         self.assertRaises(Exception, ext_config_settings_handler.read_file, seq_no)
@@ -275,7 +276,7 @@ class TestExtConfigSettingsHandler(unittest.TestCase):
         test_dir = tempfile.mkdtemp()
         file_name = "123.settings"
         self.runtime.create_temp_file(test_dir, file_name, content=None)
-        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.json_file_handler, test_dir)
+        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.telemetry_writer, self.json_file_handler, test_dir)
         seq_no = "123"
         self.assertRaises(Exception, ext_config_settings_handler.read_file, seq_no)
         shutil.rmtree(test_dir)
@@ -284,7 +285,7 @@ class TestExtConfigSettingsHandler(unittest.TestCase):
         test_dir = tempfile.mkdtemp()
         file_name = "1237.settings"
         self.runtime.create_temp_file(test_dir, file_name, content="{}")
-        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.json_file_handler, test_dir)
+        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.telemetry_writer, self.json_file_handler, test_dir)
         seq_no = "1237"
         self.assertRaises(Exception, ext_config_settings_handler.read_file, seq_no)
         shutil.rmtree(test_dir)
@@ -294,12 +295,12 @@ class TestExtConfigSettingsHandler(unittest.TestCase):
         seq_no = "1237"
         file_name = seq_no + ".settings"
         self.runtime.create_temp_file(test_dir, file_name, content='{"runtimeSettings": []}')
-        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.json_file_handler, test_dir)
+        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.telemetry_writer, self.json_file_handler, test_dir)
         self.assertRaises(Exception, ext_config_settings_handler.read_file, seq_no)
         shutil.rmtree(test_dir)
 
     def test_read_all_config_settings_from_file(self):
-        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.json_file_handler, os.path.join(os.path.pardir, "tests", "helpers"))
+        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.telemetry_writer, self.json_file_handler, os.path.join(os.path.pardir, "tests", "helpers"))
         seq_no = ext_config_settings_handler.get_seq_no(is_enable_request=True)
         config_settings = ext_config_settings_handler.read_file(seq_no)
 
@@ -347,7 +348,7 @@ class TestExtConfigSettingsHandler(unittest.TestCase):
 
         # verify patchRolloutId is read successfully if maintenanceRunId is not available
         # todo: remove this test and patch_rollout_id_bak_compat_test.settings file, once patch rollout id is removed
-        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.json_file_handler, os.path.join(os.path.pardir, "tests", "helpers"))
+        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.telemetry_writer, self.json_file_handler, os.path.join(os.path.pardir, "tests", "helpers"))
         config_settings = ext_config_settings_handler.read_file("patch_rollout_id_bak_compat_test")
         self.assertNotEqual(config_settings.__getattribute__(self.config_public_settings_fields.maintenance_run_id), None)
         self.assertEqual(config_settings.__getattribute__(self.config_public_settings_fields.maintenance_run_id), "2019-07-22T12:12:14Z")

--- a/src/extension/tests/TestExtOutputStatusHandler.py
+++ b/src/extension/tests/TestExtOutputStatusHandler.py
@@ -31,6 +31,7 @@ class TestExtOutputStatusHandler(unittest.TestCase):
         VirtualTerminal().print_lowlight("\n----------------- setup test runner -----------------")
         self.runtime = RuntimeComposer()
         self.logger = self.runtime.logger
+        self.telemetry_writer = self.runtime.telemetry_writer
         self.utility = self.runtime.utility
         self.json_file_handler = self.runtime.json_file_handler
         self.status_file_fields = Constants.StatusFileFields
@@ -43,7 +44,7 @@ class TestExtOutputStatusHandler(unittest.TestCase):
         file_name = "test"
         dir_path = tempfile.mkdtemp()
         operation = "Assessment"
-        ext_status_handler = ExtOutputStatusHandler(self.logger, self.utility, self.json_file_handler, dir_path)
+        ext_status_handler = ExtOutputStatusHandler(self.logger, self.telemetry_writer, self.utility, self.json_file_handler, dir_path)
         ext_status_handler.write_status_file(operation, file_name, self.status.Transitioning.lower())
 
         with open(dir_path + "\\" + file_name + ext_status_handler.file_ext) as status_file:
@@ -60,7 +61,7 @@ class TestExtOutputStatusHandler(unittest.TestCase):
         dir_path = tempfile.mkdtemp()
         operation = "Assessment"
 
-        ext_output_status_handler = ExtOutputStatusHandler(self.logger, self.utility, self.json_file_handler, dir_path)
+        ext_output_status_handler = ExtOutputStatusHandler(self.logger, self.telemetry_writer, self.utility, self.json_file_handler, dir_path)
         ext_output_status_handler.write_status_file(operation, file_name, self.status.Transitioning.lower())
         status_json = ext_output_status_handler.read_file(file_name)
         parent_key = self.status_file_fields.status
@@ -74,7 +75,7 @@ class TestExtOutputStatusHandler(unittest.TestCase):
         dir_path = tempfile.mkdtemp()
         operation = "Assessment"
 
-        ext_status_handler = ExtOutputStatusHandler(self.logger, self.utility, self.json_file_handler, dir_path)
+        ext_status_handler = ExtOutputStatusHandler(self.logger, self.telemetry_writer, self.utility, self.json_file_handler, dir_path)
         ext_status_handler.write_status_file(operation, file_name, self.status.Success.lower())
         stat_file_name = os.stat(os.path.join(dir_path, file_name + ".status"))
         prev_modified_time = stat_file_name.st_mtime
@@ -95,7 +96,7 @@ class TestExtOutputStatusHandler(unittest.TestCase):
     def test_add_error_to_status(self):
         file_name = "test"
         dir_path = tempfile.mkdtemp()
-        ext_output_status_handler = ExtOutputStatusHandler(self.logger, self.utility, self.json_file_handler, dir_path)
+        ext_output_status_handler = ExtOutputStatusHandler(self.logger, self.telemetry_writer, self.utility, self.json_file_handler, dir_path)
         ext_output_status_handler.set_current_operation(Constants.NOOPERATION)
         self.logger.file_logger = FileLogger(dir_path, "test.log")
         ext_output_status_handler.read_file(file_name)

--- a/src/extension/tests/TestExtOutputStatusHandler.py
+++ b/src/extension/tests/TestExtOutputStatusHandler.py
@@ -32,6 +32,7 @@ class TestExtOutputStatusHandler(unittest.TestCase):
         self.runtime = RuntimeComposer()
         self.logger = self.runtime.logger
         self.telemetry_writer = self.runtime.telemetry_writer
+        self.logger.telemetry_writer = self.telemetry_writer
         self.utility = self.runtime.utility
         self.json_file_handler = self.runtime.json_file_handler
         self.status_file_fields = Constants.StatusFileFields
@@ -44,7 +45,7 @@ class TestExtOutputStatusHandler(unittest.TestCase):
         file_name = "test"
         dir_path = tempfile.mkdtemp()
         operation = "Assessment"
-        ext_status_handler = ExtOutputStatusHandler(self.logger, self.telemetry_writer, self.utility, self.json_file_handler, dir_path)
+        ext_status_handler = ExtOutputStatusHandler(self.logger, self.utility, self.json_file_handler, dir_path)
         ext_status_handler.write_status_file(operation, file_name, self.status.Transitioning.lower())
 
         with open(dir_path + "\\" + file_name + ext_status_handler.file_ext) as status_file:
@@ -61,7 +62,7 @@ class TestExtOutputStatusHandler(unittest.TestCase):
         dir_path = tempfile.mkdtemp()
         operation = "Assessment"
 
-        ext_output_status_handler = ExtOutputStatusHandler(self.logger, self.telemetry_writer, self.utility, self.json_file_handler, dir_path)
+        ext_output_status_handler = ExtOutputStatusHandler(self.logger, self.utility, self.json_file_handler, dir_path)
         ext_output_status_handler.write_status_file(operation, file_name, self.status.Transitioning.lower())
         status_json = ext_output_status_handler.read_file(file_name)
         parent_key = self.status_file_fields.status
@@ -75,7 +76,7 @@ class TestExtOutputStatusHandler(unittest.TestCase):
         dir_path = tempfile.mkdtemp()
         operation = "Assessment"
 
-        ext_status_handler = ExtOutputStatusHandler(self.logger, self.telemetry_writer, self.utility, self.json_file_handler, dir_path)
+        ext_status_handler = ExtOutputStatusHandler(self.logger, self.utility, self.json_file_handler, dir_path)
         ext_status_handler.write_status_file(operation, file_name, self.status.Success.lower())
         stat_file_name = os.stat(os.path.join(dir_path, file_name + ".status"))
         prev_modified_time = stat_file_name.st_mtime
@@ -96,7 +97,7 @@ class TestExtOutputStatusHandler(unittest.TestCase):
     def test_add_error_to_status(self):
         file_name = "test"
         dir_path = tempfile.mkdtemp()
-        ext_output_status_handler = ExtOutputStatusHandler(self.logger, self.telemetry_writer, self.utility, self.json_file_handler, dir_path)
+        ext_output_status_handler = ExtOutputStatusHandler(self.logger, self.utility, self.json_file_handler, dir_path)
         ext_output_status_handler.set_current_operation(Constants.NOOPERATION)
         self.logger.file_logger = FileLogger(dir_path, "test.log")
         ext_output_status_handler.read_file(file_name)

--- a/src/extension/tests/TestInstallCommandHandler.py
+++ b/src/extension/tests/TestInstallCommandHandler.py
@@ -31,6 +31,7 @@ class TestInstallCommandHandler(unittest.TestCase):
         runtime = RuntimeComposer()
         self.logger = runtime.logger
         self.telemetry_writer = runtime.telemetry_writer
+        self.logger.telemetry_writer = self.telemetry_writer
         self.json_file_handler = runtime.json_file_handler
         self.get_json_file_content_backup = self.json_file_handler.get_json_file_content
         self.json_file_handler.get_json_file_content = self.mock_get_json_file_content_to_return_none
@@ -45,13 +46,13 @@ class TestInstallCommandHandler(unittest.TestCase):
 
     def test_validate_os_type_is_linux(self):
         ext_env_handler = ExtEnvHandler(self.json_file_handler)
-        install_command_handler = InstallCommandHandler(self.logger, self.telemetry_writer, ext_env_handler)
+        install_command_handler = InstallCommandHandler(self.logger, ext_env_handler)
         sys.platform = 'linux'
         self.assertTrue(install_command_handler.validate_os_type())
 
     def test_validate_os_type_not_linux(self):
         ext_env_handler = ExtEnvHandler(self.json_file_handler)
-        install_command_handler = InstallCommandHandler(self.logger, self.telemetry_writer, ext_env_handler)
+        install_command_handler = InstallCommandHandler(self.logger, ext_env_handler)
         sys.platform = 'win32'
         self.assertRaises(Exception, install_command_handler.validate_os_type)
 
@@ -60,14 +61,14 @@ class TestInstallCommandHandler(unittest.TestCase):
 
         # file has no content
         ext_env_handler = ExtEnvHandler(self.json_file_handler)
-        install_command_handler = InstallCommandHandler(self.logger, self.telemetry_writer, ext_env_handler)
+        install_command_handler = InstallCommandHandler(self.logger, ext_env_handler)
         self.assertRaises(Exception, install_command_handler.validate_environment)
 
         # Validating datatype for fields in HandlerEnvironment
         handler_environment = []
         handler_environment_dict = {}
         handler_environment.append(handler_environment_dict)
-        install_command_handler = InstallCommandHandler(self.logger, self.telemetry_writer, handler_environment)
+        install_command_handler = InstallCommandHandler(self.logger, handler_environment)
         self.verify_key(handler_environment[0], 'version', 1.0, 'abc', True, Exception, install_command_handler.validate_environment)
         self.verify_key(handler_environment[0], 'version', 1.0, '', True, Exception, install_command_handler.validate_environment)
         self.verify_key(handler_environment[0], 'handlerEnvironment', {}, 'abc', True, Exception, install_command_handler.validate_environment)
@@ -79,7 +80,7 @@ class TestInstallCommandHandler(unittest.TestCase):
         # reseting mock to original func def
         self.json_file_handler.get_json_file_content = self.get_json_file_content_backup
         ext_env_handler = ExtEnvHandler(self.json_file_handler, handler_env_file_path=os.path.join(os.path.pardir, "tests", "helpers"))
-        install_command_handler = InstallCommandHandler(self.logger, self.telemetry_writer, ext_env_handler)
+        install_command_handler = InstallCommandHandler(self.logger, ext_env_handler)
         install_command_handler.validate_environment()
 
     def verify_key(self, config_type, key, expected_value, incorrect_value, is_required, exception_type, function_name):
@@ -98,7 +99,7 @@ class TestInstallCommandHandler(unittest.TestCase):
         # reseting mock to original func def
         self.json_file_handler.get_json_file_content = self.get_json_file_content_backup
         ext_env_handler = ExtEnvHandler(self.json_file_handler, handler_env_file_path=os.path.join(os.path.pardir, "tests", "helpers"))
-        install_command_handler = InstallCommandHandler(self.logger, self.telemetry_writer, ext_env_handler)
+        install_command_handler = InstallCommandHandler(self.logger, ext_env_handler)
         self.assertEqual(install_command_handler.execute_handler_action(), Constants.ExitCode.Okay)
 
 

--- a/src/extension/tests/TestProcessHandler.py
+++ b/src/extension/tests/TestProcessHandler.py
@@ -33,11 +33,12 @@ class TestProcessHandler(unittest.TestCase):
         runtime = RuntimeComposer()
         self.logger = runtime.logger
         self.telemetry_writer = runtime.telemetry_writer
+        self.logger.telemetry_writer = self.telemetry_writer
         self.utility = runtime.utility
         self.json_file_handler = runtime.json_file_handler
         seq_no = 1234
         dir_path = os.path.join(os.path.pardir, "tests", "helpers")
-        self.ext_output_status_handler = ExtOutputStatusHandler(self.logger, self.telemetry_writer, self.utility, self.json_file_handler, dir_path)
+        self.ext_output_status_handler = ExtOutputStatusHandler(self.logger, self.utility, self.json_file_handler, dir_path)
         self.process = subprocess.Popen(["echo", "Hello World!"], shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     def tearDown(self):
@@ -84,10 +85,10 @@ class TestProcessHandler(unittest.TestCase):
         return 0
 
     def test_get_public_config_settings(self):
-        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.telemetry_writer, self.json_file_handler, os.path.join(os.path.pardir, "tests", "helpers"))
+        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.json_file_handler, os.path.join(os.path.pardir, "tests", "helpers"))
         seq_no = "1234"
         config_settings = ext_config_settings_handler.read_file(seq_no)
-        process_handler = ProcessHandler(self.logger, self.telemetry_writer, self.ext_output_status_handler)
+        process_handler = ProcessHandler(self.logger, self.ext_output_status_handler)
         public_config_settings = process_handler.get_public_config_settings(config_settings)
         self.assertTrue(public_config_settings is not None)
         self.assertEqual(public_config_settings.get(Constants.ConfigPublicSettingsFields.operation), "Installation")
@@ -96,7 +97,7 @@ class TestProcessHandler(unittest.TestCase):
     def test_get_env_settings(self):
         handler_env_file_path = os.path.join(os.path.pardir, "tests", "helpers")
         ext_env_handler = ExtEnvHandler(self.json_file_handler, handler_env_file_path=handler_env_file_path)
-        process_handler = ProcessHandler(self.logger, self.telemetry_writer, self.ext_output_status_handler)
+        process_handler = ProcessHandler(self.logger, self.ext_output_status_handler)
         env_settings = process_handler.get_env_settings(ext_env_handler)
         self.assertTrue(env_settings is not None)
         self.assertEqual(env_settings.get(Constants.EnvSettingsFields.log_folder), "mockLog")
@@ -110,7 +111,7 @@ class TestProcessHandler(unittest.TestCase):
 
         # error in terminating process
         pid = 123
-        process_handler = ProcessHandler(self.logger, self.telemetry_writer, self.ext_output_status_handler)
+        process_handler = ProcessHandler(self.logger, self.ext_output_status_handler)
         self.assertRaises(OSError, process_handler.kill_process, pid)
 
         # reseting mocks
@@ -120,7 +121,7 @@ class TestProcessHandler(unittest.TestCase):
     def test_get_python_cmd(self):
         # setting mocks
         run_command_output_backup = ProcessHandler.run_command_output
-        process_handler = ProcessHandler(self.logger, self.telemetry_writer, self.ext_output_status_handler)
+        process_handler = ProcessHandler(self.logger, self.ext_output_status_handler)
 
         # testing for 'python' command
         ProcessHandler.run_command_output = self.mock_run_command_output_for_python
@@ -144,7 +145,7 @@ class TestProcessHandler(unittest.TestCase):
         subprocess_popen_backup = subprocess.Popen
 
         # Initializing config env
-        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.telemetry_writer, self.json_file_handler, os.path.join(os.path.pardir, "tests", "helpers"))
+        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.json_file_handler, os.path.join(os.path.pardir, "tests", "helpers"))
         seq_no = "1234"
         config_settings = ext_config_settings_handler.read_file(seq_no)
         handler_env_file_path = os.path.join(os.path.pardir, "tests", "helpers")
@@ -152,19 +153,19 @@ class TestProcessHandler(unittest.TestCase):
 
         # process was not launched
         subprocess.Popen = self.mock_subprocess_popen_process_not_launched
-        process_handler = ProcessHandler(self.logger, self.telemetry_writer, self.ext_output_status_handler)
+        process_handler = ProcessHandler(self.logger, self.ext_output_status_handler)
         process = process_handler.start_daemon(seq_no, config_settings, ext_env_handler)
         self.assertTrue(process is None)
 
         # process launched with no issues
         subprocess.Popen = self.mock_subprocess_popen_process_launched_with_no_issues
-        process_handler = ProcessHandler(self.logger, self.telemetry_writer, self.ext_output_status_handler)
+        process_handler = ProcessHandler(self.logger, self.ext_output_status_handler)
         process = process_handler.start_daemon(seq_no, config_settings, ext_env_handler)
         self.assertTrue(process is not None)
 
         # process launched but is not running soon after
         subprocess.Popen = self.mock_subprocess_popen_process_not_running_after_launch
-        process_handler = ProcessHandler(self.logger, self.telemetry_writer, self.ext_output_status_handler)
+        process_handler = ProcessHandler(self.logger, self.ext_output_status_handler)
         process = process_handler.start_daemon(seq_no, config_settings, ext_env_handler)
         self.assertTrue(process is None)
 

--- a/src/extension/tests/TestProcessHandler.py
+++ b/src/extension/tests/TestProcessHandler.py
@@ -32,11 +32,12 @@ class TestProcessHandler(unittest.TestCase):
         VirtualTerminal().print_lowlight("\n----------------- setup test runner -----------------")
         runtime = RuntimeComposer()
         self.logger = runtime.logger
+        self.telemetry_writer = runtime.telemetry_writer
         self.utility = runtime.utility
         self.json_file_handler = runtime.json_file_handler
         seq_no = 1234
         dir_path = os.path.join(os.path.pardir, "tests", "helpers")
-        self.ext_output_status_handler = ExtOutputStatusHandler(self.logger, self.utility, self.json_file_handler, dir_path)
+        self.ext_output_status_handler = ExtOutputStatusHandler(self.logger, self.telemetry_writer, self.utility, self.json_file_handler, dir_path)
         self.process = subprocess.Popen(["echo", "Hello World!"], shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     def tearDown(self):
@@ -83,10 +84,10 @@ class TestProcessHandler(unittest.TestCase):
         return 0
 
     def test_get_public_config_settings(self):
-        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.json_file_handler, os.path.join(os.path.pardir, "tests", "helpers"))
+        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.telemetry_writer, self.json_file_handler, os.path.join(os.path.pardir, "tests", "helpers"))
         seq_no = "1234"
         config_settings = ext_config_settings_handler.read_file(seq_no)
-        process_handler = ProcessHandler(self.logger, self.ext_output_status_handler)
+        process_handler = ProcessHandler(self.logger, self.telemetry_writer, self.ext_output_status_handler)
         public_config_settings = process_handler.get_public_config_settings(config_settings)
         self.assertTrue(public_config_settings is not None)
         self.assertEqual(public_config_settings.get(Constants.ConfigPublicSettingsFields.operation), "Installation")
@@ -95,7 +96,7 @@ class TestProcessHandler(unittest.TestCase):
     def test_get_env_settings(self):
         handler_env_file_path = os.path.join(os.path.pardir, "tests", "helpers")
         ext_env_handler = ExtEnvHandler(self.json_file_handler, handler_env_file_path=handler_env_file_path)
-        process_handler = ProcessHandler(self.logger, self.ext_output_status_handler)
+        process_handler = ProcessHandler(self.logger, self.telemetry_writer, self.ext_output_status_handler)
         env_settings = process_handler.get_env_settings(ext_env_handler)
         self.assertTrue(env_settings is not None)
         self.assertEqual(env_settings.get(Constants.EnvSettingsFields.log_folder), "mockLog")
@@ -109,7 +110,7 @@ class TestProcessHandler(unittest.TestCase):
 
         # error in terminating process
         pid = 123
-        process_handler = ProcessHandler(self.logger, self.ext_output_status_handler)
+        process_handler = ProcessHandler(self.logger, self.telemetry_writer, self.ext_output_status_handler)
         self.assertRaises(OSError, process_handler.kill_process, pid)
 
         # reseting mocks
@@ -119,7 +120,7 @@ class TestProcessHandler(unittest.TestCase):
     def test_get_python_cmd(self):
         # setting mocks
         run_command_output_backup = ProcessHandler.run_command_output
-        process_handler = ProcessHandler(self.logger, self.ext_output_status_handler)
+        process_handler = ProcessHandler(self.logger, self.telemetry_writer, self.ext_output_status_handler)
 
         # testing for 'python' command
         ProcessHandler.run_command_output = self.mock_run_command_output_for_python
@@ -143,7 +144,7 @@ class TestProcessHandler(unittest.TestCase):
         subprocess_popen_backup = subprocess.Popen
 
         # Initializing config env
-        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.json_file_handler, os.path.join(os.path.pardir, "tests", "helpers"))
+        ext_config_settings_handler = ExtConfigSettingsHandler(self.logger, self.telemetry_writer, self.json_file_handler, os.path.join(os.path.pardir, "tests", "helpers"))
         seq_no = "1234"
         config_settings = ext_config_settings_handler.read_file(seq_no)
         handler_env_file_path = os.path.join(os.path.pardir, "tests", "helpers")
@@ -151,19 +152,19 @@ class TestProcessHandler(unittest.TestCase):
 
         # process was not launched
         subprocess.Popen = self.mock_subprocess_popen_process_not_launched
-        process_handler = ProcessHandler(self.logger, self.ext_output_status_handler)
+        process_handler = ProcessHandler(self.logger, self.telemetry_writer, self.ext_output_status_handler)
         process = process_handler.start_daemon(seq_no, config_settings, ext_env_handler)
         self.assertTrue(process is None)
 
         # process launched with no issues
         subprocess.Popen = self.mock_subprocess_popen_process_launched_with_no_issues
-        process_handler = ProcessHandler(self.logger, self.ext_output_status_handler)
+        process_handler = ProcessHandler(self.logger, self.telemetry_writer, self.ext_output_status_handler)
         process = process_handler.start_daemon(seq_no, config_settings, ext_env_handler)
         self.assertTrue(process is not None)
 
         # process launched but is not running soon after
         subprocess.Popen = self.mock_subprocess_popen_process_not_running_after_launch
-        process_handler = ProcessHandler(self.logger, self.ext_output_status_handler)
+        process_handler = ProcessHandler(self.logger, self.telemetry_writer, self.ext_output_status_handler)
         process = process_handler.start_daemon(seq_no, config_settings, ext_env_handler)
         self.assertTrue(process is None)
 

--- a/src/extension/tests/TestRuntimeContextHandler.py
+++ b/src/extension/tests/TestRuntimeContextHandler.py
@@ -30,9 +30,8 @@ class TestRuntimeContextHandler(unittest.TestCase):
     def setUp(self):
         VirtualTerminal().print_lowlight("\n----------------- setup test runner -----------------")
         runtime = RuntimeComposer()
-        self.logger = runtime.logger
         self.json_file_handler = runtime.json_file_handler
-        self.runtime_context_handler = RuntimeContextHandler(self.logger)
+        self.runtime_context_handler = RuntimeContextHandler(runtime.logger, runtime.telemetry_writer)
         self.core_state_fields = Constants.CoreStateFields
 
     def tearDown(self):

--- a/src/extension/tests/TestRuntimeContextHandler.py
+++ b/src/extension/tests/TestRuntimeContextHandler.py
@@ -31,7 +31,7 @@ class TestRuntimeContextHandler(unittest.TestCase):
         VirtualTerminal().print_lowlight("\n----------------- setup test runner -----------------")
         runtime = RuntimeComposer()
         self.json_file_handler = runtime.json_file_handler
-        self.runtime_context_handler = RuntimeContextHandler(runtime.logger, runtime.telemetry_writer)
+        self.runtime_context_handler = RuntimeContextHandler(runtime.logger)
         self.core_state_fields = Constants.CoreStateFields
 
     def tearDown(self):

--- a/src/extension/tests/TestTelemetryWriter.py
+++ b/src/extension/tests/TestTelemetryWriter.py
@@ -43,6 +43,11 @@ class TestTelemetryWriter(unittest.TestCase):
             f.close()
 
         self.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task2")
+        with open(os.path.join(self.telemetry_writer.events_folder_path, os.listdir(self.telemetry_writer.events_folder_path)[1]), 'r+') as f:
+            events = json.load(f)
+            self.assertTrue(events is not None)
+            self.assertEquals(events[0]["TaskName"], "Test Task2")
+            f.close()
 
     def test_write_multiple_events_in_same_file(self):
         time_backup = time.time

--- a/src/extension/tests/helpers/RuntimeComposer.py
+++ b/src/extension/tests/helpers/RuntimeComposer.py
@@ -10,8 +10,8 @@ class RuntimeComposer(object):
     def __init__(self):
         self.logger = Logger()
         self.telemetry_writer = TelemetryWriter(self.logger)
-        self.utility = Utility(self.logger, self.telemetry_writer)
-        self.json_file_handler = JsonFileHandler(self.logger, self.telemetry_writer)
+        self.utility = Utility(self.logger)
+        self.json_file_handler = JsonFileHandler(self.logger)
         time.sleep = self.mock_sleep
 
     def mock_sleep(self, seconds):

--- a/src/extension/tests/helpers/RuntimeComposer.py
+++ b/src/extension/tests/helpers/RuntimeComposer.py
@@ -9,10 +9,9 @@ from extension.src.local_loggers.Logger import Logger
 class RuntimeComposer(object):
     def __init__(self):
         self.logger = Logger()
-        telemetry_writer = TelemetryWriter()
-        self.logger = Logger(telemetry_writer=telemetry_writer)
-        self.utility = Utility(self.logger)
-        self.json_file_handler = JsonFileHandler(self.logger)
+        self.telemetry_writer = TelemetryWriter(self.logger)
+        self.utility = Utility(self.logger, self.telemetry_writer)
+        self.json_file_handler = JsonFileHandler(self.logger, self.telemetry_writer)
         time.sleep = self.mock_sleep
 
     def mock_sleep(self, seconds):


### PR DESCRIPTION
Includes:

- Separating Logger and TelemetryWriter
- Setting OperationId to a common timestamp for all non-enable commands
- Telemetry on/off switch