### PR TITLE
Fixing failing unit tests in python 3

### DIFF
--- a/src/core/src/bootstrap/EnvLayer.py
+++ b/src/core/src/bootstrap/EnvLayer.py
@@ -157,9 +157,9 @@ class EnvLayer(object):
     @staticmethod
     def __convert_process_output_to_ascii(output):
         if sys.version_info.major == 2:
-            return output.decode('utf8', 'ignore').encode("ascii", "ignore")
+            return output.decode('utf8', 'ignore').encode('ascii', 'ignore')
         elif sys.version_info.major == 3:
-            return output.encode("ascii", "ignore")
+            return output.decode('utf8', 'ignore')
         else:
             raise Exception("Unknown version of python encountered.")
 

--- a/src/core/tests/library/RuntimeCompositor.py
+++ b/src/core/tests/library/RuntimeCompositor.py
@@ -18,6 +18,8 @@ import datetime
 import json
 import os
 import time
+
+from core.src.service_interfaces.TelemetryWriter import TelemetryWriter
 from core.tests.library.ArgumentComposer import ArgumentComposer
 from core.tests.library.LegacyEnvLayerExtensions import LegacyEnvLayerExtensions
 from core.src.bootstrap.Bootstrapper import Bootstrapper
@@ -47,7 +49,12 @@ class RuntimeCompositor(object):
         self.container = bootstrapper.build_out_container()
         self.file_logger = bootstrapper.file_logger
         self.composite_logger = bootstrapper.composite_logger
-        self.telemetry_writer = bootstrapper.telemetry_writer
+
+        # re-initializing telemetry_writer, outside of Bootstrapper, to correctly set the env_layer configured for tests
+        self.telemetry_writer = TelemetryWriter(self.env_layer, self.composite_logger, bootstrapper.telemetry_writer.events_folder_path)
+        bootstrapper.telemetry_writer = self.telemetry_writer
+        bootstrapper.composite_logger.telemetry_writer = self.telemetry_writer
+
         self.lifecycle_manager, self.status_handler = bootstrapper.build_core_components(self.container)
 
         # Business logic components


### PR DESCRIPTION
Tests were failing in python 3 due to the datatype (bytes) returned from subprocess.communicate() as opposed to str in python 2. __convert_process_output_to_ascii() returns a str for python 2, even with encode('ascii', 'ignore). Modified the code to return str for python 3 as well, since output, returned by running any command, is processed as a str in all places it is consumed in the code

This was identified due to:
- Telemetry_writer writes machine_config_info during init. which is fetched using the cmd: "cat /proc/cpuinfo | grep name" 
- In our test setup, the mock(LegacyEnvLayerExtensions) for this command is set to always return a str
-  But this mock is set after telemetry_writer is initialized (in Bootstrapper), and hence the mock was never used for fetching machine_config_info, thereby returning bytes type that was not handled correctly.

Modified the test setup to use mocks for telemetry_writer as well. 
NOTE: Since telemetry_writer is first initialized within Bootstrapper, it will always run the command, to get machine config info, once without mock and then run it with mock, on explicit init in RuntimeCompositor.

Tested on Azure VM with python 2.7 and python 3.6. All test results attached in bug # 9448869