### PR TITLE
Bug fix for core not working in python 3

### DIFF
--- a/src/core/src/bootstrap/EnvLayer.py
+++ b/src/core/src/bootstrap/EnvLayer.py
@@ -96,12 +96,18 @@ class EnvLayer(object):
         Reports exceptions to Error if chk_err parameter is True
         """
 
-        def check_output(no_output, *popenargs, **kwargs):
+        def check_output(*popenargs, **kwargs):
             """
             Backport from subprocess module from python 2.7
             """
             if 'stdout' in kwargs:
                 raise ValueError('stdout argument not allowed, it will be overridden.')
+
+            no_output = False
+            if type(popenargs[0]) is bool:
+                no_output = popenargs[0]
+                popenargs = popenargs[1:]
+
             if no_output is True:
                 out_file = None
             else:

--- a/src/core/src/local_loggers/StdOutFileMirror.py
+++ b/src/core/src/local_loggers/StdOutFileMirror.py
@@ -18,6 +18,7 @@
 If the log file language is set to 'Python' in Notepad++, with code as implemented below, useful collapsibility is obtained."""
 import sys
 
+
 class StdOutFileMirror(object):
     """Mirrors all terminal output to a local file"""
 

--- a/src/extension/src/ProcessHandler.py
+++ b/src/extension/src/ProcessHandler.py
@@ -114,12 +114,18 @@ class ProcessHandler(object):
         Reports exceptions to Error if chk_err parameter is True
         """
 
-        def check_output(no_output, *popenargs, **kwargs):
+        def check_output(*popenargs, **kwargs):
             """
             Backport from subprocess module from python 2.7
             """
             if 'stdout' in kwargs:
                 raise ValueError('stdout argument not allowed, it will be overridden.')
+
+            no_output = False
+            if type(popenargs[0]) is bool:
+                no_output = popenargs[0]
+                popenargs = popenargs[1:]
+
             if no_output is True:
                 out_file = None
             else:


### PR DESCRIPTION
**Current implementation in extension**:
We have overridden check_output() from subprocess module, based on it's implementation in python 2.7's dependency. We add no_output to the func's arg, and set stdout for Popen based on no_output.

**What was happening**:
**Python3**:
In telemetry writer init, we write 'machine_arch': str(self.env_layer.platform.machine()), as one of the configs. Now for python3, platform.machine() subsequently calls subprocess.check_output() with cmd ('uname', '-p'). Since, we have overridden check_output(), our function now expects 3 args def check_output(no_output, *popenargs, **kwargs)But this internal call only passes *popenargs and **kwargs. Because of the arg order, the value meant for *popenargs (i.e. ('uname', '-p')) is captured in no_output and *popenargs remains empty, which is then passed to subprocess.Popen() and hence the missing positional arg error for subprocess.Popen().

**Python2**:
Platform.machine() does not call check_output and hence this issue never surfaced there.

This was not caught in tests because we mock run_command_output which is the caller to check_output()

**Fix**:
Changing check_output() override signature to: def check_output(*popenargs, **kwargs): and checking for no_output within *popenargs, if found using that for the existing stdout functionality and removing that from popenargs passed to subprocess.Popen

**Question**:
Since check_output() override was taken from python 2.7, do we need a similar one for python 3? Since the implementation is slightly different in these versions

**Python 2.7**:
def check_output(*popenargs, **kwargs):
    r"""Run command with arguments and return its output as a byte string.

    If the exit code was non-zero it raises a CalledProcessError.  The
    CalledProcessError object will have the return code in the returncode
    attribute and output in the output attribute.

    The arguments are the same as for the Popen constructor.  Example:

    >>> check_output(["ls", "-l", "/dev/null"])
    'crw-rw-rw- 1 root root 1, 3 Oct 18  2007 /dev/null\n'

    The stdout argument is not allowed as it is used internally.
    To capture standard error in the result, use stderr=STDOUT.

    >>> check_output(["/bin/sh", "-c",
    ...               "ls -l non_existent_file ; exit 0"],
    ...              stderr=STDOUT)
    'ls: non_existent_file: No such file or directory\n'
    """
    if 'stdout' in kwargs:
        raise ValueError('stdout argument not allowed, it will be overridden.')
    process = **Popen**(stdout=PIPE, *popenargs, **kwargs)
    output, unused_err = process.communicate()
    retcode = process.poll()
    if retcode:
        cmd = kwargs.get("args")
        if cmd is None:
            cmd = popenargs[0]
        raise CalledProcessError(retcode, cmd, output=output)
    return output


**Python 3.8**:
def check_output(*popenargs, timeout=None, **kwargs):
    r"""Run command with arguments and return its output.

    If the exit code was non-zero it raises a CalledProcessError.  The
    CalledProcessError object will have the return code in the returncode
    attribute and output in the output attribute.

    The arguments are the same as for the Popen constructor.  Example:

    >>> check_output(["ls", "-l", "/dev/null"])
    b'crw-rw-rw- 1 root root 1, 3 Oct 18  2007 /dev/null\n'

    The stdout argument is not allowed as it is used internally.
    To capture standard error in the result, use stderr=STDOUT.

    >>> check_output(["/bin/sh", "-c",
    ...               "ls -l non_existent_file ; exit 0"],
    ...              stderr=STDOUT)
    b'ls: non_existent_file: No such file or directory\n'

    There is an additional optional argument, "input", allowing you to
    pass a string to the subprocess's stdin.  If you use this argument
    you may not also use the Popen constructor's "stdin" argument, as
    it too will be used internally.  Example:

    >>> check_output(["sed", "-e", "s/foo/bar/"],
    ...              input=b"when in the course of fooman events\n")
    b'when in the course of barman events\n'

    By default, all communication is in bytes, and therefore any "input"
    should be bytes, and the return value will be bytes.  If in text mode,
    any "input" should be a string, and the return value will be a string
    decoded according to locale encoding, or by "encoding" if set. Text mode
    is triggered by setting any of text, encoding, errors or universal_newlines.
    """
    if 'stdout' in kwargs:
        raise ValueError('stdout argument not allowed, it will be overridden.')

    if 'input' in kwargs and kwargs['input'] is None:
        # Explicitly passing input=None was previously equivalent to passing an
        # empty string. That is maintained here for backwards compatibility.
        if kwargs.get('universal_newlines') or kwargs.get('text'):
            empty = ''
        else:
            empty = b''
        kwargs['input'] = empty

    return **run**(*popenargs, stdout=PIPE, timeout=timeout, check=True,
               **kwargs).stdout

NOTE: **run then calls subprocess.Popen**
