### PR TITLE
Adding telemetry to core

### DIFF
--- a/src/core/src/CoreMain.py
+++ b/src/core/src/CoreMain.py
@@ -26,7 +26,8 @@ class CoreMain(object):
         file_logger = bootstrapper.file_logger
         composite_logger = bootstrapper.composite_logger
         stdout_file_mirror = bootstrapper.stdout_file_mirror
-        lifecycle_manager = telemetry_writer = status_handler = None
+        telemetry_writer = bootstrapper.telemetry_writer
+        lifecycle_manager = status_handler = None
 
         # Init operation statuses
         patch_operation_requested = Constants.UNKNOWN
@@ -37,8 +38,7 @@ class CoreMain(object):
             # Level 2 bootstrapping
             composite_logger.log_debug("Building out full container...")
             container = bootstrapper.build_out_container()
-            lifecycle_manager, telemetry_writer, status_handler = bootstrapper.build_core_components(container)
-            composite_logger.telemetry_writer = telemetry_writer  # Need to set telemetry_writer within logger to enable sending all logs to telemetry
+            lifecycle_manager, status_handler = bootstrapper.build_core_components(container)
             composite_logger.log_debug("Completed building out full container.\n\n")
 
             # Basic environment check
@@ -49,7 +49,7 @@ class CoreMain(object):
             # Execution config retrieval
             composite_logger.log_debug("Obtaining execution configuration...")
             execution_config = container.get('execution_config')
-            telemetry_writer.setup_telemetry(execution_config)
+            telemetry_writer.set_operation_id(execution_config.activity_id)
             patch_operation_requested = execution_config.operation.lower()
             patch_assessor = container.get('patch_assessor')
             package_manager = container.get('package_manager')

--- a/src/core/src/CoreMain.py
+++ b/src/core/src/CoreMain.py
@@ -38,7 +38,7 @@ class CoreMain(object):
             composite_logger.log_debug("Building out full container...")
             container = bootstrapper.build_out_container()
             lifecycle_manager, telemetry_writer, status_handler = bootstrapper.build_core_components(container)
-            composite_logger.telemetry_writer = telemetry_writer  # Need to set telemetry_writer within composite logger to enable all logs to be sent to telemetry
+            composite_logger.telemetry_writer = telemetry_writer  # Need to set telemetry_writer within logger to enable sending all logs to telemetry
             composite_logger.log_debug("Completed building out full container.\n\n")
 
             # Basic environment check
@@ -49,6 +49,7 @@ class CoreMain(object):
             # Execution config retrieval
             composite_logger.log_debug("Obtaining execution configuration...")
             execution_config = container.get('execution_config')
+            telemetry_writer.setup_telemetry(execution_config)
             patch_operation_requested = execution_config.operation.lower()
             patch_assessor = container.get('patch_assessor')
             package_manager = container.get('package_manager')
@@ -81,7 +82,6 @@ class CoreMain(object):
 
             composite_logger.log_debug("Safely completing required operations after exception...")
             if telemetry_writer is not None:
-                # telemetry_writer.send_error_info("EXCEPTION: " + repr(error))
                 telemetry_writer.write_event("EXCEPTION: " + repr(error), Constants.TelemetryEventLevel.Error)
             if status_handler is not None:
                 composite_logger.log_debug(' - Status handler pending writes flags [I=' + str(patch_installation_successful) + ', A=' + str(patch_assessment_successful) + ']')

--- a/src/core/src/CoreMain.py
+++ b/src/core/src/CoreMain.py
@@ -38,6 +38,7 @@ class CoreMain(object):
             composite_logger.log_debug("Building out full container...")
             container = bootstrapper.build_out_container()
             lifecycle_manager, telemetry_writer, status_handler = bootstrapper.build_core_components(container)
+            composite_logger.telemetry_writer = telemetry_writer  # Need to set telemetry_writer within composite logger to enable all logs to be sent to telemetry
             composite_logger.log_debug("Completed building out full container.\n\n")
 
             # Basic environment check
@@ -80,7 +81,8 @@ class CoreMain(object):
 
             composite_logger.log_debug("Safely completing required operations after exception...")
             if telemetry_writer is not None:
-                telemetry_writer.send_error_info("EXCEPTION: " + repr(error))
+                # telemetry_writer.send_error_info("EXCEPTION: " + repr(error))
+                telemetry_writer.write_event("EXCEPTION: " + repr(error), Constants.TelemetryEventLevel.Error)
             if status_handler is not None:
                 composite_logger.log_debug(' - Status handler pending writes flags [I=' + str(patch_installation_successful) + ', A=' + str(patch_assessment_successful) + ']')
                 if patch_operation_requested == Constants.INSTALLATION.lower() and not patch_installation_successful:
@@ -103,8 +105,7 @@ class CoreMain(object):
             if lifecycle_manager is not None:
                 lifecycle_manager.update_core_sequence(completed=True)
 
-            telemetry_writer.send_runbook_state_info("Succeeded.")
-            telemetry_writer.close_transports()
+            telemetry_writer.write_event("Completed Linux Patch core operation.", Constants.TelemetryEventLevel.Informational)
 
             stdout_file_mirror.stop()
             file_logger.close(message_at_close="<End of output>")

--- a/src/core/src/bootstrap/Bootstrapper.py
+++ b/src/core/src/bootstrap/Bootstrapper.py
@@ -23,6 +23,7 @@ from core.src.bootstrap.ConfigurationFactory import ConfigurationFactory
 from core.src.bootstrap.Constants import Constants
 from core.src.bootstrap.Container import Container
 from core.src.local_loggers.StdOutFileMirror import StdOutFileMirror
+from core.src.service_interfaces.TelemetryWriter import TelemetryWriter
 
 
 class Bootstrapper(object):

--- a/src/core/src/bootstrap/Bootstrapper.py
+++ b/src/core/src/bootstrap/Bootstrapper.py
@@ -23,7 +23,6 @@ from core.src.bootstrap.ConfigurationFactory import ConfigurationFactory
 from core.src.bootstrap.Constants import Constants
 from core.src.bootstrap.Container import Container
 from core.src.local_loggers.StdOutFileMirror import StdOutFileMirror
-from core.src.service_interfaces.TelemetryWriter import TelemetryWriter
 
 
 class Bootstrapper(object):

--- a/src/core/src/bootstrap/ConfigurationFactory.py
+++ b/src/core/src/bootstrap/ConfigurationFactory.py
@@ -136,7 +136,7 @@ class ConfigurationFactory(object):
             },
             'telemetry_writer': {
                 'component': TelemetryWriter,
-                'component_args': ['composite_logger', 'env_layer'],
+                'component_args': ['env_layer', 'composite_logger'],
                 'component_kwargs': {
                     'events_folder_path': events_folder
                 }

--- a/src/core/src/bootstrap/ConfigurationFactory.py
+++ b/src/core/src/bootstrap/ConfigurationFactory.py
@@ -130,10 +130,10 @@ class ConfigurationFactory(object):
                 'component': CompositeLogger,
                 'component_args': ['env_layer', 'file_logger'],
                 'component_kwargs': {
-                    'current_env': config_env
+                    'current_env': config_env,
+                    'telemetry_writer': None  # Has to be initialized without telemetry_writer to avoid running into a circular dependency loop. Telemetry writer within composite logger will be set later after telemetry writer has been initialized
                 }
             },
-
         }
 
         if config_env is Constants.DEV or config_env is Constants.TEST:
@@ -158,7 +158,7 @@ class ConfigurationFactory(object):
             },
             'telemetry_writer': {
                 'component': TelemetryWriter,
-                'component_args': ['env_layer', 'execution_config'],
+                'component_args': ['composite_logger'],
                 'component_kwargs': {}
             },
             'package_manager': {

--- a/src/core/src/bootstrap/ConfigurationFactory.py
+++ b/src/core/src/bootstrap/ConfigurationFactory.py
@@ -43,11 +43,11 @@ class ConfigurationFactory(object):
     """ Class for generating module definitions. Configuration is list of key value pairs. Please DON'T change key name.
     DI container relies on the key name to find and resolve dependencies. If you do need change it, please make sure to
     update the key name in all places that reference it. """
-    def __init__(self, log_file_path, real_record_path, recorder_enabled, emulator_enabled):
+    def __init__(self, log_file_path, real_record_path, recorder_enabled, emulator_enabled, events_folder):
         self.bootstrap_configurations = {
-            'prod_config':  self.new_bootstrap_configuration(Constants.PROD, log_file_path, real_record_path, recorder_enabled, emulator_enabled),
-            'dev_config':   self.new_bootstrap_configuration(Constants.DEV, log_file_path, real_record_path, recorder_enabled, emulator_enabled),
-            'test_config':  self.new_bootstrap_configuration(Constants.TEST, log_file_path, real_record_path, recorder_enabled, emulator_enabled)
+            'prod_config':  self.new_bootstrap_configuration(Constants.PROD, log_file_path, real_record_path, recorder_enabled, emulator_enabled, events_folder),
+            'dev_config':   self.new_bootstrap_configuration(Constants.DEV, log_file_path, real_record_path, recorder_enabled, emulator_enabled, events_folder),
+            'test_config':  self.new_bootstrap_configuration(Constants.TEST, log_file_path, real_record_path, recorder_enabled, emulator_enabled, events_folder)
         }
 
         self.configurations = {
@@ -106,7 +106,7 @@ class ConfigurationFactory(object):
 
     # region - Configuration Builders
     @staticmethod
-    def new_bootstrap_configuration(config_env, log_file_path, real_record_path, recorder_enabled, emulator_enabled):
+    def new_bootstrap_configuration(config_env, log_file_path, real_record_path, recorder_enabled, emulator_enabled, events_folder):
         """ Core configuration definition. """
         configuration = {
             'config_env': config_env,
@@ -134,6 +134,13 @@ class ConfigurationFactory(object):
                     'telemetry_writer': None  # Has to be initialized without telemetry_writer to avoid running into a circular dependency loop. Telemetry writer within composite logger will be set later after telemetry writer has been initialized
                 }
             },
+            'telemetry_writer': {
+                'component': TelemetryWriter,
+                'component_args': ['composite_logger', 'env_layer'],
+                'component_kwargs': {
+                    'events_folder_path': events_folder
+                }
+            },
         }
 
         if config_env is Constants.DEV or config_env is Constants.TEST:
@@ -154,11 +161,6 @@ class ConfigurationFactory(object):
             'status_handler': {
                 'component': StatusHandler,
                 'component_args': ['env_layer', 'execution_config', 'composite_logger', 'telemetry_writer'],
-                'component_kwargs': {}
-            },
-            'telemetry_writer': {
-                'component': TelemetryWriter,
-                'component_args': ['composite_logger'],
                 'component_kwargs': {}
             },
             'package_manager': {

--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -175,6 +175,7 @@ class Constants(object):
     TELEMETRY_EVENT_FILE_SIZE_LIMIT_IN_BYTES = 4194304  # 4MB
     TELEMETRY_DIR_SIZE_LIMIT_IN_BYTES = 41943040  # 40MB
     TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_BYTES = 80  # buffer for the bytes dropped text added at the end of the truncated telemetry message
+    TELEMETRY_EVENT_COUNTER_MSG_SIZE_LIMIT_IN_BYTES = 80  # buffer for telemetry event counter text added at the end of every message sent to telemetry
 
     # Telemetry Event Level
     class TelemetryEventLevel(EnumBackport):

--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -186,6 +186,8 @@ class Constants(object):
         LogAlways = "LogAlways"
 
     TELEMETRY_TASK_NAME = "ExtensionCoreLog"
+    TELEMETRY_AT_AGENT_NOT_COMPATIBLE_ERROR_MSG = "The minimum Azure Linux Agent version prerequisite for Linux patching was not met. Please update the Azure Linux Agent on this machine following instructions here: http://aka.ms/UpdateLinuxAgent"
+    TELEMETRY_AT_AGENT_COMPATIBLE_MSG = "The minimum Azure Linux Agent version prerequisite for Linux patching was met."
 
     UTC_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
@@ -194,3 +196,4 @@ class Constants(object):
         PRIVILEGED_OP_MARKER = "Privileged_Op_e6df678d-d09b-436a-a08a-65f2f70a6798"
         PRIVILEGED_OP_REBOOT = PRIVILEGED_OP_MARKER + "Reboot_Exception"
         PRIVILEGED_OP_EXIT = PRIVILEGED_OP_MARKER + "Exit_"
+

--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -29,6 +29,9 @@ class Constants(object):
     GLOBAL_EXCLUSION_LIST = ""   # if a package needs to be blocked across all of Azure
     UNKNOWN = "Unknown"
 
+    # Extension version (todo: move to a different file)
+    EXT_VERSION = "1.6.15"
+
     # Runtime environments
     TEST = 'Test'
     DEV = 'Dev'
@@ -165,12 +168,32 @@ class Constants(object):
     ERROR_ADDED_TO_STATUS = "Error_added_to_status"
 
     # Telemetry Categories
-    TELEMETRY_OPERATION_STATE = "State"
-    TELEMETRY_CONFIG = "Config"
-    TELEMETRY_PACKAGE = "PackageInfo"
-    TELEMETRY_ERROR = "Error"
-    TELEMETRY_INFO = "Info"
-    TELEMETRY_DEBUG = "Debug"
+    # TELEMETRY_OPERATION_STATE = "State"
+    # TELEMETRY_CONFIG = "Config"
+    # TELEMETRY_PACKAGE = "PackageInfo"
+    # TELEMETRY_ERROR = "Error"
+    # TELEMETRY_INFO = "Info"
+    # TELEMETRY_DEBUG = "Debug"
+
+    TELEMETRY_ENABLED_AT_EXTENSION = True
+
+    # Telemetry Settings
+    TELEMETRY_MSG_SIZE_LIMIT_IN_BYTES = 3072  # 3KB
+    TELEMETRY_EVENT_SIZE_LIMIT_IN_BYTES = 6144  # 6KB
+    TELEMETRY_EVENT_FILE_SIZE_LIMIT_IN_BYTES = 4194304  # 4MB
+    TELEMETRY_DIR_SIZE_LIMIT_IN_BYTES = 41943040  # 40MB
+    TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_BYTES = 80  # buffer for the bytes dropped text added at the end of the truncated telemetry message
+
+    # Telemetry Event Level
+    class TelemetryEventLevel(EnumBackport):
+        Critical = "Critical"
+        Error = "Error"
+        Warning = "Warning"
+        Verbose = "Verbose"
+        Informational = "Informational"
+        LogAlways = "LogAlways"
+
+    TELEMETRY_TASK_NAME = "ExtensionCoreLog"
 
     UTC_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 

--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -167,14 +167,6 @@ class Constants(object):
 
     ERROR_ADDED_TO_STATUS = "Error_added_to_status"
 
-    # Telemetry Categories
-    # TELEMETRY_OPERATION_STATE = "State"
-    # TELEMETRY_CONFIG = "Config"
-    # TELEMETRY_PACKAGE = "PackageInfo"
-    # TELEMETRY_ERROR = "Error"
-    # TELEMETRY_INFO = "Info"
-    # TELEMETRY_DEBUG = "Debug"
-
     TELEMETRY_ENABLED_AT_EXTENSION = True
 
     # Telemetry Settings

--- a/src/core/src/core_logic/ExecutionConfig.py
+++ b/src/core/src/core_logic/ExecutionConfig.py
@@ -26,7 +26,7 @@ class ExecutionConfig(object):
         self.env_layer = env_layer
         self.composite_logger = composite_logger
         self.execution_parameters = eval(execution_parameters)
-
+        self.composite_logger.log_debug(" - Input parameters... [InputParameters={0}]".format(str(execution_parameters)))
         # Environment details
         self.global_exclusion_list = str(Constants.GLOBAL_EXCLUSION_LIST) if Constants.GLOBAL_EXCLUSION_LIST else None
 

--- a/src/core/src/core_logic/PatchAssessor.py
+++ b/src/core/src/core_logic/PatchAssessor.py
@@ -27,7 +27,6 @@ class PatchAssessor(object):
 
         self.composite_logger = composite_logger
         self.telemetry_writer = telemetry_writer
-        self.is_telemetry_setup = False
         self.status_handler = status_handler
 
         self.package_manager = package_manager
@@ -35,7 +34,7 @@ class PatchAssessor(object):
     def start_assessment(self):
         """ Start an update assessment """
         self.status_handler.set_current_operation(Constants.ASSESSMENT)
-        self.telemetry_writer.is_agent_compatible()
+        self.raise_if_agent_incompatible()
 
         self.composite_logger.log('\nStarting patch assessment...')
 
@@ -75,4 +74,12 @@ class PatchAssessor(object):
 
         self.composite_logger.log("\nPatch assessment completed.\n")
         return True
+
+    def raise_if_agent_incompatible(self):
+        if not self.telemetry_writer.is_agent_compatible():
+            error_msg = Constants.TELEMETRY_AT_AGENT_NOT_COMPATIBLE_ERROR_MSG
+            self.composite_logger.log_error(error_msg)
+            raise Exception(error_msg)
+
+        self.composite_logger.log(Constants.TELEMETRY_AT_AGENT_COMPATIBLE_MSG)
 

--- a/src/core/src/core_logic/PatchAssessor.py
+++ b/src/core/src/core_logic/PatchAssessor.py
@@ -35,7 +35,7 @@ class PatchAssessor(object):
     def start_assessment(self):
         """ Start an update assessment """
         self.status_handler.set_current_operation(Constants.ASSESSMENT)
-        self.telemetry_setup()
+        self.telemetry_writer.startup_telemetry_if_agent_compatible()
 
         self.composite_logger.log('\nStarting patch assessment...')
 
@@ -75,22 +75,4 @@ class PatchAssessor(object):
 
         self.composite_logger.log("\nPatch assessment completed.\n")
         return True
-
-    def telemetry_setup(self):
-        """ Verifies if telemetry is available. Stops execution is not available """
-
-        if self.is_telemetry_setup:  # to avoid executing this again on implicit assessment i.e. 2nd assessment after install
-            return
-
-        if self.execution_config.events_folder is None:
-            error_msg = "The minimum Azure Linux Agent version prerequisite for Linux patching was not met. Please update the Azure Linux Agent on this machine."
-            self.composite_logger.log_error(error_msg)
-            raise Exception(error_msg)
-
-        self.composite_logger.log("The minimum Azure Linux Agent version prerequisite for Linux patching was met.")
-        self.telemetry_writer.events_folder_path = self.execution_config.events_folder
-        self.telemetry_writer.set_operation_id(self.execution_config.activity_id)
-        self.telemetry_writer.telemetry_startup()
-        self.is_telemetry_setup = True
-
 

--- a/src/core/src/core_logic/PatchAssessor.py
+++ b/src/core/src/core_logic/PatchAssessor.py
@@ -35,7 +35,7 @@ class PatchAssessor(object):
     def start_assessment(self):
         """ Start an update assessment """
         self.status_handler.set_current_operation(Constants.ASSESSMENT)
-        self.telemetry_writer.startup_telemetry_if_agent_compatible()
+        self.telemetry_writer.is_agent_compatible()
 
         self.composite_logger.log('\nStarting patch assessment...')
 

--- a/src/core/src/core_logic/PatchInstaller.py
+++ b/src/core/src/core_logic/PatchInstaller.py
@@ -119,16 +119,16 @@ class PatchInstaller(object):
         package_manager.refresh_repo()
 
         packages, package_versions = package_manager.get_available_updates(self.package_filter)  # Initial, ignoring exclusions
-        self.telemetry_writer.send_debug_info("Initial package list: " + str(packages))
+        self.telemetry_writer.write_event("Initial package list: " + str(packages), Constants.TelemetryEventLevel.Verbose)
 
         not_included_packages, not_included_package_versions = self.get_not_included_updates(package_manager, packages)
-        self.telemetry_writer.send_debug_info("Not Included package list: " + str(not_included_packages))
+        self.telemetry_writer.write_event("Not Included package list: " + str(not_included_packages), Constants.TelemetryEventLevel.Verbose)
 
         excluded_packages, excluded_package_versions = self.get_excluded_updates(package_manager, packages, package_versions)
-        self.telemetry_writer.send_debug_info("Excluded package list: " + str(excluded_packages))
+        self.telemetry_writer.write_event("Excluded package list: " + str(excluded_packages), Constants.TelemetryEventLevel.Verbose)
 
         packages, package_versions = self.filter_out_excluded_updates(packages, package_versions, excluded_packages)  # Final, honoring exclusions
-        self.telemetry_writer.send_debug_info("Final package list: " + str(packages))
+        self.telemetry_writer.write_event("Final package list: " + str(packages), Constants.TelemetryEventLevel.Verbose)
 
         # Set initial statuses
         if not package_manager.get_package_manager_setting(Constants.PACKAGE_MGR_SETTING_REPEAT_PATCH_OPERATION, False):  # 'Not included' list is not accurate when a repeat is required
@@ -138,7 +138,7 @@ class PatchInstaller(object):
         self.composite_logger.log("\nList of packages to be updated: \n" + str(packages))
 
         sec_packages, sec_package_versions = self.package_manager.get_security_updates()
-        self.telemetry_writer.send_debug_info("Security packages out of the final package list: " + str(sec_packages))
+        self.telemetry_writer.write_event("Security packages out of the final package list: " + str(sec_packages), Constants.TelemetryEventLevel.Verbose)
         self.status_handler.set_package_install_status_classification(sec_packages, sec_package_versions, classification="Security")
 
         self.composite_logger.log("\nNote: Packages that are neither included nor excluded may still be installed if an included package has a dependency on it.")
@@ -154,7 +154,7 @@ class PatchInstaller(object):
         patch_installation_successful = True
         maintenance_window_exceeded = False
         all_packages, all_package_versions = package_manager.get_all_updates(True)  # cached is fine
-        self.telemetry_writer.send_debug_info("All available packages list: " + str(all_packages))
+        self.telemetry_writer.write_event("All available packages list: " + str(all_packages), Constants.TelemetryEventLevel.Verbose)
         self.last_still_needed_packages = all_packages
         self.last_still_needed_package_versions = all_package_versions
 
@@ -177,7 +177,6 @@ class PatchInstaller(object):
             progress_status = self.progress_template.format(str(datetime.timedelta(minutes=remaining_time)), str(attempted_parent_update_count), str(successful_parent_update_count), str(failed_parent_update_count), str(installed_update_count - successful_parent_update_count),
                                                             "Processing package: " + str(package) + " (" + str(version) + ")")
             self.composite_logger.log(progress_status)
-            self.telemetry_writer.send_info(progress_status)
 
             # include all dependencies (with specified versions) explicitly
             package_and_dependencies = [package]
@@ -242,7 +241,6 @@ class PatchInstaller(object):
                     # status is not logged by design here, in case you were wondering if that's a bug
                     message = " - [Info] Dependency appears to have failed to install (note: it *may* be retried): " + str(dependency) + "(" + str(dependency_version) + ")"
                     self.composite_logger.log_debug(message)
-                    self.telemetry_writer.send_debug_info(message)
 
             # dependency package result management fallback (not reliable enough to be used as primary, and will be removed; remember to retain last_still_needed refresh when you do that)
             installed_update_count += self.perform_status_reconciliation_conditionally(package_manager, condition=(attempted_parent_update_count % Constants.PACKAGE_STATUS_REFRESH_RATE_IN_SECONDS == 0))  # reconcile status after every 10 attempted installs
@@ -250,7 +248,6 @@ class PatchInstaller(object):
         progress_status = self.progress_template.format(str(datetime.timedelta(minutes=maintenance_window.get_remaining_time_in_minutes())), str(attempted_parent_update_count), str(successful_parent_update_count), str(failed_parent_update_count), str(installed_update_count - successful_parent_update_count),
                                                         "Completed processing packages!")
         self.composite_logger.log(progress_status)
-        self.telemetry_writer.send_info(progress_status)
 
         self.composite_logger.log_debug("\nPerforming final system state reconciliation...")
         installed_update_count += self.perform_status_reconciliation_conditionally(package_manager, True)  # final reconciliation

--- a/src/core/src/core_logic/PatchInstaller.py
+++ b/src/core/src/core_logic/PatchInstaller.py
@@ -46,8 +46,10 @@ class PatchInstaller(object):
 
     def start_installation(self, simulate=False):
         """ Kick off a patch installation run """
-        self.composite_logger.log('\nStarting patch installation...')
         self.status_handler.set_current_operation(Constants.INSTALLATION)
+        self.telemetry_writer.is_agent_compatible()
+
+        self.composite_logger.log('\nStarting patch installation...')
 
         self.composite_logger.log("\nMachine Id: " + self.env_layer.platform.node())
         self.composite_logger.log("Activity Id: " + self.execution_config.activity_id)

--- a/src/core/src/core_logic/PatchInstaller.py
+++ b/src/core/src/core_logic/PatchInstaller.py
@@ -47,7 +47,7 @@ class PatchInstaller(object):
     def start_installation(self, simulate=False):
         """ Kick off a patch installation run """
         self.status_handler.set_current_operation(Constants.INSTALLATION)
-        self.telemetry_writer.is_agent_compatible()
+        self.raise_if_agent_incompatible()
 
         self.composite_logger.log('\nStarting patch installation...')
 
@@ -114,6 +114,14 @@ class PatchInstaller(object):
             # NOTE: For auto patching requests, no need to report patch metadata to healthstore in case of failure
 
         return overall_patch_installation_successful
+
+    def raise_if_agent_incompatible(self):
+        if not self.telemetry_writer.is_agent_compatible():
+            error_msg = Constants.TELEMETRY_AT_AGENT_NOT_COMPATIBLE_ERROR_MSG
+            self.composite_logger.log_error(error_msg)
+            raise Exception(error_msg)
+
+        self.composite_logger.log(Constants.TELEMETRY_AT_AGENT_COMPATIBLE_MSG)
 
     def install_updates(self, maintenance_window, package_manager, simulate=False):
         """wrapper function of installing updates"""

--- a/src/core/src/local_loggers/CompositeLogger.py
+++ b/src/core/src/local_loggers/CompositeLogger.py
@@ -84,7 +84,8 @@ class CompositeLogger(object):
         message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
         message = (self.NEWLINE_REPLACE_CHAR.join(message.split(os.linesep))).strip()
         if self.file_logger is not None:
-            self.file_logger.write("\n" + self.TELEMETRY_ERROR + " " + message)
+            timestamp = self.env_layer.datetime.timestamp()
+            self.file_logger.write("\n" + timestamp + "> " + self.TELEMETRY_ERROR + message.strip(), fail_silently=False)
         else:
             print(self.TELEMETRY_ERROR + " " + message)
 
@@ -93,7 +94,8 @@ class CompositeLogger(object):
         message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
         message = (self.NEWLINE_REPLACE_CHAR.join(message.split(os.linesep))).strip()
         if self.file_logger is not None:
-            self.file_logger.write("\n" + self.TELEMETRY_LOG + " " + message)
+            timestamp = self.env_layer.datetime.timestamp()
+            self.file_logger.write("\n" + timestamp + "> " + self.TELEMETRY_LOG + message.strip(), fail_silently=False)
         else:
             print(self.TELEMETRY_LOG + " " + message)
 

--- a/src/core/src/local_loggers/CompositeLogger.py
+++ b/src/core/src/local_loggers/CompositeLogger.py
@@ -81,7 +81,6 @@ class CompositeLogger(object):
 
     def log_telemetry_module_error(self, message):
         """Used exclusively by telemetry writer to log any errors raised within it's operation"""
-        message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
         message = (self.NEWLINE_REPLACE_CHAR.join(message.split(os.linesep))).strip()
         if self.file_logger is not None:
             timestamp = self.env_layer.datetime.timestamp()
@@ -91,7 +90,6 @@ class CompositeLogger(object):
 
     def log_telemetry_module(self, message):
         """Used exclusively by telemetry writer to log messages from it's operation"""
-        message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
         message = (self.NEWLINE_REPLACE_CHAR.join(message.split(os.linesep))).strip()
         if self.file_logger is not None:
             timestamp = self.env_layer.datetime.timestamp()

--- a/src/core/src/local_loggers/CompositeLogger.py
+++ b/src/core/src/local_loggers/CompositeLogger.py
@@ -22,20 +22,25 @@ from core.src.bootstrap.Constants import Constants
 class CompositeLogger(object):
     """ Manages diverting different kinds of output to the right sinks for them. """
 
-    def __init__(self, env_layer=None, file_logger=None, current_env=None):
+    def __init__(self, env_layer=None, file_logger=None, current_env=None, telemetry_writer=None):
         self.env_layer = env_layer
         self.file_logger = file_logger
+        self.telemetry_writer = telemetry_writer  # Although telemetry_writer is an independent entity, it is used within composite_logger for ease of sending all logs to telemetry
         self.ERROR = "ERROR:"
         self.WARNING = "WARNING:"
         self.DEBUG = "DEBUG:"
         self.VERBOSE = "VERBOSE:"
+        self.TELEMETRY_ERROR = "TELEMETRY_ERROR:"
+        self.TELEMETRY_LOG = "TELEMETRY_LOG:"
         self.current_env = current_env
         self.NEWLINE_REPLACE_CHAR = " "
 
-    def log(self, message):
+    def log(self, message, message_type=Constants.TelemetryEventLevel.Informational):
         """log output"""
         message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
         message = message.strip()
+        if self.telemetry_writer is not None and self.telemetry_writer.events_folder_path is not None:
+            self.telemetry_writer.write_event(message, message_type)
         if self.current_env in (Constants.DEV, Constants.TEST):
             for line in message.splitlines():  # allows the extended file logger to strip unnecessary white space
                 print(line)
@@ -47,28 +52,50 @@ class CompositeLogger(object):
         """log errors"""
         message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
         message = self.ERROR + (self.NEWLINE_REPLACE_CHAR.join(message.split(os.linesep))).strip()
-        self.log(message)
+        self.log(message, message_type=Constants.TelemetryEventLevel.Error)
 
     def log_warning(self, message):
         """log warning"""
         message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
         message = self.WARNING + (self.NEWLINE_REPLACE_CHAR.join(message.split(os.linesep))).strip()
-        self.log(message)
+        self.log(message, message_type=Constants.TelemetryEventLevel.Warning)
 
     def log_debug(self, message):
         """log debug"""
         message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
         message = message.strip()
+        if self.telemetry_writer is not None and self.telemetry_writer.events_folder_path is not None and self.current_env not in (Constants.DEV, Constants.TEST):
+            self.telemetry_writer.write_event(message, Constants.TelemetryEventLevel.Verbose)
         if self.current_env in (Constants.DEV, Constants.TEST):
-            self.log(self.current_env + ": " + message)  # send to standard output if dev or test env
+            self.log(self.current_env + ": " + message, Constants.TelemetryEventLevel.Verbose)  # send to standard output if dev or test env
         elif self.file_logger is not None:
             self.file_logger.write("\n\t" + self.DEBUG + " " + "\n\t".join(message.splitlines()).strip())
 
     def log_verbose(self, message):
         """log verbose"""
         message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
+        if self.telemetry_writer is not None and self.telemetry_writer.events_folder_path is not None:
+            self.telemetry_writer.write_event(message, Constants.TelemetryEventLevel.Verbose)
         if self.file_logger is not None:
             self.file_logger.write("\n\t" + self.VERBOSE + " " + "\n\t".join(message.strip().splitlines()).strip())
+
+    def log_telemetry_error(self, message):
+        """Log telemetry error"""
+        message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
+        message = (self.NEWLINE_REPLACE_CHAR.join(message.split(os.linesep))).strip()
+        if self.file_logger is not None:
+            self.file_logger.write("\n" + self.TELEMETRY_ERROR + " " + message)
+        else:
+            print(self.TELEMETRY_ERROR + " " + message)
+
+    def log_telemetry(self, message):
+        """Log telemetry"""
+        message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
+        message = (self.NEWLINE_REPLACE_CHAR.join(message.split(os.linesep))).strip()
+        if self.file_logger is not None:
+            self.file_logger.write("\n" + self.TELEMETRY_LOG + " " + message)
+        else:
+            print(self.TELEMETRY_LOG + " " + message)
 
     @staticmethod
     def __remove_substring_from_message(message, substring=Constants.ERROR_ADDED_TO_STATUS):

--- a/src/core/src/local_loggers/CompositeLogger.py
+++ b/src/core/src/local_loggers/CompositeLogger.py
@@ -79,8 +79,8 @@ class CompositeLogger(object):
         if self.file_logger is not None:
             self.file_logger.write("\n\t" + self.VERBOSE + " " + "\n\t".join(message.strip().splitlines()).strip())
 
-    def log_telemetry_error(self, message):
-        """Log telemetry error"""
+    def log_telemetry_module_error(self, message):
+        """Used exclusively by telemetry writer to log any errors raised within it's operation"""
         message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
         message = (self.NEWLINE_REPLACE_CHAR.join(message.split(os.linesep))).strip()
         if self.file_logger is not None:
@@ -89,8 +89,8 @@ class CompositeLogger(object):
         else:
             print(self.TELEMETRY_ERROR + " " + message)
 
-    def log_telemetry(self, message):
-        """Log telemetry"""
+    def log_telemetry_module(self, message):
+        """Used exclusively by telemetry writer to log messages from it's operation"""
         message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
         message = (self.NEWLINE_REPLACE_CHAR.join(message.split(os.linesep))).strip()
         if self.file_logger is not None:

--- a/src/core/src/package_managers/PackageManager.py
+++ b/src/core/src/package_managers/PackageManager.py
@@ -264,9 +264,9 @@ class PackageManager(object):
 
         if not simulate:
             if install_result == Constants.FAILED:
-                error = self.telemetry_writer.send_package_info(package_and_dependencies[0], package_and_dependency_versions[0], package_size, round(time.time() - start_time, 2), install_result, code_path, exec_cmd, str(out))
+                error = self.telemetry_writer.write_package_info(package_and_dependencies[0], package_and_dependency_versions[0], package_size, round(time.time() - start_time, 2), install_result, code_path, exec_cmd, str(out))
             else:
-                error = self.telemetry_writer.send_package_info(package_and_dependencies[0], package_and_dependency_versions[0], package_size, round(time.time() - start_time, 2), install_result, code_path, exec_cmd)
+                error = self.telemetry_writer.write_package_info(package_and_dependencies[0], package_and_dependency_versions[0], package_size, round(time.time() - start_time, 2), install_result, code_path, exec_cmd)
 
             if error is not None:
                 self.composite_logger.log_debug('\nEXCEPTION writing package telemetry: ' + repr(error))

--- a/src/core/src/package_managers/YumPackageManager.py
+++ b/src/core/src/package_managers/YumPackageManager.py
@@ -68,7 +68,7 @@ class YumPackageManager(PackageManager):
             self.composite_logger.log('[ERROR] Package manager was invoked using: ' + command)
             self.composite_logger.log_warning(" - Return code from package manager: " + str(code))
             self.composite_logger.log_warning(" - Output from package manager: \n|\t" + "\n|\t".join(out.splitlines()))
-            self.telemetry_writer.send_execution_error(command, code, out)
+            self.telemetry_writer.write_execution_error(command, code, out)
             error_msg = 'Unexpected return code (' + str(code) + ') from package manager on command: ' + command
             self.status_handler.add_error_to_status(error_msg, Constants.PatchOperationErrorCodes.PACKAGE_MANAGER_FAILURE)
             raise Exception(error_msg, "[{0}]".format(Constants.ERROR_ADDED_TO_STATUS))

--- a/src/core/src/package_managers/ZypperPackageManager.py
+++ b/src/core/src/package_managers/ZypperPackageManager.py
@@ -64,7 +64,7 @@ class ZypperPackageManager(PackageManager):
             self.composite_logger.log('[ERROR] Package manager was invoked using: ' + command)
             self.composite_logger.log_warning(" - Return code from package manager: " + str(code))
             self.composite_logger.log_warning(" - Output from package manager: \n|\t" + "\n|\t".join(out.splitlines()))
-            self.telemetry_writer.send_execution_error(command, code, out)
+            self.telemetry_writer.write_execution_error(command, code, out)
             error_msg = 'Unexpected return code (' + str(code) + ') from package manager on command: ' + command
             self.status_handler.add_error_to_status(error_msg, Constants.PatchOperationErrorCodes.PACKAGE_MANAGER_FAILURE)
             raise Exception(error_msg, "[{0}]".format(Constants.ERROR_ADDED_TO_STATUS))

--- a/src/core/src/service_interfaces/TelemetryWriter.py
+++ b/src/core/src/service_interfaces/TelemetryWriter.py
@@ -129,7 +129,7 @@ class TelemetryWriter(object):
         formatted_message = re.sub(r"\s+", " ", str(full_message))
 
         if len(formatted_message.encode('utf-8')) > message_size_limit_in_bytes:
-            self.composite_logger.log_telemetry("Data sent to telemetry will be truncated as it exceeds size limit. [Message={0}]".format(str(formatted_message)))
+            self.composite_logger.log_telemetry_module("Data sent to telemetry will be truncated as it exceeds size limit. [Message={0}]".format(str(formatted_message)))
             formatted_message = formatted_message.encode('utf-8')
             bytes_dropped = len(formatted_message) - message_size_limit_in_bytes + Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_BYTES
             return formatted_message[:message_size_limit_in_bytes - Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_BYTES].decode('utf-8') + '. [{0} bytes dropped]'.format(bytes_dropped)
@@ -145,7 +145,7 @@ class TelemetryWriter(object):
 
         event = self.__new_event_json(event_level, message, task_name)
         if len(json.dumps(event)) > Constants.TELEMETRY_EVENT_SIZE_LIMIT_IN_BYTES:
-            self.composite_logger.log_telemetry_error("Cannot send data to telemetry as it exceeded the acceptable data size. [Data not sent={0}]".format(json.dumps(message)))
+            self.composite_logger.log_telemetry_module_error("Cannot send data to telemetry as it exceeded the acceptable data size. [Data not sent={0}]".format(json.dumps(message)))
         else:
             self.write_event_using_temp_file(self.events_folder_path, event)
 
@@ -155,7 +155,7 @@ class TelemetryWriter(object):
             # Not deleting any existing event files as the event directory does not exceed max limit. At least one new event file can be added. Not printing this statement as it will add repetitive logs
             return
 
-        self.composite_logger.log_telemetry("Events directory size exceeds maximum limit. Deleting older event files until at least one new event file can be added.")
+        self.composite_logger.log_telemetry_module("Events directory size exceeds maximum limit. Deleting older event files until at least one new event file can be added.")
         event_files = [os.path.join(self.events_folder_path, event_file) for event_file in os.listdir(self.events_folder_path) if (event_file.lower().endswith(".json"))]
         event_files.sort(key=os.path.getmtime, reverse=True)
 
@@ -167,9 +167,9 @@ class TelemetryWriter(object):
 
                 if os.path.exists(event_file):
                     os.remove(event_file)
-                    self.composite_logger.log_telemetry("Deleted event file. [File={0}]".format(repr(event_file)))
+                    self.composite_logger.log_telemetry_module("Deleted event file. [File={0}]".format(repr(event_file)))
             except Exception as e:
-                self.composite_logger.log_telemetry_error("Error deleting event file. [File={0}] [Exception={1}]".format(repr(event_file), repr(e)))
+                self.composite_logger.log_telemetry_module_error("Error deleting event file. [File={0}] [Exception={1}]".format(repr(event_file), repr(e)))
 
         if self.__get_events_dir_size() >= Constants.TELEMETRY_DIR_SIZE_LIMIT_IN_BYTES:
             raise Exception("Older event files were not deleted. Current event will not be sent to telemetry as events directory size exceeds maximum limit")
@@ -222,13 +222,13 @@ class TelemetryWriter(object):
 
         if self.events_folder_path is None:
             error_msg = "The minimum Azure Linux Agent version prerequisite for Linux patching was not met. Please update the Azure Linux Agent on this machine."
-            self.composite_logger.log_telemetry_error(error_msg)
+            self.composite_logger.log_telemetry_module_error(error_msg)
             raise Exception(error_msg)
 
-        self.composite_logger.log_telemetry("The minimum Azure Linux Agent version prerequisite for Linux patching was met.")
+        self.composite_logger.log_telemetry_module("The minimum Azure Linux Agent version prerequisite for Linux patching was met.")
         if not self.__is_telemetry_startup:
             self.write_telemetry_startup_events()
             self.__is_telemetry_startup = True
         else:
-            self.composite_logger.log_telemetry("Telemetry startup was completed in an earlier instance, please check older telemetry events")
+            self.composite_logger.log_telemetry_module("Telemetry startup was completed in an earlier instance, please check older telemetry events")
 

--- a/src/core/src/service_interfaces/TelemetryWriter.py
+++ b/src/core/src/service_interfaces/TelemetryWriter.py
@@ -225,10 +225,10 @@ class TelemetryWriter(object):
             self.composite_logger.log_telemetry_module_error(error_msg)
             raise Exception(error_msg)
 
-        self.composite_logger.log_telemetry_module("The minimum Azure Linux Agent version prerequisite for Linux patching was met.")
         if not self.__is_telemetry_startup:
+            self.composite_logger.log_telemetry_module("The minimum Azure Linux Agent version prerequisite for Linux patching was met.")
             self.write_telemetry_startup_events()
             self.__is_telemetry_startup = True
         else:
-            self.composite_logger.log_telemetry_module("Telemetry startup was completed in an earlier instance, please check older telemetry events")
+            self.composite_logger.log_telemetry_module("Telemetry startup was completed in an earlier instance. Will continue to write to telemetry using that instance")
 

--- a/src/core/src/service_interfaces/TelemetryWriter.py
+++ b/src/core/src/service_interfaces/TelemetryWriter.py
@@ -27,9 +27,9 @@ from core.src.bootstrap.Constants import Constants
 class TelemetryWriter(object):
     """Class for writing telemetry data to data transports"""
 
-    def __init__(self, composite_logger, env_layer, events_folder_path):
-        self.composite_logger = composite_logger
+    def __init__(self, env_layer, composite_logger, events_folder_path):
         self.env_layer = env_layer
+        self.composite_logger = composite_logger
         self.__is_agent_compatible = False
         self.__operation_id = str(datetime.datetime.utcnow())
         self.events_folder_path = None
@@ -83,7 +83,7 @@ class TelemetryWriter(object):
         error_payload = {
             'cmd': str(cmd),
             'code': str(code),
-            'output': str(output)[0:3072]
+            'output': str(output)
         }
         return self.write_event(error_payload, Constants.TelemetryEventLevel.Error)
     # endregion
@@ -140,17 +140,19 @@ class TelemetryWriter(object):
 
     def write_event(self, message, event_level=Constants.TelemetryEventLevel.Informational, task_name=Constants.TELEMETRY_TASK_NAME):
         """ Creates and writes event to event file after validating none of the telemetry size restrictions are breached """
-        # if self.events_folder_path is None or not os.path.exists(self.events_folder_path) or not Constants.TELEMETRY_ENABLED_AT_EXTENSION:
-        if not self.__is_agent_compatible or not Constants.TELEMETRY_ENABLED_AT_EXTENSION:
-            return
+        try:
+            if not self.__is_agent_compatible or not Constants.TELEMETRY_ENABLED_AT_EXTENSION:
+                return
 
-        self.__delete_older_events()
+            self.__delete_older_events()
 
-        event = self.__new_event_json(event_level, message, task_name)
-        if len(json.dumps(event)) > Constants.TELEMETRY_EVENT_SIZE_LIMIT_IN_BYTES:
-            self.composite_logger.log_telemetry_module_error("Cannot send data to telemetry as it exceeded the acceptable data size. [Data not sent={0}]".format(json.dumps(message)))
-        else:
-            self.write_event_using_temp_file(self.events_folder_path, event)
+            event = self.__new_event_json(event_level, message, task_name)
+            if len(json.dumps(event)) > Constants.TELEMETRY_EVENT_SIZE_LIMIT_IN_BYTES:
+                self.composite_logger.log_telemetry_module_error("Cannot send data to telemetry as it exceeded the acceptable data size. [Data not sent={0}]".format(json.dumps(message)))
+            else:
+                self.__write_event_using_temp_file(self.events_folder_path, event)
+        except Exception:
+            raise Exception("Internal reporting error. Execution could not complete.")
 
     def __delete_older_events(self):
         """ Delete older events until the at least one new event file can be added as per the size restrictions """
@@ -175,9 +177,10 @@ class TelemetryWriter(object):
                 self.composite_logger.log_telemetry_module_error("Error deleting event file. [File={0}] [Exception={1}]".format(repr(event_file), repr(e)))
 
         if self.__get_events_dir_size() >= Constants.TELEMETRY_DIR_SIZE_LIMIT_IN_BYTES:
-            raise Exception("Older event files were not deleted. Current event will not be sent to telemetry as events directory size exceeds maximum limit")
+            self.composite_logger.log_telemetry_module_error("Older event files were not deleted. Current event will not be sent to telemetry as events directory size exceeds maximum limit")
+            raise
 
-    def write_event_using_temp_file(self, folder_path, data, mode='w'):
+    def __write_event_using_temp_file(self, folder_path, data, mode='w'):
         """ Writes to a temp file in a single operation and then moves/overrides the original file with the temp """
         file_path = self.__get_event_file_path(folder_path)
         prev_events = []
@@ -197,21 +200,30 @@ class TelemetryWriter(object):
                 tempname = tf.name
             shutil.move(tempname, file_path)
         except Exception as error:
-            raise Exception("Unable to write to telemetry. [Event File={0}] [Error={1}].".format(str(file_path), repr(error)))
+            self.composite_logger.log_telemetry_module_error("Unable to write to telemetry. [Event File={0}] [Error={1}].".format(str(file_path), repr(error)))
+            raise
 
     def __get_events_dir_size(self):
-        return sum([os.path.getsize(os.path.join(self.events_folder_path, f)) for f in os.listdir(self.events_folder_path) if os.path.isfile(os.path.join(self.events_folder_path, f))])
+        """ Returns total size, in bytes, of the events folder """
+        total_dir_size = 0
+        for f in os.listdir(self.events_folder_path):
+            if os.path.isfile(os.path.join(self.events_folder_path, f)):
+                total_dir_size += os.path.getsize(os.path.join(self.events_folder_path, f))
+        return total_dir_size
 
     @staticmethod
     def __get_event_file_path(folder_path):
+        """ Returns the filename, generated from current timestamp in seconds, to be used to write an event. Eg: 1614111606855.json"""
         return os.path.join(folder_path, str(int(round(time.time() * 1000))) + ".json")
 
     @staticmethod
     def get_file_size(file_path):
+        """ Returns the size of a file. Extracted out for mocking in unit test """
         return os.path.getsize(file_path)
 
     @staticmethod
     def __fetch_events_from_previous_file(file_path):
+        """ Fetch contents from the file """
         with open(file_path, 'r') as file_handle:
             file_contents = file_handle.read()
             return json.loads(file_contents)
@@ -221,11 +233,5 @@ class TelemetryWriter(object):
 
     def is_agent_compatible(self):
         """ Verifies if telemetry is available. Stops execution if not available. """
-
-        if not self.__is_agent_compatible:
-            error_msg = "The minimum Azure Linux Agent version prerequisite for Linux patching was not met. Please update the Azure Linux Agent on this machine."
-            self.composite_logger.log_telemetry_module_error(error_msg)
-            raise Exception(error_msg)
-
-        self.composite_logger.log_telemetry_module("The minimum Azure Linux Agent version prerequisite for Linux patching was met.")
+        return self.__is_agent_compatible
 

--- a/src/core/src/service_interfaces/TelemetryWriter.py
+++ b/src/core/src/service_interfaces/TelemetryWriter.py
@@ -13,40 +13,54 @@
 # limitations under the License.
 #
 # Requires Python 2.7+
-
+import datetime
 import json
+import os
+import re
+import shutil
+import tempfile
+import time
+
 from core.src.bootstrap.Constants import Constants
 
 
 class TelemetryWriter(object):
     """Class for writing telemetry data to data transports"""
 
-    def __init__(self, env_layer, execution_config):
-        self.data_transports = []
+    def __init__(self, composite_logger, env_layer):
+        self.composite_logger = composite_logger
         self.env_layer = env_layer
-        self.activity_id = execution_config.activity_id
+        self.events_folder_path = None
+        self.__operation_id = ""
 
-        # Init state report
-        self.send_runbook_state_info('Started Linux patch runbook.')
-        self.send_machine_config_info()
-        self.send_config_info(execution_config.config_settings, 'execution_config')
+    def telemetry_startup(self):
+        self.write_event('Started Linux patch core operation.', Constants.TelemetryEventLevel.Informational)
+        self.write_machine_config_info()
 
-    # region Primary payloads
-    def send_runbook_state_info(self, state_info):
-        # Expected to send up only pivotal runbook state changes
-        return self.try_send_message(state_info, Constants.TELEMETRY_OPERATION_STATE)
+        #todo later
+        #self.write_config_info(execution_config.config_settings, 'execution_config')
 
-    def send_config_info(self, config_info, config_type='unknown'):
+    # def __init__(self, env_layer, execution_config):
+    #     self.data_transports = []
+    #     self.env_layer = env_layer
+    #     self.activity_id = execution_config.activity_id
+    #
+    #     # Init state report
+    #     self.send_runbook_state_info('Started Linux patch runbook.')
+    #     self.send_machine_config_info()
+    #     self.send_config_info(execution_config.config_settings, 'execution_config')
+
+    def write_config_info(self, config_info, config_type='unknown'):
         # Configuration info
         payload_json = {
             'config_type': config_type,
             'config_value': config_info
         }
-        return self.try_send_message(payload_json, Constants.TELEMETRY_CONFIG)
+        return self.write_event(payload_json, Constants.TelemetryEventLevel.Informational)
 
-    def send_package_info(self, package_name, package_ver, package_size, install_dur, install_result, code_path, install_cmd, output=''):
+    def write_package_info(self, package_name, package_ver, package_size, install_dur, install_result, code_path, install_cmd, output=''):
         # Package information compiled after the package is attempted to be installed
-        max_output_length = 3072
+        max_output_length = 1024
         errors = ""
 
         # primary payload
@@ -54,31 +68,16 @@ class TelemetryWriter(object):
                    'package_size': str(package_size), 'install_duration': str(install_dur),
                    'install_result': str(install_result), 'code_path': code_path,
                    'install_cmd': str(install_cmd), 'output': str(output)[0:max_output_length]}
-        errors += self.try_send_message(message, Constants.TELEMETRY_PACKAGE)
+        self.write_event(message, Constants.TelemetryEventLevel.Informational)
 
         # additional message payloads for output continuation only if we need it for specific troubleshooting
         if len(output) > max_output_length:
             for i in range(1, int(len(output)/max_output_length) + 1):
                 message = {'install_cmd': str(install_cmd), 'output_continuation': str(output)[(max_output_length*i):(max_output_length*(i+1))]}
-                errors += self.try_send_message(message, Constants.TELEMETRY_PACKAGE)
-
-        return errors  # if any. Nobody consumes this at the time of this writing.
-
-    def send_error_info(self, error_info):
-        # Expected to log significant errors or exceptions
-        return self.try_send_message(error_info, Constants.TELEMETRY_ERROR)
-
-    def send_debug_info(self, error_info):
-        # Usually expected to instrument possibly problematic code
-        return self.try_send_message(error_info, Constants.TELEMETRY_DEBUG)
-
-    def send_info(self, info):
-        # Usually expected to be significant runbook output
-        return self.try_send_message(info, Constants.TELEMETRY_INFO)
-    # endregion
+                self.write_event(message, Constants.TelemetryEventLevel.Informational)
 
     # Composed payload
-    def send_machine_config_info(self):
+    def write_machine_config_info(self):
         # Machine info - sent only once at the start of the run
         machine_info = {
             'platform_name': str(self.env_layer.platform.linux_distribution()[0]),
@@ -87,35 +86,16 @@ class TelemetryWriter(object):
             'machine_arch': str(self.env_layer.platform.machine()),
             'disk_type': self.get_disk_type()
         }
-        return self.send_config_info(machine_info, 'machine_config')
+        return self.write_config_info(machine_info, 'machine_config')
 
-    def send_execution_error(self, cmd, code, output):
+    def write_execution_error(self, cmd, code, output):
         # Expected to log any errors from a cmd execution, including package manager execution errors
         error_payload = {
             'cmd': str(cmd),
             'code': str(code),
             'output': str(output)[0:3072]
         }
-        return self.send_error_info(error_payload)
-    # endregion
-
-    # region Transport layer
-    def try_send_message(self, message, category=Constants.TELEMETRY_INFO):
-        """ Tries to send a message immediately. Returns None if successful. Error message if not."""
-        try:
-            payload = {'activity_id': str(self.activity_id), 'category': str(category), 'ver': "[%runbook_sub_ver%]", 'message': message}
-            payload = json.dumps(payload)[0:4095]
-            for transport in self.data_transports:
-                transport.write(payload)
-            return ""  # for consistency
-        except Exception as error:
-            return repr(error)  # if the caller cares
-
-    def close_transports(self):
-        """Close data transports"""
-        self.send_runbook_state_info('Closing telemetry channel(s).')
-        for transport in self.data_transports:
-            transport.close()
+        return self.write_event(error_payload, Constants.TelemetryEventLevel.Error)
     # endregion
 
     # region Machine config retrieval methods
@@ -142,3 +122,108 @@ class TelemetryWriter(object):
         else:
             return "Unknown"
     # end region
+
+    def __new_event_json(self, event_level, message, task_name):
+        return {
+            "Version": Constants.EXT_VERSION,
+            "Timestamp": str(datetime.datetime.utcnow()),
+            "TaskName": task_name,
+            "EventLevel": event_level,
+            "Message": self.__ensure_message_restriction_compliance(message),
+            "EventPid": "",
+            "EventTid": "",
+            "OperationId": self.__operation_id  # activity id from from config settings
+        }
+
+    def __ensure_message_restriction_compliance(self, full_message):
+        """ Removes line breaks, tabs and restricts message to a byte limit """
+        message_size_limit_in_bytes = Constants.TELEMETRY_MSG_SIZE_LIMIT_IN_BYTES
+        formatted_message = re.sub(r"\s+", " ", str(full_message))
+
+        if len(formatted_message.encode('utf-8')) > message_size_limit_in_bytes:
+            self.composite_logger.log_telemetry("Data sent to telemetry will be truncated as it exceeds size limit. [Message={0}]".format(str(formatted_message)))
+            formatted_message = formatted_message.encode('utf-8')
+            bytes_dropped = len(formatted_message) - message_size_limit_in_bytes + Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_BYTES
+            return formatted_message[:message_size_limit_in_bytes - Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_BYTES].decode('utf-8') + '. [{0} bytes dropped]'.format(bytes_dropped)
+
+        return formatted_message
+
+    def write_event(self, message, event_level=Constants.TelemetryEventLevel.Informational, task_name=Constants.TELEMETRY_TASK_NAME):
+        """ Creates and writes event to event file after validating none of the telemetry size restrictions are breached """
+        if self.events_folder_path is None or not os.path.exists(self.events_folder_path) or not Constants.TELEMETRY_ENABLED_AT_EXTENSION:
+            return
+
+        self.__delete_older_events()
+
+        event = self.__new_event_json(event_level, message, task_name)
+        if len(json.dumps(event)) > Constants.TELEMETRY_EVENT_SIZE_LIMIT_IN_BYTES:
+            self.composite_logger.log_telemetry_error("Cannot send data to telemetry as it exceeded the acceptable data size. [Data not sent={0}]".format(json.dumps(message)))
+        else:
+            self.write_event_using_temp_file(self.events_folder_path, event)
+
+    def __delete_older_events(self):
+        """ Delete older events until the at least one new event file can be added as per the size restrictions """
+        if self.__get_events_dir_size() < Constants.TELEMETRY_DIR_SIZE_LIMIT_IN_BYTES - Constants.TELEMETRY_EVENT_FILE_SIZE_LIMIT_IN_BYTES:
+            # Not deleting any existing event files as the event directory does not exceed max limit. At least one new event file can be added. Not printing this statement as it will add repetitive logs
+            return
+
+        self.composite_logger.log_telemetry("Events directory size exceeds maximum limit. Deleting older event files until at least one new event file can be added.")
+        event_files = [os.path.join(self.events_folder_path, event_file) for event_file in os.listdir(self.events_folder_path) if (event_file.lower().endswith(".json"))]
+        event_files.sort(key=os.path.getmtime, reverse=True)
+
+        for event_file in event_files:
+            try:
+                if self.__get_events_dir_size() < Constants.TELEMETRY_DIR_SIZE_LIMIT_IN_BYTES - Constants.TELEMETRY_EVENT_FILE_SIZE_LIMIT_IN_BYTES:
+                    # Not deleting any more event files as the event directory has sufficient space to add at least one new event file. Not printing this statement as it will add repetitive logs
+                    break
+
+                if os.path.exists(event_file):
+                    os.remove(event_file)
+                    self.composite_logger.log_telemetry("Deleted event file. [File={0}]".format(repr(event_file)))
+            except Exception as e:
+                self.composite_logger.log_telemetry_error("Error deleting event file. [File={0}] [Exception={1}]".format(repr(event_file), repr(e)))
+
+        if self.__get_events_dir_size() >= Constants.TELEMETRY_DIR_SIZE_LIMIT_IN_BYTES:
+            raise Exception("Older event files were not deleted. Current event will not be sent to telemetry as events directory size exceeds maximum limit")
+
+    def write_event_using_temp_file(self, folder_path, data, mode='w'):
+        """ Writes to a temp file in a single operation and then moves/overrides the original file with the temp """
+        file_path = self.__get_event_file_path(folder_path)
+        prev_events = []
+        try:
+            if os.path.exists(file_path):
+                file_size = self.get_file_size(file_path)
+                # if file_size exceeds max limit, sleep for 1 second, so the event can be written to a new file since the event file name is a timestamp
+                if file_size >= Constants.TELEMETRY_EVENT_FILE_SIZE_LIMIT_IN_BYTES:
+                    time.sleep(1)
+                    file_path = self.__get_event_file_path(folder_path)
+                else:
+                    prev_events = self.__fetch_events_from_previous_file(file_path)
+
+            prev_events.append(data)
+            with tempfile.NamedTemporaryFile(mode, dir=os.path.dirname(file_path), delete=False) as tf:
+                json.dump(prev_events, tf, default=data.__str__())
+                tempname = tf.name
+            shutil.move(tempname, file_path)
+        except Exception as error:
+            raise Exception("Unable to write to telemetry. [Event File={0}] [Error={1}].".format(str(file_path), repr(error)))
+
+    def set_operation_id(self, operation_id):
+        self.__operation_id = operation_id
+
+    def __get_events_dir_size(self):
+        return sum([os.path.getsize(os.path.join(self.events_folder_path, f)) for f in os.listdir(self.events_folder_path) if os.path.isfile(os.path.join(self.events_folder_path, f))])
+
+    @staticmethod
+    def __get_event_file_path(folder_path):
+        return os.path.join(folder_path, str(int(round(time.time() * 1000))) + ".json")
+
+    @staticmethod
+    def get_file_size(file_path):
+        return os.path.getsize(file_path)
+
+    @staticmethod
+    def __fetch_events_from_previous_file(file_path):
+        with open(file_path, 'r') as file_handle:
+            file_contents = file_handle.read()
+            return json.loads(file_contents)

--- a/src/core/src/service_interfaces/TelemetryWriter.py
+++ b/src/core/src/service_interfaces/TelemetryWriter.py
@@ -27,17 +27,19 @@ from core.src.bootstrap.Constants import Constants
 class TelemetryWriter(object):
     """Class for writing telemetry data to data transports"""
 
-    def __init__(self, composite_logger, env_layer):
+    def __init__(self, composite_logger, env_layer, events_folder_path):
         self.composite_logger = composite_logger
         self.env_layer = env_layer
+        self.__is_agent_compatible = False
+        self.__operation_id = str(datetime.datetime.utcnow())
         self.events_folder_path = None
-        self.__execution_config = None
-        self.__is_telemetry_startup = False  # to avoid re-sending startup events to telemetry
 
-    def write_telemetry_startup_events(self):
+        if events_folder_path is not None and os.path.exists(events_folder_path):
+            self.events_folder_path = events_folder_path
+            self.__is_agent_compatible = True
+
         self.write_event('Started Linux patch core operation.', Constants.TelemetryEventLevel.Informational)
         self.write_machine_config_info()
-        self.write_config_info(self.__execution_config.config_settings, 'execution_config')
 
     def write_config_info(self, config_info, config_type='unknown'):
         # Configuration info
@@ -120,7 +122,7 @@ class TelemetryWriter(object):
             "Message": self.__ensure_message_restriction_compliance(message),
             "EventPid": "",
             "EventTid": "",
-            "OperationId": "" if self.__execution_config is None else self.__execution_config.activity_id  # activity id from from config settings
+            "OperationId": self.__operation_id  # activity id from from config settings
         }
 
     def __ensure_message_restriction_compliance(self, full_message):
@@ -138,7 +140,8 @@ class TelemetryWriter(object):
 
     def write_event(self, message, event_level=Constants.TelemetryEventLevel.Informational, task_name=Constants.TELEMETRY_TASK_NAME):
         """ Creates and writes event to event file after validating none of the telemetry size restrictions are breached """
-        if self.events_folder_path is None or not os.path.exists(self.events_folder_path) or not Constants.TELEMETRY_ENABLED_AT_EXTENSION:
+        # if self.events_folder_path is None or not os.path.exists(self.events_folder_path) or not Constants.TELEMETRY_ENABLED_AT_EXTENSION:
+        if not self.__is_agent_compatible or not Constants.TELEMETRY_ENABLED_AT_EXTENSION:
             return
 
         self.__delete_older_events()
@@ -196,10 +199,6 @@ class TelemetryWriter(object):
         except Exception as error:
             raise Exception("Unable to write to telemetry. [Event File={0}] [Error={1}].".format(str(file_path), repr(error)))
 
-    def setup_telemetry(self, execution_config):
-        self.__execution_config = execution_config
-        self.events_folder_path = self.__execution_config.events_folder
-
     def __get_events_dir_size(self):
         return sum([os.path.getsize(os.path.join(self.events_folder_path, f)) for f in os.listdir(self.events_folder_path) if os.path.isfile(os.path.join(self.events_folder_path, f))])
 
@@ -217,18 +216,16 @@ class TelemetryWriter(object):
             file_contents = file_handle.read()
             return json.loads(file_contents)
 
-    def startup_telemetry_if_agent_compatible(self):
-        """ Verifies if telemetry is available. Stops execution if not available. Sends startup events if telemetry is available """
+    def set_operation_id(self, operation_id):
+        self.__operation_id = operation_id
 
-        if self.events_folder_path is None:
+    def is_agent_compatible(self):
+        """ Verifies if telemetry is available. Stops execution if not available. """
+
+        if not self.__is_agent_compatible:
             error_msg = "The minimum Azure Linux Agent version prerequisite for Linux patching was not met. Please update the Azure Linux Agent on this machine."
             self.composite_logger.log_telemetry_module_error(error_msg)
             raise Exception(error_msg)
 
-        if not self.__is_telemetry_startup:
-            self.composite_logger.log_telemetry_module("The minimum Azure Linux Agent version prerequisite for Linux patching was met.")
-            self.write_telemetry_startup_events()
-            self.__is_telemetry_startup = True
-        else:
-            self.composite_logger.log_telemetry_module("Telemetry startup was completed in an earlier instance. Will continue to write to telemetry using that instance")
+        self.composite_logger.log_telemetry_module("The minimum Azure Linux Agent version prerequisite for Linux patching was met.")
 

--- a/src/core/tests/TestCoreMain.py
+++ b/src/core/tests/TestCoreMain.py
@@ -15,6 +15,8 @@
 # Requires Python 2.7+
 import datetime
 import json
+import os
+import re
 import unittest
 from core.src.CoreMain import CoreMain
 from core.src.bootstrap.Constants import Constants
@@ -40,6 +42,11 @@ class TestCoreMain(unittest.TestCase):
         runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.ZYPPER)
         runtime.set_legacy_test_type('FailInstallPath')
         CoreMain(argument_composer.get_composed_arguments())
+
+        # check telemetry events
+        self.__check_telemetry_events(runtime)
+
+        # check status file
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
         self.assertEquals(len(substatus_file_data), 2)
@@ -56,6 +63,11 @@ class TestCoreMain(unittest.TestCase):
         runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.ZYPPER)
         runtime.set_legacy_test_type('FailInstallPath')
         CoreMain(argument_composer.get_composed_arguments())
+
+        # check telemetry events
+        self.__check_telemetry_events(runtime)
+
+        # check status file
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
         self.assertEquals(len(substatus_file_data), 3)
@@ -76,6 +88,11 @@ class TestCoreMain(unittest.TestCase):
         runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.ZYPPER)
         runtime.set_legacy_test_type('SuccessInstallPath')
         CoreMain(argument_composer.get_composed_arguments())
+
+        # check telemetry events
+        self.__check_telemetry_events(runtime)
+
+        # check status file
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
         self.assertEquals(len(substatus_file_data), 2)
@@ -93,6 +110,11 @@ class TestCoreMain(unittest.TestCase):
         runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.ZYPPER)
         runtime.set_legacy_test_type('SuccessInstallPath')
         CoreMain(argument_composer.get_composed_arguments())
+
+        # check telemetry events
+        self.__check_telemetry_events(runtime)
+
+        # check status file
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
         self.assertEquals(len(substatus_file_data), 3)
@@ -117,6 +139,11 @@ class TestCoreMain(unittest.TestCase):
         runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.APT)
         runtime.set_legacy_test_type("SuccessInstallPath")
         CoreMain(argument_composer.get_composed_arguments())
+
+        # check telemetry events
+        self.__check_telemetry_events(runtime)
+
+        # check status file
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
         self.assertEquals(len(substatus_file_data), 3)
@@ -146,6 +173,11 @@ class TestCoreMain(unittest.TestCase):
         runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.ZYPPER)
         runtime.set_legacy_test_type('SuccessInstallPath')
         CoreMain(argument_composer.get_composed_arguments())
+
+        # check telemetry events
+        self.__check_telemetry_events(runtime)
+
+        # check status file
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
         self.assertEquals(len(substatus_file_data), 3)
@@ -168,6 +200,11 @@ class TestCoreMain(unittest.TestCase):
         runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.ZYPPER)
         runtime.set_legacy_test_type('SuccessInstallPath')
         CoreMain(argument_composer.get_composed_arguments())
+
+        # check telemetry events
+        self.__check_telemetry_events(runtime)
+
+        # check status file
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
         self.assertEquals(len(substatus_file_data), 3)
@@ -188,6 +225,11 @@ class TestCoreMain(unittest.TestCase):
         runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.ZYPPER)
         runtime.set_legacy_test_type('HappyPath')
         CoreMain(argument_composer.get_composed_arguments())
+
+        # check telemetry events
+        self.__check_telemetry_events(runtime)
+
+        # check status file
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
         self.assertEquals(len(substatus_file_data), 1)
@@ -201,6 +243,11 @@ class TestCoreMain(unittest.TestCase):
         runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.ZYPPER)
         runtime.set_legacy_test_type('ExceptionPath')
         CoreMain(argument_composer.get_composed_arguments())
+
+        # check telemetry events
+        self.__check_telemetry_events(runtime)
+
+        # check status file
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
         self.assertEquals(len(substatus_file_data), 1)
@@ -245,6 +292,16 @@ class TestCoreMain(unittest.TestCase):
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
         self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_ERROR.lower())
         runtime.stop()
+
+    def __check_telemetry_events(self, runtime):
+        all_events = os.listdir(runtime.telemetry_writer.events_folder_path)
+        self.assertTrue(len(all_events) > 0)
+        latest_event_file = [pos_json for pos_json in os.listdir(runtime.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)][-1]
+        with open(os.path.join(runtime.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:
+            events = json.load(f)
+            self.assertTrue(events is not None)
+            self.assertTrue('ExtensionCoreLog' in events[0]['TaskName'])
+            f.close()
 
 
 if __name__ == '__main__':

--- a/src/core/tests/TestCoreMain.py
+++ b/src/core/tests/TestCoreMain.py
@@ -259,9 +259,9 @@ class TestCoreMain(unittest.TestCase):
     def test_assessment_operation_fail_due_to_no_telemetry(self):
         argument_composer = ArgumentComposer()
         argument_composer.operation = Constants.ASSESSMENT
+        argument_composer.events_folder = None
         runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.ZYPPER)
         runtime.set_legacy_test_type('HappyPath')
-        runtime.execution_config.events_folder = None
         CoreMain(argument_composer.get_composed_arguments())
 
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
@@ -277,9 +277,9 @@ class TestCoreMain(unittest.TestCase):
         # testing on auto patching request
         argument_composer = ArgumentComposer()
         argument_composer.maintenance_run_id = str(datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ"))
+        argument_composer.events_folder = None
         runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.ZYPPER)
         runtime.set_legacy_test_type('SuccessInstallPath')
-        runtime.execution_config.events_folder = None
         CoreMain(argument_composer.get_composed_arguments())
 
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:

--- a/src/core/tests/TestPatchAssessor.py
+++ b/src/core/tests/TestPatchAssessor.py
@@ -54,5 +54,6 @@ class TestPatchAssessor(unittest.TestCase):
     def mock_refresh_repo(self):
         pass
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/core/tests/TestTelemetryWriter.py
+++ b/src/core/tests/TestTelemetryWriter.py
@@ -26,8 +26,6 @@ from core.tests.library.RuntimeCompositor import RuntimeCompositor
 class TestTelemetryWriter(unittest.TestCase):
     def setUp(self):
         self.runtime = RuntimeCompositor(ArgumentComposer().get_composed_arguments(), True)
-        self.runtime.telemetry_writer.events_folder_path = self.runtime.execution_config.events_folder
-        self.runtime.telemetry_writer.set_operation_id(self.runtime.execution_config.activity_id)
 
     def tearDown(self):
         self.runtime.stop()

--- a/src/core/tests/TestTelemetryWriter.py
+++ b/src/core/tests/TestTelemetryWriter.py
@@ -45,19 +45,29 @@ class TestTelemetryWriter(unittest.TestCase):
     def test_write_event(self):
         self.runtime.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task")
         latest_event_file = [pos_json for pos_json in os.listdir(self.runtime.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)][-1]
+        telemetry_event_counter_in_first_test_event = None
         with open(os.path.join(self.runtime.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:
             events = json.load(f)
             self.assertTrue(events is not None)
             self.assertEquals(events[0]["TaskName"], "Test Task")
+            text_found = re.search('TC=([0-9]+)', events[0]['Message'])
+            telemetry_event_counter_in_first_test_event = text_found.group(1) if text_found else None
             f.close()
 
         self.runtime.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task2")
         latest_event_file = [pos_json for pos_json in os.listdir(self.runtime.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)][-1]
+        telemetry_event_counter_in_second_test_event = None
         with open(os.path.join(self.runtime.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:
             events = json.load(f)
             self.assertTrue(events is not None)
             self.assertEquals(events[-1]["TaskName"], "Test Task2")
+            text_found = re.search('TC=([0-9]+)', events[0]['Message'])
+            telemetry_event_counter_in_second_test_event = text_found.group(1) if text_found else None
             f.close()
+
+        self.assertTrue(telemetry_event_counter_in_first_test_event is not None)
+        self.assertTrue(telemetry_event_counter_in_second_test_event is not None)
+        self.assertTrue(int(telemetry_event_counter_in_second_test_event) - int(telemetry_event_counter_in_first_test_event) == 1)
 
     def test_write_multiple_events_in_same_file(self):
         time_backup = time.time
@@ -84,7 +94,7 @@ class TestTelemetryWriter(unittest.TestCase):
             self.assertTrue(events is not None)
             self.assertEquals(events[0]["TaskName"], "Test Task")
             self.assertTrue(len(events[0]["Message"]) < len(message.encode('utf-8')))
-            bytes_dropped = len(message.encode('utf-8')) - Constants.TELEMETRY_MSG_SIZE_LIMIT_IN_BYTES + Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_BYTES
+            bytes_dropped = len(message.encode('utf-8')) - Constants.TELEMETRY_MSG_SIZE_LIMIT_IN_BYTES + Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_BYTES + Constants.TELEMETRY_EVENT_COUNTER_MSG_SIZE_LIMIT_IN_BYTES
             self.assertEquals(events[0]["Message"], "a"*(len(message.encode('utf-8')) - bytes_dropped) + ". [{0} bytes dropped]".format(bytes_dropped))
             f.close()
 

--- a/src/core/tests/TestTelemetryWriter.py
+++ b/src/core/tests/TestTelemetryWriter.py
@@ -13,7 +13,10 @@
 # limitations under the License.
 #
 # Requires Python 2.7+
-
+import json
+import os
+import re
+import time
 import unittest
 from core.src.bootstrap.Constants import Constants
 from core.tests.library.ArgumentComposer import ArgumentComposer
@@ -23,13 +26,135 @@ from core.tests.library.RuntimeCompositor import RuntimeCompositor
 class TestTelemetryWriter(unittest.TestCase):
     def setUp(self):
         self.runtime = RuntimeCompositor(ArgumentComposer().get_composed_arguments(), True)
-        self.container = self.runtime.container
+        self.runtime.telemetry_writer.events_folder_path = self.runtime.execution_config.events_folder
+        self.runtime.telemetry_writer.set_operation_id(self.runtime.execution_config.activity_id)
 
     def tearDown(self):
         self.runtime.stop()
 
-    def test_something(self):
-        self.assertEqual(True, True)
+    def mock_time(self):
+        return 1234
+
+    def mock_os_remove(self, filepath):
+        raise Exception("File could not be deleted")
+
+    def mock_os_path_exists(self, filepath):
+        return True
+
+    def mock_get_file_size(self, file_path):
+        return Constants.TELEMETRY_EVENT_FILE_SIZE_LIMIT_IN_BYTES + 10
+
+    def test_write_event(self):
+        self.runtime.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task")
+        latest_event_file = [pos_json for pos_json in os.listdir(self.runtime.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)][-1]
+        with open(os.path.join(self.runtime.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:
+            events = json.load(f)
+            self.assertTrue(events is not None)
+            self.assertEquals(events[0]["TaskName"], "Test Task")
+            f.close()
+
+        self.runtime.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task2")
+        latest_event_file = [pos_json for pos_json in os.listdir(self.runtime.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)][-1]
+        with open(os.path.join(self.runtime.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:
+            events = json.load(f)
+            self.assertTrue(events is not None)
+            self.assertEquals(events[-1]["TaskName"], "Test Task2")
+            f.close()
+
+    def test_write_multiple_events_in_same_file(self):
+        time_backup = time.time
+        time.time = self.mock_time
+        self.runtime.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task")
+        self.runtime.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task2")
+        latest_event_file = [pos_json for pos_json in os.listdir(self.runtime.telemetry_writer.events_folder_path) if re.search('^' + str(self.mock_time()) + '0+.json$', pos_json)][-1]
+        with open(os.path.join(self.runtime.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:
+            events = json.load(f)
+            self.assertTrue(events is not None)
+            self.assertEquals(len(events), 2)
+            self.assertEquals(events[0]["TaskName"], "Test Task")
+            self.assertEquals(events[1]["TaskName"], "Test Task2")
+            f.close()
+        time.time = time_backup
+
+    def test_write_event_msg_size_limit(self):
+        # Assuming 1 char is 1 byte
+        message = "a"*3074
+        self.runtime.telemetry_writer.write_event(message, Constants.TelemetryEventLevel.Error, "Test Task")
+        latest_event_file = [pos_json for pos_json in os.listdir(self.runtime.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)][-1]
+        with open(os.path.join(self.runtime.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:
+            events = json.load(f)
+            self.assertTrue(events is not None)
+            self.assertEquals(events[0]["TaskName"], "Test Task")
+            self.assertTrue(len(events[0]["Message"]) < len(message.encode('utf-8')))
+            bytes_dropped = len(message.encode('utf-8')) - Constants.TELEMETRY_MSG_SIZE_LIMIT_IN_BYTES + Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_BYTES
+            self.assertEquals(events[0]["Message"], "a"*(len(message.encode('utf-8')) - bytes_dropped) + ". [{0} bytes dropped]".format(bytes_dropped))
+            f.close()
+
+    def test_write_event_size_limit(self):
+        # will not write to telemetry if event size exceeds limit
+        self.runtime.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task")
+        old_events = os.listdir(self.runtime.telemetry_writer.events_folder_path)
+        message = "a" * 3074
+        task_name = "b" * 5000
+        self.runtime.telemetry_writer.write_event(message, Constants.TelemetryEventLevel.Error, task_name)
+        new_events = os.listdir(self.runtime.telemetry_writer.events_folder_path)
+        self.assertEquals(old_events, new_events)
+        latest_event_file = [pos_json for pos_json in os.listdir(self.runtime.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)][-1]
+        with open(os.path.join(self.runtime.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:
+            events = json.load(f)
+            self.assertTrue(events is not None)
+            self.assertTrue(task_name not in events[0]['TaskName'])
+            f.close()
+
+    def test_write_to_new_file_if_event_file_limit_reached(self):
+        self.runtime.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task")
+        os_path_exists_backup = os.path.exists
+        os.path.exists = self.mock_os_path_exists
+        telemetry_get_event_file_size_backup = self.runtime.telemetry_writer.get_file_size
+        self.runtime.telemetry_writer.get_file_size = self.mock_get_file_size
+
+        self.runtime.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task2")
+        events = os.listdir(self.runtime.telemetry_writer.events_folder_path)
+        self.assertTrue(len(events) > 1)
+        os.path.exists = os_path_exists_backup
+        self.runtime.telemetry_writer.get_file_size = telemetry_get_event_file_size_backup
+
+    def test_delete_older_events(self):
+
+        # deleting older event files before adding new one
+        self.runtime.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task")
+        self.runtime.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task2")
+        self.runtime.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task3")
+        old_events = [pos_json for pos_json in os.listdir(self.runtime.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)]
+        telemetry_dir_size_backup = Constants.TELEMETRY_DIR_SIZE_LIMIT_IN_BYTES
+        Constants.TELEMETRY_DIR_SIZE_LIMIT_IN_BYTES = 1030
+        telemetry_event_size_backup = Constants.TELEMETRY_EVENT_FILE_SIZE_LIMIT_IN_BYTES
+        Constants.TELEMETRY_EVENT_FILE_SIZE_LIMIT_IN_BYTES = 1024
+
+        self.runtime.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task4")
+        new_events = [pos_json for pos_json in os.listdir(self.runtime.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)]
+        self.assertEquals(len(new_events), 1)
+        self.assertTrue(old_events[0] not in new_events)
+        Constants.TELEMETRY_DIR_SIZE_LIMIT_IN_BYTES = telemetry_dir_size_backup
+        Constants.TELEMETRY_EVENT_FILE_SIZE_LIMIT_IN_BYTES = telemetry_event_size_backup
+
+        # error while deleting event files where the directory size exceeds limit even after deletion attempts
+        self.runtime.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task")
+        self.runtime.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task2")
+        self.runtime.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task3")
+        old_events = [pos_json for pos_json in os.listdir(self.runtime.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)]
+        telemetry_dir_size_backup = Constants.TELEMETRY_DIR_SIZE_LIMIT_IN_BYTES
+        Constants.TELEMETRY_DIR_SIZE_LIMIT_IN_BYTES = 500
+        telemetry_event_size_backup = Constants.TELEMETRY_EVENT_FILE_SIZE_LIMIT_IN_BYTES
+        Constants.TELEMETRY_EVENT_FILE_SIZE_LIMIT_IN_BYTES = 400
+        os_remove_backup = os.remove
+        os.remove = self.mock_os_remove
+
+        self.assertRaises(Exception, lambda: self.runtime.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task4"))
+
+        Constants.TELEMETRY_DIR_SIZE_LIMIT_IN_BYTES = telemetry_dir_size_backup
+        Constants.TELEMETRY_EVENT_FILE_SIZE_LIMIT_IN_BYTES = telemetry_event_size_backup
+        os.remove = os_remove_backup
 
 
 if __name__ == '__main__':

--- a/src/core/tests/TestYumPackageManager.py
+++ b/src/core/tests/TestYumPackageManager.py
@@ -97,9 +97,6 @@ class TestYumPackageManager(unittest.TestCase):
         size = package_manager.get_package_size(out)
         self.assertEqual(size, "735 k")
 
-        telemetry_writer = self.container.get('telemetry_writer')
-        telemetry_writer.close_transports()
-
         # test for all available versions
         package_versions = package_manager.get_all_available_versions_of_package("kernel")
         self.assertEqual(len(package_versions), 7)

--- a/src/core/tests/TestZypperPackageManager.py
+++ b/src/core/tests/TestZypperPackageManager.py
@@ -105,9 +105,6 @@ class TestZypperPackageManager(unittest.TestCase):
         size = package_manager.get_package_size(out)
         self.assertEqual(size, "810.9 KiB")
 
-        telemetry_writer = self.container.get('telemetry_writer')
-        telemetry_writer.close_transports()
-
         # test for get_dependent_list
         # legacy_test_type ='Happy Path'
         dependent_list = package_manager.get_dependent_list("man")

--- a/src/core/tests/library/ArgumentComposer.py
+++ b/src/core/tests/library/ArgumentComposer.py
@@ -36,7 +36,7 @@ class ArgumentComposer(object):
         self.sequence_number = 1
 
         # environment settings
-        self.__log_folder = self.__config_folder = self.__status_folder = self.__events_folder = self.__get_scratch_folder()
+        self.__log_folder = self.__config_folder = self.__status_folder = self.events_folder = self.__get_scratch_folder()
 
         # config settings
         self.operation = Constants.INSTALLATION
@@ -58,7 +58,7 @@ class ArgumentComposer(object):
             "logFolder": self.__log_folder,
             "configFolder": self.__config_folder,
             "statusFolder": self.__status_folder,
-            "eventsFolder": self.__events_folder
+            "eventsFolder": self.events_folder
         }
 
         config_settings = {

--- a/src/core/tests/library/RuntimeCompositor.py
+++ b/src/core/tests/library/RuntimeCompositor.py
@@ -51,6 +51,7 @@ class RuntimeCompositor(object):
 
         # Business logic components
         self.execution_config = self.container.get('execution_config')
+        self.telemetry_writer.setup_telemetry(self.execution_config)
         self.package_manager = self.container.get('package_manager')
         self.reboot_manager = self.container.get('reboot_manager')
         self.reconfigure_reboot_manager()
@@ -63,7 +64,6 @@ class RuntimeCompositor(object):
         self.write_ext_state_file(self.lifecycle_manager.ext_state_file_path, self.execution_config.sequence_number, datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ"), self.execution_config.operation)
 
     def stop(self):
-        # self.telemetry_writer.close_transports()
         self.file_logger.close(message_at_close="<Runtime stopped>")
         self.container.reset()
 

--- a/src/core/tests/library/RuntimeCompositor.py
+++ b/src/core/tests/library/RuntimeCompositor.py
@@ -47,6 +47,7 @@ class RuntimeCompositor(object):
         self.container = bootstrapper.build_out_container()
         self.file_logger = bootstrapper.file_logger
         self.composite_logger = bootstrapper.composite_logger
+        self.telemetry_writer = bootstrapper.telemetry_writer
         self.lifecycle_manager, self.status_handler = bootstrapper.build_core_components(self.container)
 
         # Business logic components

--- a/src/core/tests/library/RuntimeCompositor.py
+++ b/src/core/tests/library/RuntimeCompositor.py
@@ -63,7 +63,7 @@ class RuntimeCompositor(object):
         self.write_ext_state_file(self.lifecycle_manager.ext_state_file_path, self.execution_config.sequence_number, datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ"), self.execution_config.operation)
 
     def stop(self):
-        self.telemetry_writer.close_transports()
+        # self.telemetry_writer.close_transports()
         self.file_logger.close(message_at_close="<Runtime stopped>")
         self.container.reset()
 

--- a/src/core/tests/library/RuntimeCompositor.py
+++ b/src/core/tests/library/RuntimeCompositor.py
@@ -47,11 +47,10 @@ class RuntimeCompositor(object):
         self.container = bootstrapper.build_out_container()
         self.file_logger = bootstrapper.file_logger
         self.composite_logger = bootstrapper.composite_logger
-        self.lifecycle_manager, self.telemetry_writer, self.status_handler = bootstrapper.build_core_components(self.container)
+        self.lifecycle_manager, self.status_handler = bootstrapper.build_core_components(self.container)
 
         # Business logic components
         self.execution_config = self.container.get('execution_config')
-        self.telemetry_writer.setup_telemetry(self.execution_config)
         self.package_manager = self.container.get('package_manager')
         self.reboot_manager = self.container.get('reboot_manager')
         self.reconfigure_reboot_manager()

--- a/src/extension/src/ActionHandler.py
+++ b/src/extension/src/ActionHandler.py
@@ -86,10 +86,10 @@ class ActionHandler(object):
         # check if events folder exists, if it does init telemetry, if events folder does not exist, log that telemetry is not supported by agent since events folder does not exist
         events_folder = self.ext_env_handler.events_folder
         if events_folder is None or not os.path.exists(events_folder):
-            err_msg = "The minimum Azure Linux Agent version prerequisite for Linux patching was not met. Please update the Azure Linux Agent on this machine. \n"
+            err_msg = Constants.TELEMETRY_AT_AGENT_NOT_COMPATIBLE_ERROR_MSG
             self.logger.log_error(err_msg)
         else:
-            self.logger.log("The minimum Azure Linux Agent version prerequisite for Linux patching was met.")
+            self.logger.log(Constants.TELEMETRY_AT_AGENT_COMPATIBLE_MSG)
             self.telemetry_writer.events_folder_path = events_folder
             # As this is a common function used by all handler actions, setting operation_id such that it will be the same timestamp for all handler actions, which can be used for identifying all events for an operation.
             # NOTE: Enable handler action will set operation_id to activity_id from config settings. And the same will be used in Core.

--- a/src/extension/src/Constants.py
+++ b/src/extension/src/Constants.py
@@ -66,6 +66,8 @@ class Constants(object):
     TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_BYTES = 80  # buffer for the bytes dropped text added at the end of the truncated telemetry message
 
     TELEMETRY_ENABLED_AT_EXTENSION = True
+    TELEMETRY_AT_AGENT_NOT_COMPATIBLE_ERROR_MSG = "The minimum Azure Linux Agent version prerequisite for Linux patching was not met. Please update the Azure Linux Agent on this machine following instructions here: http://aka.ms/UpdateLinuxAgent"
+    TELEMETRY_AT_AGENT_COMPATIBLE_MSG = "The minimum Azure Linux Agent version prerequisite for Linux patching was met."
 
     # Telemetry Event Level
     class TelemetryEventLevel(EnumBackport):

--- a/src/extension/src/local_loggers/Logger.py
+++ b/src/extension/src/local_loggers/Logger.py
@@ -92,7 +92,6 @@ class Logger(object):
 
     def log_telemetry_module_error(self, message):
         """Used exclusively by telemetry writer to log any errors raised within it's operation"""
-        message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
         message = (self.NEWLINE_REPLACE_CHAR.join(message.split(os.linesep))).strip()
         if self.file_logger is not None:
             self.file_logger.write("\n" + self.TELEMETRY_ERROR + " " + message)
@@ -101,7 +100,6 @@ class Logger(object):
 
     def log_telemetry_module(self, message):
         """Used exclusively by telemetry writer to log messages from it's operation"""
-        message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
         message = (self.NEWLINE_REPLACE_CHAR.join(message.split(os.linesep))).strip()
         if self.file_logger is not None:
             self.file_logger.write("\n" + self.TELEMETRY_LOG + " " + message)


### PR DESCRIPTION
Basic telemetry guidelines to consider:

1. Write events (i.e. logs) to json file/s
2. Event is a json structure
3. One file can have multiple events. There can be multiple event files. It is up to the extension on how to write event and event files. We are creating new event files/ms
4. Size restrictions as defined in Constants.py. Agent will check for these limitations, but good to check them at our end as well.
5. Agent will pick up the latest event files/5 mins. (Latest to avoid missing recent data in case the events exceed limit and some have to be deleted)

- Also, contains a telemetry on/off switch at extension
- Adds a telemetry event counter at the end of every message written to telemetry

Tested locally by manually enabling agent's telemetry pipeline on a VM

ToDo:
- [x] Fix unit tests