### PR TITLE
Bug fix for telemetry event count throttle

### DIFF
--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -177,8 +177,8 @@ class Constants(object):
     TELEMETRY_DIR_SIZE_LIMIT_IN_CHARS = 41943040
     TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_CHARS = 25  # buffer for the chars dropped text added at the end of the truncated telemetry message
     TELEMETRY_EVENT_COUNTER_MSG_SIZE_LIMIT_IN_CHARS = 15  # buffer for telemetry event counter text added at the end of every message sent to telemetry
-    TELEMETRY_MAX_EVENT_FILE_THROTTLE_COUNT = 60
-    TELEMETRY_MAX_TIME_IN_SECONDS_FOR_EVENT_FILE_THROTTLE = 60
+    TELEMETRY_MAX_EVENT_COUNT_THROTTLE = 60
+    TELEMETRY_MAX_TIME_IN_SECONDS_FOR_EVENT_COUNT_THROTTLE = 60
 
     # Telemetry Event Level
     class TelemetryEventLevel(EnumBackport):

--- a/src/core/src/core_logic/RebootManager.py
+++ b/src/core/src/core_logic/RebootManager.py
@@ -83,6 +83,7 @@ class RebootManager(object):
                 raise Exception(error_msg, "[{0}]".format(Constants.ERROR_ADDED_TO_STATUS))
             else:
                 self.composite_logger.log_debug("Waiting for machine reboot. [ElapsedTimeInMinutes={0}] [MaxTimeInMinutes={1}]".format(str(elapsed_time_in_minutes), str(max_allowable_time_to_reboot_in_minutes)))
+                self.composite_logger.file_logger.flush()
                 time.sleep(60)
 
     def start_reboot_if_required_and_time_available(self, current_time_available):

--- a/src/core/src/local_loggers/FileLogger.py
+++ b/src/core/src/local_loggers/FileLogger.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 # Requires Python 2.7+
-
+import os
 import sys
 
 
@@ -40,7 +40,6 @@ class FileLogger(object):
         try:
             if self.log_file_handle is not None:
                 self.log_file_handle.write(message)
-                self.flush()
         except Exception as error:
             # DO NOT write any errors here to stdout
             failure_message = "Fatal exception trying to write to log file: " + repr(error) + ". Attempted message: " + str(message)
@@ -55,11 +54,12 @@ class FileLogger(object):
                 timestamp = self.env_layer.datetime.timestamp()
                 fail_log.write("\n" + timestamp + "> " + message)
         except Exception:
-           pass
+            pass
 
     def flush(self):
         if self.log_file_handle is not None:
             self.log_file_handle.flush()
+            os.fsync(self.log_file_handle.fileno())
 
     def close(self, message_at_close='<Log file was closed.>'):
         if self.log_file_handle is not None:

--- a/src/core/src/local_loggers/FileLogger.py
+++ b/src/core/src/local_loggers/FileLogger.py
@@ -40,6 +40,7 @@ class FileLogger(object):
         try:
             if self.log_file_handle is not None:
                 self.log_file_handle.write(message)
+                self.flush()
         except Exception as error:
             # DO NOT write any errors here to stdout
             failure_message = "Fatal exception trying to write to log file: " + repr(error) + ". Attempted message: " + str(message)

--- a/src/core/src/service_interfaces/TelemetryWriter.py
+++ b/src/core/src/service_interfaces/TelemetryWriter.py
@@ -214,10 +214,10 @@ class TelemetryWriter(object):
             return
 
         if (datetime.datetime.utcnow() - self.start_time_for_event_count_throttle_check).total_seconds() < Constants.TELEMETRY_MAX_TIME_IN_SECONDS_FOR_EVENT_COUNT_THROTTLE:
-            # If event file count limit reached before time period, wait out the remaining time. Checking against one less than max limit to allow room for writing a throttling msg to telemetry
+            # If event count limit reached before time period, wait out the remaining time. Checking against one less than max limit to allow room for writing a throttling msg to telemetry
             if self.event_count >= Constants.TELEMETRY_MAX_EVENT_COUNT_THROTTLE - 1:
-                end_time_for_event_file_throttle = self.start_time_for_event_count_throttle_check + datetime.timedelta(seconds=Constants.TELEMETRY_MAX_TIME_IN_SECONDS_FOR_EVENT_COUNT_THROTTLE)
-                time_to_wait_in_secs = (end_time_for_event_file_throttle - datetime.datetime.utcnow()).total_seconds()
+                end_time_for_event_count_throttle_check = self.start_time_for_event_count_throttle_check + datetime.timedelta(seconds=Constants.TELEMETRY_MAX_TIME_IN_SECONDS_FOR_EVENT_COUNT_THROTTLE)
+                time_to_wait_in_secs = (end_time_for_event_count_throttle_check - datetime.datetime.utcnow()).total_seconds()
                 event_write_throttled_msg = "Max telemetry event file limit reached. Extension will wait until a telemetry event file can be written again. [WaitTimeInSecs={0}]".format(str(time_to_wait_in_secs))
                 self.composite_logger.log_telemetry_module(event_write_throttled_msg)
                 self.write_event(message=event_write_throttled_msg, event_level=Constants.TelemetryEventLevel.Informational, is_event_file_throttling_needed=False)

--- a/src/core/tests/TestTelemetryWriter.py
+++ b/src/core/tests/TestTelemetryWriter.py
@@ -50,8 +50,8 @@ class TestTelemetryWriter(unittest.TestCase):
         with open(os.path.join(self.runtime.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:
             events = json.load(f)
             self.assertTrue(events is not None)
-            self.assertEquals(events[0]["TaskName"], "Test Task")
-            text_found = re.search('TC=([0-9]+)', events[0]['Message'])
+            self.assertEquals(events[-1]["TaskName"], "Test Task")
+            text_found = re.search('TC=([0-9]+)', events[-1]['Message'])
             telemetry_event_counter_in_first_test_event = text_found.group(1) if text_found else None
             f.close()
 
@@ -62,7 +62,7 @@ class TestTelemetryWriter(unittest.TestCase):
             events = json.load(f)
             self.assertTrue(events is not None)
             self.assertEquals(events[-1]["TaskName"], "Test Task2")
-            text_found = re.search('TC=([0-9]+)', events[0]['Message'])
+            text_found = re.search('TC=([0-9]+)', events[-1]['Message'])
             telemetry_event_counter_in_second_test_event = text_found.group(1) if text_found else None
             f.close()
 
@@ -79,9 +79,8 @@ class TestTelemetryWriter(unittest.TestCase):
         with open(os.path.join(self.runtime.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:
             events = json.load(f)
             self.assertTrue(events is not None)
-            self.assertEquals(len(events), 2)
-            self.assertEquals(events[0]["TaskName"], "Test Task")
-            self.assertEquals(events[1]["TaskName"], "Test Task2")
+            self.assertEquals(events[-2]["TaskName"], "Test Task")
+            self.assertEquals(events[-1]["TaskName"], "Test Task2")
             f.close()
         time.time = time_backup
 
@@ -93,10 +92,10 @@ class TestTelemetryWriter(unittest.TestCase):
         with open(os.path.join(self.runtime.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:
             events = json.load(f)
             self.assertTrue(events is not None)
-            self.assertEquals(events[0]["TaskName"], "Test Task")
-            self.assertTrue(len(events[0]["Message"]) < len(message.encode('utf-8')))
+            self.assertEquals(events[-1]["TaskName"], "Test Task")
+            self.assertTrue(len(events[-1]["Message"]) < len(message.encode('utf-8')))
             chars_dropped = len(message.encode('utf-8')) - Constants.TELEMETRY_MSG_SIZE_LIMIT_IN_CHARS + Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_CHARS + Constants.TELEMETRY_EVENT_COUNTER_MSG_SIZE_LIMIT_IN_CHARS
-            self.assertTrue("a"*(len(message.encode('utf-8')) - chars_dropped) + ". [{0} chars dropped]".format(chars_dropped) in events[0]["Message"])
+            self.assertTrue("a"*(len(message.encode('utf-8')) - chars_dropped) + ". [{0} chars dropped]".format(chars_dropped) in events[-1]["Message"])
             f.close()
 
     def test_write_event_size_limit(self):
@@ -112,19 +111,22 @@ class TestTelemetryWriter(unittest.TestCase):
         with open(os.path.join(self.runtime.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:
             events = json.load(f)
             self.assertTrue(events is not None)
-            self.assertTrue(task_name not in events[0]['TaskName'])
+            self.assertTrue(task_name not in events[-1]['TaskName'])
             f.close()
 
     def test_write_to_new_file_if_event_file_limit_reached(self):
         self.runtime.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task")
+        first_event_file = [pos_json for pos_json in os.listdir(self.runtime.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)][-1]
         os_path_exists_backup = os.path.exists
         os.path.exists = self.mock_os_path_exists
         telemetry_get_event_file_size_backup = self.runtime.telemetry_writer.get_file_size
         self.runtime.telemetry_writer.get_file_size = self.mock_get_file_size
 
         self.runtime.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task2")
-        events = os.listdir(self.runtime.telemetry_writer.events_folder_path)
-        self.assertTrue(len(events) > 1)
+        event_files = os.listdir(self.runtime.telemetry_writer.events_folder_path)
+        self.assertTrue(len(event_files) > 1)
+        second_event_file = [pos_json for pos_json in os.listdir(self.runtime.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)][-1]
+        self.assertFalse(first_event_file == second_event_file)
         os.path.exists = os_path_exists_backup
         self.runtime.telemetry_writer.get_file_size = telemetry_get_event_file_size_backup
 
@@ -134,16 +136,16 @@ class TestTelemetryWriter(unittest.TestCase):
         self.runtime.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task")
         self.runtime.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task2")
         self.runtime.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task3")
-        old_events = [pos_json for pos_json in os.listdir(self.runtime.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)]
+        old_event_files = [pos_json for pos_json in os.listdir(self.runtime.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)]
         telemetry_dir_size_backup = Constants.TELEMETRY_DIR_SIZE_LIMIT_IN_CHARS
         Constants.TELEMETRY_DIR_SIZE_LIMIT_IN_CHARS = 1030
         telemetry_event_size_backup = Constants.TELEMETRY_EVENT_FILE_SIZE_LIMIT_IN_CHARS
         Constants.TELEMETRY_EVENT_FILE_SIZE_LIMIT_IN_CHARS = 1024
 
         self.runtime.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task4")
-        new_events = [pos_json for pos_json in os.listdir(self.runtime.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)]
-        self.assertEquals(len(new_events), 1)
-        self.assertTrue(old_events[0] not in new_events)
+        new_event_files = [pos_json for pos_json in os.listdir(self.runtime.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)]
+        self.assertEquals(len(new_event_files), 1)
+        self.assertTrue(old_event_files[0] not in new_event_files and old_event_files[1] not in new_event_files and old_event_files[2] not in new_event_files)
         Constants.TELEMETRY_DIR_SIZE_LIMIT_IN_CHARS = telemetry_dir_size_backup
         Constants.TELEMETRY_EVENT_FILE_SIZE_LIMIT_IN_CHARS = telemetry_event_size_backup
 
@@ -151,7 +153,7 @@ class TestTelemetryWriter(unittest.TestCase):
         self.runtime.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task")
         self.runtime.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task2")
         self.runtime.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task3")
-        old_events = [pos_json for pos_json in os.listdir(self.runtime.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)]
+        old_event_files = [pos_json for pos_json in os.listdir(self.runtime.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)]
         telemetry_dir_size_backup = Constants.TELEMETRY_DIR_SIZE_LIMIT_IN_CHARS
         Constants.TELEMETRY_DIR_SIZE_LIMIT_IN_CHARS = 500
         telemetry_event_size_backup = Constants.TELEMETRY_EVENT_FILE_SIZE_LIMIT_IN_CHARS
@@ -167,8 +169,8 @@ class TestTelemetryWriter(unittest.TestCase):
 
     def test_write_event_event_file_max_throttle_reached(self):
         event_file_max_throttle_backup = Constants.TELEMETRY_MAX_EVENT_COUNT_THROTTLE
-        Constants.TELEMETRY_MAX_EVENT_COUNT_THROTTLE = 4
-        self.runtime.telemetry_writer.event_file_count = 0
+        Constants.TELEMETRY_MAX_EVENT_COUNT_THROTTLE = 5
+        self.runtime.telemetry_writer.event_count = 1
         self.runtime.telemetry_writer.start_time_for_event_file_throttle_check = datetime.datetime.utcnow()
 
         self.runtime.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task")
@@ -178,7 +180,7 @@ class TestTelemetryWriter(unittest.TestCase):
         with open(os.path.join(self.runtime.telemetry_writer.events_folder_path, event_file_task3), 'r+') as f:
             events = json.load(f)
             self.assertTrue(events is not None)
-            self.assertTrue("Test Task3" in events[0]['TaskName'])
+            self.assertTrue("Test Task3" in events[-1]['TaskName'])
             f.close()
 
         self.runtime.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task4")
@@ -186,17 +188,17 @@ class TestTelemetryWriter(unittest.TestCase):
         with open(os.path.join(self.runtime.telemetry_writer.events_folder_path, event_file_task4), 'r+') as f:
             events = json.load(f)
             self.assertTrue(events is not None)
-            self.assertTrue("Test Task4" in events[0]['TaskName'])
+            self.assertTrue("Test Task4" in events[-1]['TaskName'])
             f.close()
-        self.assertTrue(self.runtime.telemetry_writer.event_file_count == 1)
+        self.assertTrue(self.runtime.telemetry_writer.event_count == 2)
 
         self.runtime.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task5")
-        self.assertTrue(self.runtime.telemetry_writer.event_file_count == 2)
+        self.assertTrue(self.runtime.telemetry_writer.event_count == 3)
 
         max_time_for_event_file_throttle_backup = Constants.TELEMETRY_MAX_TIME_IN_SECONDS_FOR_EVENT_COUNT_THROTTLE
         Constants.TELEMETRY_MAX_TIME_IN_SECONDS_FOR_EVENT_COUNT_THROTTLE = 0
         self.runtime.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task6")
-        self.assertTrue(self.runtime.telemetry_writer.event_file_count == 1)
+        self.assertTrue(self.runtime.telemetry_writer.event_count == 2)
         Constants.TELEMETRY_MAX_TIME_IN_SECONDS_FOR_EVENT_COUNT_THROTTLE = max_time_for_event_file_throttle_backup
 
         Constants.TELEMETRY_MAX_EVENT_COUNT_THROTTLE = event_file_max_throttle_backup

--- a/src/core/tests/TestTelemetryWriter.py
+++ b/src/core/tests/TestTelemetryWriter.py
@@ -167,11 +167,11 @@ class TestTelemetryWriter(unittest.TestCase):
         Constants.TELEMETRY_EVENT_FILE_SIZE_LIMIT_IN_CHARS = telemetry_event_size_backup
         os.remove = os_remove_backup
 
-    def test_write_event_event_file_max_throttle_reached(self):
-        event_file_max_throttle_backup = Constants.TELEMETRY_MAX_EVENT_COUNT_THROTTLE
+    def test_write_event_max_event_count_throttle_reached(self):
+        event_count_max_throttle_backup = Constants.TELEMETRY_MAX_EVENT_COUNT_THROTTLE
         Constants.TELEMETRY_MAX_EVENT_COUNT_THROTTLE = 5
         self.runtime.telemetry_writer.event_count = 1
-        self.runtime.telemetry_writer.start_time_for_event_file_throttle_check = datetime.datetime.utcnow()
+        self.runtime.telemetry_writer.start_time_for_event_count_throttle_check = datetime.datetime.utcnow()
 
         self.runtime.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task")
         self.runtime.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task2")
@@ -195,13 +195,13 @@ class TestTelemetryWriter(unittest.TestCase):
         self.runtime.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task5")
         self.assertTrue(self.runtime.telemetry_writer.event_count == 3)
 
-        max_time_for_event_file_throttle_backup = Constants.TELEMETRY_MAX_TIME_IN_SECONDS_FOR_EVENT_COUNT_THROTTLE
+        max_time_for_event_count_throttle_backup = Constants.TELEMETRY_MAX_TIME_IN_SECONDS_FOR_EVENT_COUNT_THROTTLE
         Constants.TELEMETRY_MAX_TIME_IN_SECONDS_FOR_EVENT_COUNT_THROTTLE = 0
         self.runtime.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task6")
         self.assertTrue(self.runtime.telemetry_writer.event_count == 2)
-        Constants.TELEMETRY_MAX_TIME_IN_SECONDS_FOR_EVENT_COUNT_THROTTLE = max_time_for_event_file_throttle_backup
+        Constants.TELEMETRY_MAX_TIME_IN_SECONDS_FOR_EVENT_COUNT_THROTTLE = max_time_for_event_count_throttle_backup
 
-        Constants.TELEMETRY_MAX_EVENT_COUNT_THROTTLE = event_file_max_throttle_backup
+        Constants.TELEMETRY_MAX_EVENT_COUNT_THROTTLE = event_count_max_throttle_backup
 
 
 if __name__ == '__main__':

--- a/src/core/tests/TestTelemetryWriter.py
+++ b/src/core/tests/TestTelemetryWriter.py
@@ -166,8 +166,8 @@ class TestTelemetryWriter(unittest.TestCase):
         os.remove = os_remove_backup
 
     def test_write_event_event_file_max_throttle_reached(self):
-        event_file_max_throttle_backup = Constants.TELEMETRY_MAX_EVENT_FILE_THROTTLE_COUNT
-        Constants.TELEMETRY_MAX_EVENT_FILE_THROTTLE_COUNT = 4
+        event_file_max_throttle_backup = Constants.TELEMETRY_MAX_EVENT_COUNT_THROTTLE
+        Constants.TELEMETRY_MAX_EVENT_COUNT_THROTTLE = 4
         self.runtime.telemetry_writer.event_file_count = 0
         self.runtime.telemetry_writer.start_time_for_event_file_throttle_check = datetime.datetime.utcnow()
 
@@ -193,13 +193,13 @@ class TestTelemetryWriter(unittest.TestCase):
         self.runtime.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task5")
         self.assertTrue(self.runtime.telemetry_writer.event_file_count == 2)
 
-        max_time_for_event_file_throttle_backup = Constants.TELEMETRY_MAX_TIME_IN_SECONDS_FOR_EVENT_FILE_THROTTLE
-        Constants.TELEMETRY_MAX_TIME_IN_SECONDS_FOR_EVENT_FILE_THROTTLE = 0
+        max_time_for_event_file_throttle_backup = Constants.TELEMETRY_MAX_TIME_IN_SECONDS_FOR_EVENT_COUNT_THROTTLE
+        Constants.TELEMETRY_MAX_TIME_IN_SECONDS_FOR_EVENT_COUNT_THROTTLE = 0
         self.runtime.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task6")
         self.assertTrue(self.runtime.telemetry_writer.event_file_count == 1)
-        Constants.TELEMETRY_MAX_TIME_IN_SECONDS_FOR_EVENT_FILE_THROTTLE = max_time_for_event_file_throttle_backup
+        Constants.TELEMETRY_MAX_TIME_IN_SECONDS_FOR_EVENT_COUNT_THROTTLE = max_time_for_event_file_throttle_backup
 
-        Constants.TELEMETRY_MAX_EVENT_FILE_THROTTLE_COUNT = event_file_max_throttle_backup
+        Constants.TELEMETRY_MAX_EVENT_COUNT_THROTTLE = event_file_max_throttle_backup
 
 
 if __name__ == '__main__':

--- a/src/core/tests/library/ArgumentComposer.py
+++ b/src/core/tests/library/ArgumentComposer.py
@@ -31,12 +31,14 @@ class ArgumentComposer(object):
         self.__TESTS_FOLDER = "tests"
         self.__SCRATCH_FOLDER = "scratch"
         self.__ARG_TEMPLATE = "{0} {1} {2} {3} \'{4}\' {5} \'{6}\'"
+        self.__EVENTS_FOLDER = "events"
 
         # sequence number
         self.sequence_number = 1
 
         # environment settings
-        self.__log_folder = self.__config_folder = self.__status_folder = self.events_folder = self.__get_scratch_folder()
+        self.__log_folder = self.__config_folder = self.__status_folder = self.__get_scratch_folder()
+        self.events_folder = self.__get_events_folder(self.__log_folder)
 
         # config settings
         self.operation = Constants.INSTALLATION
@@ -47,7 +49,7 @@ class ArgumentComposer(object):
         self.classifications_to_include = []
         self.patches_to_include = []
         self.patches_to_exclude = []
-        self.maintenance_run_id = None #Since this is optional, all possible inputs for this are added in respective tests
+        self.maintenance_run_id = None  # Since this is optional, all possible inputs for this are added in respective tests
 
         # REAL environment settings
         self.emulator_enabled = False
@@ -92,6 +94,15 @@ class ArgumentComposer(object):
         if not os.path.exists(scratch_folder):
             os.mkdir(scratch_folder)
         return scratch_folder
+
+    def __get_events_folder(self, scratch_folder):
+        """ Returns a predetermined events folder and guarantees it exists and is empty. """
+        events_folder = os.path.join(scratch_folder, self.__EVENTS_FOLDER)
+        if os.path.exists(events_folder):
+            shutil.rmtree(events_folder, ignore_errors=True)
+        if not os.path.exists(events_folder):
+            os.mkdir(events_folder)
+        return events_folder
 
     def __try_get_tests_folder(self, path=os.getcwd()):
         """ Returns the current working directory if there's no folder with tests in its name in the absolute path

--- a/src/extension/src/local_loggers/FileLogger.py
+++ b/src/extension/src/local_loggers/FileLogger.py
@@ -74,6 +74,7 @@ class FileLogger(object):
         try:
             if self.log_file_handle is not None:
                 self.log_file_handle.write(message)
+                self.flush()
             else:
                 raise Exception("Log file not found")
         except IOError:

--- a/src/extension/src/local_loggers/FileLogger.py
+++ b/src/extension/src/local_loggers/FileLogger.py
@@ -74,7 +74,6 @@ class FileLogger(object):
         try:
             if self.log_file_handle is not None:
                 self.log_file_handle.write(message)
-                self.flush()
             else:
                 raise Exception("Log file not found")
         except IOError:
@@ -89,6 +88,7 @@ class FileLogger(object):
     def flush(self):
         if self.log_file_handle is not None:
             self.log_file_handle.flush()
+            os.fsync(self.log_file_handle.fileno())
 
     def close(self):
         if self.log_file_handle is not None:


### PR DESCRIPTION
Contains

- bug fix for telemetry event count throttle which lead to events being discarded by Guest Agent
- Added flush in file logger to ensure logs are written immediately to the file

NOTE: Since we only have throttling in Core (not added to Handler since there is a time restriction for handler commands at Agent), 

- events written by Handler are not included in this throttling. 
- And since throttling only considers events being written by the current Core process, any events written before by another Core process or by other Handler commands are not included.

This may lead to those older events being discarded by Guest Agent incase the event count > 300.

Tested on different VMs, links to the test results to be added in the ticket # 9431121