### PR TITLE
Addressing configure patching requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ NoOperation can be used to cancel an ongoing assess or patch operation. (**requi
 (**optional for all operations**)
 * `patchesToExclude`: packages to exclude during the operation. Package names and versions are supported (both with wildcards) 
 (**optional for all operations**)
+* `patchMode`: is a setting that will be used to configure the automatic update by OS. Acceptable values: "ImageDefault" or "AutomaticByPlatform"
 
 > Example:
 >

--- a/src/core/src/CoreMain.py
+++ b/src/core/src/CoreMain.py
@@ -45,6 +45,7 @@ class CoreMain(object):
 
             # Current operation in status handler is set to either assessment or installation when these operations begin. Setting it to assessment since that is the first operation that runs always.
             # This ensures all errors occurring before assessment starts are logged within the error objects of assessment substatus
+            #ToDo: check with Koshy on what this should be
             if status_handler.get_current_operation() is None:
                 status_handler.set_current_operation(Constants.ASSESSMENT)
 

--- a/src/core/src/CoreMain.py
+++ b/src/core/src/CoreMain.py
@@ -45,9 +45,8 @@ class CoreMain(object):
 
             # Current operation in status handler is set to either assessment or installation when these operations begin. Setting it to assessment since that is the first operation that runs always.
             # This ensures all errors occurring before assessment starts are logged within the error objects of assessment substatus
-            #ToDo: check on what this should be
             if status_handler.get_current_operation() is None:
-                status_handler.set_current_operation(Constants.ASSESSMENT)
+                status_handler.set_current_operation(Constants.ASSESSMENT)  # Needs to be revisited
 
             # Environment startup
             bootstrapper.bootstrap_splash_text()

--- a/src/core/src/CoreMain.py
+++ b/src/core/src/CoreMain.py
@@ -134,7 +134,7 @@ class CoreMain(object):
             composite_logger.log_debug('  -- Persisted failed installation substatus.')
         #todo: Q to reviewer/team, if configure patching fails for a patch installation request, do we just report patch installation summary as failed or also assessment summary?
         # Right now, it reports both assessment and installation summary as failed and adds error message in each that the failure is due to configure patching
-        if not patch_assessment_successful:
+        if not patch_assessment_successful and patch_operation_requested != Constants.CONFIGURE_PATCHING.lower():
             status_handler.set_current_operation(Constants.ASSESSMENT)
             if not configure_patching_successful:
                 status_handler.add_error_to_status("Assessment failed due to configure patching failure. Please refer the error details in configure patching substatus")

--- a/src/core/src/CoreMain.py
+++ b/src/core/src/CoreMain.py
@@ -45,7 +45,7 @@ class CoreMain(object):
 
             # Current operation in status handler is set to either assessment or installation when these operations begin. Setting it to assessment since that is the first operation that runs always.
             # This ensures all errors occurring before assessment starts are logged within the error objects of assessment substatus
-            #ToDo: check with Koshy on what this should be
+            #ToDo: check on what this should be
             if status_handler.get_current_operation() is None:
                 status_handler.set_current_operation(Constants.ASSESSMENT)
 

--- a/src/core/src/CoreMain.py
+++ b/src/core/src/CoreMain.py
@@ -82,7 +82,7 @@ class CoreMain(object):
                 patch_assessment_successful = patch_assessor.start_assessment()
 
                 # PatchInstallationSummary to be marked as completed successfully only after the implicit (i.e. 2nd) assessment is completed, as per CRP's restrictions
-                if patch_assessment_successful and patch_installation_successful and configure_patching_successful:
+                if patch_assessment_successful and patch_installation_successful:
                     patch_installer.mark_installation_completed()
                     overall_patch_installation_operation_successful = True
 
@@ -127,18 +127,14 @@ class CoreMain(object):
     def update_patch_substatus_if_pending(patch_operation_requested, overall_patch_installation_operation_successful, patch_assessment_successful, configure_patching_successful, status_handler, composite_logger):
         if patch_operation_requested == Constants.INSTALLATION.lower() and not overall_patch_installation_operation_successful:
             status_handler.set_current_operation(Constants.INSTALLATION)
-            if not configure_patching_successful:
-                status_handler.add_error_to_status("Installation failed due to configure patching failure. Please refer the error details in configure patching substatus")
-            elif not patch_assessment_successful:
+            if not patch_assessment_successful:
                 status_handler.add_error_to_status("Installation failed due to assessment failure. Please refer the error details in assessment substatus")
             status_handler.set_installation_substatus_json(status=Constants.STATUS_ERROR)
             composite_logger.log_debug('  -- Persisted failed installation substatus.')
-        #todo: Q to reviewer/team, if configure patching fails for a patch installation request, do we just report patch installation summary as failed or also assessment summary?
-        # Right now, it reports both assessment and installation summary as failed and adds error message in each that the failure is due to configure patching
         if not patch_assessment_successful and patch_operation_requested != Constants.CONFIGURE_PATCHING.lower():
-            status_handler.set_current_operation(Constants.ASSESSMENT)
-            if not configure_patching_successful:
-                status_handler.add_error_to_status("Assessment failed due to configure patching failure. Please refer the error details in configure patching substatus")
             status_handler.set_assessment_substatus_json(status=Constants.STATUS_ERROR)
             composite_logger.log_debug('  -- Persisted failed assessment substatus.')
+        if not configure_patching_successful:
+            status_handler.set_configure_patching_substatus_json(status=Constants.STATUS_ERROR)
+            composite_logger.log_debug('  -- Persisted failed configure patching substatus.')
 

--- a/src/core/src/bootstrap/ConfigurationFactory.py
+++ b/src/core/src/bootstrap/ConfigurationFactory.py
@@ -20,6 +20,7 @@ import os
 from core.src.bootstrap.Constants import Constants
 from core.src.bootstrap.EnvLayer import EnvLayer
 
+from core.src.core_logic.ConfigurePatching import ConfigurePatching
 from core.src.core_logic.ExecutionConfig import ExecutionConfig
 from core.src.core_logic.MaintenanceWindow import MaintenanceWindow
 from core.src.core_logic.PackageFilter import PackageFilter
@@ -188,6 +189,11 @@ class ConfigurationFactory(object):
             'patch_installer': {
                 'component': PatchInstaller,
                 'component_args': ['env_layer', 'execution_config', 'composite_logger', 'telemetry_writer', 'status_handler', 'lifecycle_manager', 'package_manager', 'package_filter', 'maintenance_window', 'reboot_manager'],
+                'component_kwargs': {}
+            },
+            'configure_patching': {
+                'component': ConfigurePatching,
+                'component_args': ['env_layer', 'execution_config', 'composite_logger', 'telemetry_writer', 'status_handler', 'package_manager'],
                 'component_kwargs': {}
             },
             'maintenance_window': {

--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -62,19 +62,31 @@ class Constants(object):
         PATCHES_TO_INCLUDE = 'patchesToInclude'
         PATCHES_TO_EXCLUDE = 'patchesToExclude'
         MAINTENANCE_RUN_ID = 'maintenanceRunId'
+        PATCH_MODE = 'patchMode'
 
-    # File to save default settings for auto OS updates
+        # File to save default settings for auto OS updates
     IMAGE_DEFAULT_PATCH_CONFIGURATION_BACKUP_PATH = "ImageDefaultPatchConfiguration.bak"
 
     # Operations
     ASSESSMENT = "Assessment"
     INSTALLATION = "Installation"
+    CONFIGURE_PATCHING = "ConfigurePatching"
     PATCH_ASSESSMENT_SUMMARY = "PatchAssessmentSummary"
     PATCH_INSTALLATION_SUMMARY = "PatchInstallationSummary"
     PATCH_METADATA_FOR_HEALTHSTORE = "PatchMetadataForHealthStore"
+    CONFIGURE_PATCHING_SUMMARY = "ConfigurePatchingSummary"
 
     # patch versions for healthstore when there is no maintenance run id
     PATCH_VERSION_UNKNOWN = "UNKNOWN"
+
+    # Patch Modes for Configure Patching
+    DEFAULT_FOR_IMAGE = "DefaultForImage"  # todo: cross check with CRP
+    AUTOMATIC_BY_PLATFORM = "AutomaticByPlatform"
+
+    # automatic OS patch states for configure patching
+    PATCH_STATE_UNKNOWN = "Unknown"
+    PATCH_STATE_DISABLED = "Disabled"
+    PATCH_STATE_ENABLED = "Enabled"
 
     # wait time after status updates
     WAIT_TIME_AFTER_HEALTHSTORE_STATUS_UPDATE_IN_SECS = 20

--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -64,7 +64,7 @@ class Constants(object):
         MAINTENANCE_RUN_ID = 'maintenanceRunId'
         PATCH_MODE = 'patchMode'
 
-        # File to save default settings for auto OS updates
+    # File to save default settings for auto OS updates
     IMAGE_DEFAULT_PATCH_CONFIGURATION_BACKUP_PATH = "ImageDefaultPatchConfiguration.bak"
 
     # Operations
@@ -80,7 +80,7 @@ class Constants(object):
     PATCH_VERSION_UNKNOWN = "UNKNOWN"
 
     # Patch Modes for Configure Patching
-    DEFAULT_FOR_IMAGE = "DefaultForImage"  # todo: cross check with CRP
+    IMAGE_DEFAULT = "ImageDefault"
     AUTOMATIC_BY_PLATFORM = "AutomaticByPlatform"
 
     # automatic OS patch states for configure patching

--- a/src/core/src/bootstrap/EnvLayer.py
+++ b/src/core/src/bootstrap/EnvLayer.py
@@ -316,11 +316,15 @@ class EnvLayer(object):
             # only fully emulate non_exclusive_files from the real recording; exclusive files can be redirected and handled in emulator scenarios
             if not self.__emulator_enabled or (isinstance(file_path_or_handle, str) and os.path.basename(file_path_or_handle) not in self.__non_exclusive_files):
                 file_handle, was_path = self.__obtain_file_handle(file_path_or_handle, 'r')
-                value = file_handle.read()
-                if was_path:  # what was passed in was not a file handle, so close the handle that was init here
-                    file_handle.close()
-                self.__write_record(operation, code=0, output=value, delay=0)
-                return value
+                try:
+                    value = file_handle.read()
+                    if was_path:  # what was passed in was not a file handle, so close the handle that was init here
+                        file_handle.close()
+                    self.__write_record(operation, code=0, output=value, delay=0)
+                    return value
+                except Exception as error:
+                    print("Unable to read from {0} (retries exhausted). Error: {1}.".format(str(file_path_or_handle), repr(error)))
+                    return None
             else:
                 code, output = self.__read_record(operation)
                 return output

--- a/src/core/src/bootstrap/EnvLayer.py
+++ b/src/core/src/bootstrap/EnvLayer.py
@@ -305,16 +305,15 @@ class EnvLayer(object):
                 for i in range(0, Constants.MAX_FILE_OPERATION_RETRY_COUNT):
                     try:
                         value = file_handle.read()
+                        if was_path:  # what was passed in was not a file handle, so close the handle that was init here
+                            file_handle.close()
                         self.__write_record(operation, code=0, output=value, delay=0)
                         return value
                     except Exception as error:
                         if i < Constants.MAX_FILE_OPERATION_RETRY_COUNT:
                             time.sleep(i + 1)
                         else:
-                            raise Exception("Unable to write to {0} (retries exhausted). Error: {1}.".format(str(file_handle.name), repr(error)))
-
-                if was_path:  # what was passed in was not a file handle, so close the handle that was init here
-                    file_handle.close()
+                            raise Exception("Unable to read from {0} (retries exhausted). Error: {1}.".format(str(file_path_or_handle), repr(error)))
             else:
                 code, output = self.__read_record(operation)
                 return output

--- a/src/core/src/bootstrap/EnvLayer.py
+++ b/src/core/src/bootstrap/EnvLayer.py
@@ -302,15 +302,19 @@ class EnvLayer(object):
             # only fully emulate non_exclusive_files from the real recording; exclusive files can be redirected and handled in emulator scenarios
             if not self.__emulator_enabled or (isinstance(file_path_or_handle, str) and os.path.basename(file_path_or_handle) not in self.__non_exclusive_files):
                 file_handle, was_path = self.__obtain_file_handle(file_path_or_handle, 'r')
-                try:
-                    value = file_handle.read()
-                    if was_path:  # what was passed in was not a file handle, so close the handle that was init here
-                        file_handle.close()
-                    self.__write_record(operation, code=0, output=value, delay=0)
-                    return value
-                except Exception as error:
-                    print("Unable to read from {0} (retries exhausted). Error: {1}.".format(str(file_path_or_handle), repr(error)))
-                    return None
+                for i in range(0, Constants.MAX_FILE_OPERATION_RETRY_COUNT):
+                    try:
+                        value = file_handle.read()
+                        self.__write_record(operation, code=0, output=value, delay=0)
+                        return value
+                    except Exception as error:
+                        if i < Constants.MAX_FILE_OPERATION_RETRY_COUNT:
+                            time.sleep(i + 1)
+                        else:
+                            raise Exception("Unable to write to {0} (retries exhausted). Error: {1}.".format(str(file_handle.name), repr(error)))
+
+                if was_path:  # what was passed in was not a file handle, so close the handle that was init here
+                    file_handle.close()
             else:
                 code, output = self.__read_record(operation)
                 return output

--- a/src/core/src/core_logic/ConfigurePatching.py
+++ b/src/core/src/core_logic/ConfigurePatching.py
@@ -47,6 +47,7 @@ class ConfigurePatching(object):
             self.status_handler.set_configure_patching_substatus_json(status=Constants.STATUS_TRANSITIONING, automatic_os_patch_state=current_auto_os_patch_state)
 
             # disable auto OS updates if VM is configured for platform updates only.
+            # NOTE: this condition will be false for Assessment operations, since patchMode is not sent in the API request
             if current_auto_os_patch_state == Constants.PATCH_STATE_ENABLED and self.execution_config.patch_mode == Constants.AUTOMATIC_BY_PLATFORM:
                 self.package_manager.disable_auto_os_update()
 

--- a/src/core/src/core_logic/ConfigurePatching.py
+++ b/src/core/src/core_logic/ConfigurePatching.py
@@ -1,0 +1,72 @@
+# Copyright 2020 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.7+
+
+""" Configure Patching """
+from core.src.bootstrap.Constants import Constants
+
+
+class ConfigurePatching(object):
+    def __init__(self, env_layer, execution_config, composite_logger, telemetry_writer, status_handler, package_manager):
+        self.env_layer = env_layer
+        self.execution_config = execution_config
+
+        self.composite_logger = composite_logger
+        self.telemetry_writer = telemetry_writer
+        self.status_handler = status_handler
+
+        self.package_manager = package_manager
+
+    def start_configure_patching(self):
+        """ Start configure patching """
+        self.status_handler.set_current_operation(Constants.CONFIGURE_PATCHING)
+        self.raise_if_agent_incompatible()
+        self.composite_logger.log('\nStarting configure patching...')
+
+        try:
+            self.status_handler.set_configure_patching_substatus_json(status=Constants.STATUS_TRANSITIONING, automatic_os_patch_state=Constants.PATCH_STATE_UNKNOWN)
+            self.composite_logger.log("\nMachine Id: " + self.env_layer.platform.node())
+            self.composite_logger.log("Activity Id: " + self.execution_config.activity_id)
+            self.composite_logger.log("Operation request time: " + self.execution_config.start_time)
+
+            # get current auto os updates on the machine and log it in status file
+            current_auto_os_patch_state = self.package_manager.get_current_auto_os_patch_state()
+            self.status_handler.set_configure_patching_substatus_json(status=Constants.STATUS_TRANSITIONING, automatic_os_patch_state=current_auto_os_patch_state)
+
+            # disable auto OS updates if VM is configured for platform updates only.
+            if self.execution_config.patch_mode == Constants.AUTOMATIC_BY_PLATFORM and current_auto_os_patch_state == Constants.PATCH_STATE_ENABLED:
+                self.package_manager.disable_auto_os_update()
+
+            # get current auto os updates on the machine and log it in status file
+            current_auto_os_patch_state = self.package_manager.get_current_auto_os_patch_state()
+            self.status_handler.set_configure_patching_substatus_json(status=Constants.STATUS_SUCCESS, automatic_os_patch_state=current_auto_os_patch_state)
+
+        except Exception as error:
+            error_msg = 'Error processing configure patching request: ' + repr(error)
+            self.composite_logger.log_error(error_msg)
+            self.status_handler.add_error_to_status(error_msg, Constants.PatchOperationErrorCodes.DEFAULT_ERROR)
+            if Constants.ERROR_ADDED_TO_STATUS not in repr(error):
+                error.args = (error.args, "[{0}]".format(Constants.ERROR_ADDED_TO_STATUS))
+            self.status_handler.set_configure_patching_substatus_json(status=Constants.STATUS_ERROR)
+            raise
+
+    def raise_if_agent_incompatible(self):
+        if not self.telemetry_writer.is_agent_compatible():
+            error_msg = Constants.TELEMETRY_AT_AGENT_NOT_COMPATIBLE_ERROR_MSG
+            self.composite_logger.log_error(error_msg)
+            raise Exception(error_msg)
+
+        self.composite_logger.log(Constants.TELEMETRY_AT_AGENT_COMPATIBLE_MSG)
+

--- a/src/core/src/core_logic/ConfigurePatching.py
+++ b/src/core/src/core_logic/ConfigurePatching.py
@@ -32,8 +32,8 @@ class ConfigurePatching(object):
     def start_configure_patching(self):
         """ Start configure patching """
         try:
+            configure_patching_successful = False
             self.status_handler.set_current_operation(Constants.CONFIGURE_PATCHING)
-            #ToDo: To verify with team if this is required -- windows does not check if agent supports telemetry in any of the operations -- update required, log error and continue with rest operation
             self.raise_if_agent_incompatible()
             self.composite_logger.log('\nStarting configure patching...')
 
@@ -55,16 +55,17 @@ class ConfigurePatching(object):
             self.status_handler.set_configure_patching_substatus_json(status=Constants.STATUS_SUCCESS, automatic_os_patch_state=current_auto_os_patch_state)
 
         except Exception as error:
-            #toDo: review wht windowsextension is doing in this case -- update errors here should not stop rest of the operation
             error_msg = 'Error: ' + repr(error)
             self.composite_logger.log_error(error_msg)
             self.status_handler.add_error_to_status(error_msg, Constants.PatchOperationErrorCodes.DEFAULT_ERROR)
             if Constants.ERROR_ADDED_TO_STATUS not in repr(error):
                 error.args = (error.args, "[{0}]".format(Constants.ERROR_ADDED_TO_STATUS))
             self.status_handler.set_configure_patching_substatus_json(status=Constants.STATUS_ERROR)
-            raise
+            configure_patching_successful = False
 
-        return True
+        configure_patching_successful = True
+        self.composite_logger.log("\nConfigure patching completed.\n")
+        return configure_patching_successful
 
     def raise_if_agent_incompatible(self):
         if not self.telemetry_writer.is_agent_compatible():

--- a/src/core/src/core_logic/ConfigurePatching.py
+++ b/src/core/src/core_logic/ConfigurePatching.py
@@ -33,7 +33,7 @@ class ConfigurePatching(object):
         """ Start configure patching """
         try:
             self.status_handler.set_current_operation(Constants.CONFIGURE_PATCHING)
-            #ToDo: To verify with team if this is required
+            #ToDo: To verify with team if this is required -- windows does not check if agent supports telemetry in any of the operations -- update required, log error and continue with rest operation
             self.raise_if_agent_incompatible()
             self.composite_logger.log('\nStarting configure patching...')
 
@@ -47,9 +47,7 @@ class ConfigurePatching(object):
             self.status_handler.set_configure_patching_substatus_json(status=Constants.STATUS_TRANSITIONING, automatic_os_patch_state=current_auto_os_patch_state)
 
             # disable auto OS updates if VM is configured for platform updates only.
-            if current_auto_os_patch_state == Constants.PATCH_STATE_ENABLED and \
-                    ((self.execution_config.operation.lower() == Constants.CONFIGURE_PATCHING.lower() and self.execution_config.patch_mode == Constants.AUTOMATIC_BY_PLATFORM) or
-                     (self.execution_config.operation.lower() == Constants.INSTALLATION.lower() and self.execution_config.maintenance_run_id is not None)):
+            if current_auto_os_patch_state == Constants.PATCH_STATE_ENABLED and self.execution_config.patch_mode == Constants.AUTOMATIC_BY_PLATFORM:
                 self.package_manager.disable_auto_os_update()
 
             # get current auto os updates on the machine and log it in status file
@@ -57,7 +55,7 @@ class ConfigurePatching(object):
             self.status_handler.set_configure_patching_substatus_json(status=Constants.STATUS_SUCCESS, automatic_os_patch_state=current_auto_os_patch_state)
 
         except Exception as error:
-            #toDo: review wht windowsextension is doing in this case
+            #toDo: review wht windowsextension is doing in this case -- update errors here should not stop rest of the operation
             error_msg = 'Error: ' + repr(error)
             self.composite_logger.log_error(error_msg)
             self.status_handler.add_error_to_status(error_msg, Constants.PatchOperationErrorCodes.DEFAULT_ERROR)

--- a/src/core/src/core_logic/ExecutionConfig.py
+++ b/src/core/src/core_logic/ExecutionConfig.py
@@ -57,6 +57,7 @@ class ExecutionConfig(object):
             self.reboot_setting = self.config_settings[Constants.ConfigSettings.REBOOT_SETTING]     # expected to throw if not present
         else:
             self.reboot_setting = self.__get_execution_configuration_value_safely(self.config_settings, Constants.ConfigSettings.REBOOT_SETTING, Constants.REBOOT_NEVER)     # safe extension-level default
+        self.patch_mode = self.__get_execution_configuration_value_safely(self.config_settings, Constants.ConfigSettings.PATCH_MODE)
 
         # Derived Settings
         self.composite_logger.log_debug(" - Establishing data publishing paths...")

--- a/src/core/src/core_logic/PatchAssessor.py
+++ b/src/core/src/core_logic/PatchAssessor.py
@@ -32,7 +32,7 @@ class PatchAssessor(object):
         self.package_manager = package_manager
 
     def start_assessment(self):
-        """ Start an update assessment """
+        """ Start an patch assessment """
         self.status_handler.set_current_operation(Constants.ASSESSMENT)
         self.raise_if_agent_incompatible()
 

--- a/src/core/src/core_logic/PatchAssessor.py
+++ b/src/core/src/core_logic/PatchAssessor.py
@@ -32,7 +32,7 @@ class PatchAssessor(object):
         self.package_manager = package_manager
 
     def start_assessment(self):
-        """ Start an patch assessment """
+        """ Start a patch assessment """
         self.status_handler.set_current_operation(Constants.ASSESSMENT)
         self.raise_if_agent_incompatible()
 

--- a/src/core/src/package_managers/AptitudePackageManager.py
+++ b/src/core/src/package_managers/AptitudePackageManager.py
@@ -372,12 +372,12 @@ class AptitudePackageManager(PackageManager):
         """ Gets the current auto OS update patch state on the machine """
         self.composite_logger.log("Fetching the current automatic OS patch state on the machine...")
         self.__get_current_auto_os_updates_setting_on_machine()
-        if self.unattended_upgrade_value != 0 or self.unattended_upgrade_value != 1:
-            return Constants.PATCH_STATE_UNKNOWN
-        elif self.unattended_upgrade_value:
+        if self.unattended_upgrade_value == 0:
+            return Constants.PATCH_STATE_DISABLED
+        elif self.unattended_upgrade_value == 1:
             return Constants.PATCH_STATE_ENABLED
         else:
-            return Constants.PATCH_STATE_DISABLED
+            return Constants.PATCH_STATE_UNKNOWN
 
     def __get_current_auto_os_updates_setting_on_machine(self):
         """ Gets all the update settings related to auto OS updates currently set on the machine """

--- a/src/core/src/package_managers/PackageManager.py
+++ b/src/core/src/package_managers/PackageManager.py
@@ -323,6 +323,11 @@ class PackageManager(object):
 
     # region auto OS updates
     @abstractmethod
+    def get_current_auto_os_patch_state(self):
+        """ Gets the current auto OS update patch state on the machine """
+        pass
+
+    @abstractmethod
     def disable_auto_os_update(self):
         """ Disables auto OS updates on the machine only if they are enabled and logs the default settings the machine comes with """
         pass

--- a/src/core/src/package_managers/YumPackageManager.py
+++ b/src/core/src/package_managers/YumPackageManager.py
@@ -327,6 +327,10 @@ class YumPackageManager(PackageManager):
     # endregion
 
     # region auto OS updates
+    def get_current_auto_os_patch_state(self):
+        """ Gets the current auto OS update patch state on the machine """
+        pass
+
     def disable_auto_os_update(self):
         """ Disables auto OS updates on the machine only if they are enabled and logs the default settings the machine comes with """
         pass

--- a/src/core/src/package_managers/YumPackageManager.py
+++ b/src/core/src/package_managers/YumPackageManager.py
@@ -337,10 +337,12 @@ class YumPackageManager(PackageManager):
     # region auto OS updates
     def get_current_auto_os_patch_state(self):
         """ Gets the current auto OS update patch state on the machine """
+        # NOTE: Implementation pending
         pass
 
     def disable_auto_os_update(self):
         """ Disables auto OS updates on the machine only if they are enabled and logs the default settings the machine comes with """
+        # NOTE: Implementation pending
         pass
 
     def is_image_default_patch_configuration_backup_valid(self, image_default_patch_configuration_backup):
@@ -349,9 +351,11 @@ class YumPackageManager(PackageManager):
     def backup_image_default_patch_configuration_if_not_exists(self):
         """ Records the default system settings for auto OS updates within patch extension artifacts for future reference.
         We only log the default system settings a VM comes with, any subsequent updates will not be recorded"""
+        # NOTE: Implementation pending
         pass
 
     def update_os_patch_configuration_sub_setting(self, patch_configuration_sub_setting, value):
+        # NOTE: Implementation pending
         pass
     # endregion
 

--- a/src/core/src/package_managers/ZypperPackageManager.py
+++ b/src/core/src/package_managers/ZypperPackageManager.py
@@ -357,6 +357,10 @@ class ZypperPackageManager(PackageManager):
     # endregion
 
     # region auto OS updates
+    def get_current_auto_os_patch_state(self):
+        """ Gets the current auto OS update patch state on the machine """
+        pass
+
     def disable_auto_os_update(self):
         """ Disables auto OS updates on the machine only if they are enabled and logs the default settings the machine comes with """
         pass

--- a/src/core/src/package_managers/ZypperPackageManager.py
+++ b/src/core/src/package_managers/ZypperPackageManager.py
@@ -359,10 +359,12 @@ class ZypperPackageManager(PackageManager):
     # region auto OS updates
     def get_current_auto_os_patch_state(self):
         """ Gets the current auto OS update patch state on the machine """
+        # NOTE: Implementation pending
         pass
 
     def disable_auto_os_update(self):
         """ Disables auto OS updates on the machine only if they are enabled and logs the default settings the machine comes with """
+        # NOTE: Implementation pending
         pass
 
     def is_image_default_patch_configuration_backup_valid(self, image_default_patch_configuration_backup):
@@ -371,9 +373,11 @@ class ZypperPackageManager(PackageManager):
     def backup_image_default_patch_configuration_if_not_exists(self):
         """ Records the default system settings for auto OS updates within patch extension artifacts for future reference.
         We only log the default system settings a VM comes with, any subsequent updates will not be recorded"""
+        # NOTE: Implementation pending
         pass
 
     def update_os_patch_configuration_sub_setting(self, patch_configuration_sub_setting, value):
+        # NOTE: Implementation pending
         pass
     # endregion
 

--- a/src/core/src/service_interfaces/StatusHandler.py
+++ b/src/core/src/service_interfaces/StatusHandler.py
@@ -59,6 +59,13 @@ class StatusHandler(object):
         self.__report_to_healthstore = False
         self.__patch_version = Constants.PATCH_VERSION_UNKNOWN
 
+        # Internal in-memory representation of Configure Patching data
+        self.__configure_patching_substatus_json = None
+        self.__configure_patching_summary_json = None
+        self.__configure_patching_automatic_os_patch_state = Constants.PATCH_STATE_UNKNOWN
+        self.__configure_patching_errors = []
+        self.__configure_patching_total_error_count = 0  # All errors during configure patching, includes errors not in error objects due to size limit
+
         # Load the currently persisted status file into memory
         self.__load_status_file_components(initial_load=True)
 
@@ -356,6 +363,36 @@ class StatusHandler(object):
             "shouldReportToHealthStore": report_to_healthstore
         }
 
+    def set_configure_patching_substatus_json(self, status=Constants.STATUS_TRANSITIONING, code=0, automatic_os_patch_state=Constants.PATCH_STATE_UNKNOWN):
+        """ Prepare the configure patching substatus json including the message containing configure patching summary """
+        self.composite_logger.log_debug("Setting configure patching substatus. [Substatus={0}]".format(str(status)))
+
+        # Wrap default automatic OS patch state on the machine, at the time of this request, into configure patching summary
+        self.__configure_patching_summary_json = self.__new_configure_patching_summary_json(automatic_os_patch_state)
+
+        # Wrap configure patching summary into configure patching substatus
+        self.__configure_patching_substatus_json = self.__new_substatus_json_for_operation(Constants.CONFIGURE_PATCHING_SUMMARY, status, code, json.dumps(self.__configure_patching_summary_json))
+
+        # Update status on disk
+        self.__write_status_file()
+
+    def __new_configure_patching_summary_json(self, automatic_os_patch_state):
+        """ Called by: set_configure_patching_substatus_json
+            Purpose: This composes the message inside the configure patching summary substatus:
+                Root --> Status --> Substatus [name: "ConfigurePatchingSummary"] --> FormattedMessage --> **Message** """
+
+        if automatic_os_patch_state is not Constants.PATCH_STATE_UNKNOWN:
+            self.__configure_patching_automatic_os_patch_state = automatic_os_patch_state
+
+        # Compose substatus message
+        return {
+            "activityId": str(self.execution_config.activity_id),
+            "startTime": str(self.execution_config.start_time),
+            "lastModifiedTime": str(self.env_layer.datetime.timestamp()),
+            "automaticOsPatchState": self.__configure_patching_automatic_os_patch_state,
+            "errors": self.__set_errors_json(self.__configure_patching_total_error_count, self.__configure_patching_errors)
+        }
+
     @staticmethod
     def __new_substatus_json_for_operation(operation_name, status="Transitioning", code=0, message=json.dumps("{}")):
         """ Generic substatus for assessment, installation and healthstore metadata """
@@ -410,6 +447,10 @@ class StatusHandler(object):
         self.__assessment_errors = []
         self.__metadata_for_healthstore_substatus_json = None
         self.__metadata_for_healthstore_summary_json = None
+        self.__configure_patching_substatus_json = None
+        self.__configure_patching_summary_json = None
+        self.__configure_patching_automatic_os_patch_state = Constants.PATCH_STATE_UNKNOWN
+        self.__configure_patching_errors = []
 
         # Verify the status file exists - if not, reset status file
         if not os.path.exists(self.status_file_path) and initial_load:
@@ -440,6 +481,7 @@ class StatusHandler(object):
             raise
 
         # Load portions of data that need to be built on for next write - raise exception if corrupt data is encountered
+        # todo: refactor
         self.__high_level_status_message = status_file_data['status']['formattedMessage']['message']
         for i in range(0, len(status_file_data['status']['substatus'])):
             name = status_file_data['status']['substatus'][i]['name']
@@ -464,6 +506,14 @@ class StatusHandler(object):
             if name == Constants.PATCH_METADATA_FOR_HEALTHSTORE:     # if it exists, it must be to spec, or an exception will get thrown
                 message = status_file_data['status']['substatus'][i]['formattedMessage']['message']
                 self.__metadata_for_healthstore_summary_json = json.loads(message)
+            if name == Constants.CONFIGURE_PATCHING:     # if it exists, it must be to spec, or an exception will get thrown
+                message = status_file_data['status']['substatus'][i]['formattedMessage']['message']
+                self.__configure_patching_summary_json = json.loads(message)
+                self.__configure_patching_automatic_os_patch_state = self.__configure_patching_summary_json['automaticOsPatchState']
+                errors = self.__configure_patching_summary_json['errors']
+                if errors is not None and errors['details'] is not None:
+                    self.__configure_patching_errors = errors['details']
+                    self.__configure_patching_total_error_count = self.__get_total_error_count_from_prev_status(errors['message'])
 
     def __write_status_file(self):
         """ Composes and writes the status file from **already up-to-date** in-memory data.
@@ -485,6 +535,18 @@ class StatusHandler(object):
                         __refresh_installation_reboot_status
                         errors
 
+                patch_metadata_for_healthstore_json = set_patch_metadata_for_healthstore_substatus_json
+                    __new_substatus_json_for_operation
+                    __metadata_for_healthstore_summary_json with external data --
+                        patchVersion
+                        shouldReportToHealthStore
+
+                configure_patching_substatus_json == set_configure_patching_substatus_json
+                    __new_substatus_json_for_operation
+                    __new_configure_patching_summary_json with external data --
+                        automatic_os_patch_state
+                        errors
+
         :return: None
         """
         status_file_payload = self.__new_basic_status_json()
@@ -496,6 +558,8 @@ class StatusHandler(object):
             status_file_payload['status']['substatus'].append(self.__installation_substatus_json)
         if self.__metadata_for_healthstore_substatus_json is not None:
             status_file_payload['status']['substatus'].append(self.__metadata_for_healthstore_substatus_json)
+        if self.__configure_patching_substatus_json is not None:
+            status_file_payload['status']['substatus'].append(self.__configure_patching_substatus_json)
         if os.path.isdir(self.status_file_path):
             self.composite_logger.log_error("Core state file path returned a directory. Attempting to reset.")
             shutil.rmtree(self.status_file_path)
@@ -542,6 +606,15 @@ class StatusHandler(object):
                 self.set_installation_substatus_json(status=self.__installation_substatus_json["status"], code=self.__installation_substatus_json["code"])
             else:
                 self.set_installation_substatus_json()
+        elif self.__current_operation == Constants.CONFIGURE_PATCHING:
+            self.__add_error(self.__configure_patching_errors, error_detail)
+            self.__configure_patching_total_error_count += 1
+            # retain previously set status, code and patchMode for configure patching substatus
+            if self.__configure_patching_substatus_json is not None:
+                automatic_os_patch_state = json.loads(self.__configure_patching_substatus_json["formattedMessage"]["message"])["automaticOsPatchState"]
+                self.set_configure_patching_substatus_json(status=self.__configure_patching_substatus_json["status"], code=self.__configure_patching_substatus_json["code"], automatic_os_patch_state=automatic_os_patch_state)
+            else:
+                self.set_configure_patching_substatus_json()
         else:
             return
 

--- a/src/core/tests/TestAptitudePackageManager.py
+++ b/src/core/tests/TestAptitudePackageManager.py
@@ -158,7 +158,7 @@ class TestAptitudePackageManager(unittest.TestCase):
         # disable with non existing log file
         package_manager = self.container.get('package_manager')
 
-        package_manager.disable_auto_os_update()
+        self.assertRaises(Exception, package_manager.disable_auto_os_update)
         self.assertFalse(package_manager.image_default_patch_configuration_backup_exists())
         self.assertTrue(not os.path.exists(package_manager.os_patch_configuration_settings_file_path))
 

--- a/src/core/tests/TestCoreMain.py
+++ b/src/core/tests/TestCoreMain.py
@@ -349,10 +349,11 @@ class TestCoreMain(unittest.TestCase):
         self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
         runtime.stop()
 
-    def test_operation_success_for_installation_request_with_configure_patching_handled(self):
+    def test_operation_success_for_installation_request_with_configure_patching(self):
         argument_composer = ArgumentComposer()
         argument_composer.operation = Constants.INSTALLATION
         argument_composer.maintenance_run_id = "9/28/2020 02:00:00 PM +00:00"
+        argument_composer.patch_mode = Constants.AUTOMATIC_BY_PLATFORM
         runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.APT)
         runtime.package_manager.get_current_auto_os_patch_state = runtime.backup_get_current_auto_os_patch_state
         runtime.package_manager.os_patch_configuration_settings_file_path = os.path.join(runtime.execution_config.config_folder, "20auto-upgrades")

--- a/src/core/tests/TestCoreMain.py
+++ b/src/core/tests/TestCoreMain.py
@@ -281,7 +281,6 @@ class TestCoreMain(unittest.TestCase):
         self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_SUCCESS.lower())
         runtime.stop()
 
-    #ToDO: check with team for telemetry error in configurepatching
     def test_assessment_operation_fail_due_to_no_telemetry(self):
         argument_composer = ArgumentComposer()
         argument_composer.operation = Constants.ASSESSMENT
@@ -296,8 +295,10 @@ class TestCoreMain(unittest.TestCase):
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_ERROR.lower())
         self.assertEqual(len(json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"]), 1)
-        #todo: uncomment after checking with team on how to handle telemetry unavailable in configure patching
-        #self.assertTrue(Constants.TELEMETRY_AT_AGENT_NOT_COMPATIBLE_ERROR_MSG in json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"][0]["message"])
+        self.assertTrue(Constants.TELEMETRY_AT_AGENT_NOT_COMPATIBLE_ERROR_MSG in json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"][0]["message"])
+        self.assertTrue(substatus_file_data[1]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
+        self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_ERROR.lower())
+        self.assertTrue(Constants.TELEMETRY_AT_AGENT_NOT_COMPATIBLE_ERROR_MSG in json.loads(substatus_file_data[1]["formattedMessage"]["message"])["errors"]["details"][0]["message"])
         runtime.stop()
 
     def test_installation_operation_fail_due_to_no_telemetry(self):
@@ -315,14 +316,18 @@ class TestCoreMain(unittest.TestCase):
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_ERROR.lower())
         self.assertEqual(len(json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"]), 1)
-        #todo: discuss with team and decide
-        #self.assertTrue(Constants.TELEMETRY_AT_AGENT_NOT_COMPATIBLE_ERROR_MSG in json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"][0]["message"])
+        self.assertTrue(Constants.TELEMETRY_AT_AGENT_NOT_COMPATIBLE_ERROR_MSG in json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"][0]["message"])
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
         self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_ERROR.lower())
+        self.assertEqual(len(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["errors"]["details"]), 1)
+        self.assertFalse(Constants.TELEMETRY_AT_AGENT_NOT_COMPATIBLE_ERROR_MSG in json.loads(substatus_file_data[1]["formattedMessage"]["message"])["errors"]["details"][0]["message"])
+        self.assertTrue("Installation failed due to assessment failure. Please refer the error details in assessment substatus" in json.loads(substatus_file_data[1]["formattedMessage"]["message"])["errors"]["details"][0]["message"])
         self.assertTrue(substatus_file_data[2]["name"] == Constants.PATCH_METADATA_FOR_HEALTHSTORE)
         self.assertTrue(substatus_file_data[2]["status"] == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[3]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
         self.assertTrue(substatus_file_data[3]["status"] == Constants.STATUS_ERROR.lower())
+        self.assertEqual(len(json.loads(substatus_file_data[3]["formattedMessage"]["message"])["errors"]["details"]), 1)
+        self.assertTrue(Constants.TELEMETRY_AT_AGENT_NOT_COMPATIBLE_ERROR_MSG in json.loads(substatus_file_data[3]["formattedMessage"]["message"])["errors"]["details"][0]["message"])
         runtime.stop()
 
     def test_operation_success_for_configure_patching_request_for_apt(self):
@@ -400,14 +405,13 @@ class TestCoreMain(unittest.TestCase):
         runtime.stop()
 
     def test_operation_fail_for_configure_patching_agent_incompatible(self):
-        # todo: This maybe removed after team discussion on how to handle agent telemetry unavailability in configure patching request
         argument_composer = ArgumentComposer()
         argument_composer.operation = Constants.CONFIGURE_PATCHING
         argument_composer.patch_mode = Constants.AUTOMATIC_BY_PLATFORM
         argument_composer.events_folder = None
         runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.APT)
         runtime.set_legacy_test_type('HappyPath')
-        self.assertRaises(Exception, runtime.configure_patching.start_configure_patching)
+        runtime.configure_patching.start_configure_patching()
 
         # check status file
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:

--- a/src/core/tests/TestCoreMain.py
+++ b/src/core/tests/TestCoreMain.py
@@ -293,6 +293,31 @@ class TestCoreMain(unittest.TestCase):
         self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_ERROR.lower())
         runtime.stop()
 
+    def test_operation_success_for_configure_patching_request(self):
+        #todo: update test with a proper patch setting file
+        pass
+        # argument_composer = ArgumentComposer()
+        # argument_composer.operation = Constants.CONFIGURE_PATCHING
+        # argument_composer.patch_mode = Constants.AUTOMATIC_BY_PLATFORM
+        # runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.APT)
+        # runtime.set_legacy_test_type('HappyPath')
+        # CoreMain(argument_composer.get_composed_arguments())
+        #
+        # # check telemetry events
+        # self.__check_telemetry_events(runtime)
+        #
+        # # check status file
+        # with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
+        #     substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
+        # self.assertEquals(len(substatus_file_data), 1)
+        # self.assertTrue(substatus_file_data[0]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
+        # self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
+        # runtime.stop()
+
+    def test_operation_fail_for_configure_patching_request(self):
+        # todo
+        pass
+
     def __check_telemetry_events(self, runtime):
         all_events = os.listdir(runtime.telemetry_writer.events_folder_path)
         self.assertTrue(len(all_events) > 0)

--- a/src/core/tests/TestCoreMain.py
+++ b/src/core/tests/TestCoreMain.py
@@ -56,12 +56,14 @@ class TestCoreMain(unittest.TestCase):
         # check status file
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
-        self.assertEquals(len(substatus_file_data), 2)
+        self.assertEquals(len(substatus_file_data), 3)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
         self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_ERROR.lower())
         self.assertEqual(len(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["errors"]["details"]), 1)
+        self.assertTrue(substatus_file_data[2]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
+        self.assertTrue(substatus_file_data[2]["status"] == Constants.STATUS_SUCCESS.lower())
         runtime.stop()
 
     def test_operation_fail_for_autopatching_request(self):
@@ -77,7 +79,7 @@ class TestCoreMain(unittest.TestCase):
         # check status file
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
-        self.assertEquals(len(substatus_file_data), 3)
+        self.assertEquals(len(substatus_file_data), 4)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
@@ -88,6 +90,8 @@ class TestCoreMain(unittest.TestCase):
         substatus_file_data_patch_metadata_summary = json.loads(substatus_file_data[2]["formattedMessage"]["message"])
         self.assertTrue(substatus_file_data_patch_metadata_summary["patchVersion"], Constants.PATCH_VERSION_UNKNOWN)
         self.assertFalse(substatus_file_data_patch_metadata_summary["shouldReportToHealthStore"])
+        self.assertTrue(substatus_file_data[3]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
+        self.assertTrue(substatus_file_data[3]["status"] == Constants.STATUS_SUCCESS.lower())
         runtime.stop()
 
     def test_operation_success_for_non_autopatching_request(self):
@@ -102,11 +106,13 @@ class TestCoreMain(unittest.TestCase):
         # check status file
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
-        self.assertEquals(len(substatus_file_data), 2)
+        self.assertEquals(len(substatus_file_data), 3)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
         self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[2]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
+        self.assertTrue(substatus_file_data[2]["status"] == Constants.STATUS_SUCCESS.lower())
         runtime.stop()
 
     def test_operation_success_for_autopatching_request(self):
@@ -124,7 +130,7 @@ class TestCoreMain(unittest.TestCase):
         # check status file
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
-        self.assertEquals(len(substatus_file_data), 3)
+        self.assertEquals(len(substatus_file_data), 4)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
@@ -134,6 +140,8 @@ class TestCoreMain(unittest.TestCase):
         substatus_file_data_patch_metadata_summary = json.loads(substatus_file_data[2]["formattedMessage"]["message"])
         self.assertEqual(substatus_file_data_patch_metadata_summary["patchVersion"], "2020.09.28")
         self.assertTrue(substatus_file_data_patch_metadata_summary["shouldReportToHealthStore"])
+        self.assertTrue(substatus_file_data[3]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
+        self.assertTrue(substatus_file_data[3]["status"] == Constants.STATUS_SUCCESS.lower())
         runtime.stop()
 
     def test_operation_success_for_autopatching_request_with_security_classification(self):
@@ -153,7 +161,7 @@ class TestCoreMain(unittest.TestCase):
         # check status file
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
-        self.assertEquals(len(substatus_file_data), 3)
+        self.assertEquals(len(substatus_file_data), 4)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
@@ -170,6 +178,8 @@ class TestCoreMain(unittest.TestCase):
         substatus_file_data_patch_metadata_summary = json.loads(substatus_file_data[2]["formattedMessage"]["message"])
         self.assertEqual(substatus_file_data_patch_metadata_summary["patchVersion"], "2020.09.28")
         self.assertTrue(substatus_file_data_patch_metadata_summary["shouldReportToHealthStore"])
+        self.assertTrue(substatus_file_data[3]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
+        self.assertTrue(substatus_file_data[3]["status"] == Constants.STATUS_SUCCESS.lower())
         runtime.stop()
 
     def test_invalid_maintenance_run_id(self):
@@ -187,7 +197,7 @@ class TestCoreMain(unittest.TestCase):
         # check status file
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
-        self.assertEquals(len(substatus_file_data), 3)
+        self.assertEquals(len(substatus_file_data), 4)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
@@ -197,6 +207,8 @@ class TestCoreMain(unittest.TestCase):
         substatus_file_data_patch_metadata_summary = json.loads(substatus_file_data[2]["formattedMessage"]["message"])
         self.assertEqual(substatus_file_data_patch_metadata_summary["patchVersion"], Constants.PATCH_VERSION_UNKNOWN)
         self.assertFalse(substatus_file_data_patch_metadata_summary["shouldReportToHealthStore"])
+        self.assertTrue(substatus_file_data[3]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
+        self.assertTrue(substatus_file_data[3]["status"] == Constants.STATUS_SUCCESS.lower())
         runtime.stop()
 
         # todo: This will become a valid success operation run once the temp fix for maintenanceRunId is removed
@@ -214,7 +226,7 @@ class TestCoreMain(unittest.TestCase):
         # check status file
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
-        self.assertEquals(len(substatus_file_data), 3)
+        self.assertEquals(len(substatus_file_data), 4)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
@@ -224,6 +236,8 @@ class TestCoreMain(unittest.TestCase):
         substatus_file_data_patch_metadata_summary = json.loads(substatus_file_data[2]["formattedMessage"]["message"])
         self.assertEqual(substatus_file_data_patch_metadata_summary["patchVersion"], Constants.PATCH_VERSION_UNKNOWN)
         self.assertFalse(substatus_file_data_patch_metadata_summary["shouldReportToHealthStore"])
+        self.assertTrue(substatus_file_data[3]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
+        self.assertTrue(substatus_file_data[3]["status"] == Constants.STATUS_SUCCESS.lower())
         runtime.stop()
 
     def test_assessment_operation_success(self):
@@ -239,9 +253,11 @@ class TestCoreMain(unittest.TestCase):
         # check status file
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
-        self.assertEquals(len(substatus_file_data), 1)
+        self.assertEquals(len(substatus_file_data), 2)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[1]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
+        self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_SUCCESS.lower())
         runtime.stop()
 
     def test_assessment_operation_fail(self):
@@ -257,12 +273,15 @@ class TestCoreMain(unittest.TestCase):
         # check status file
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
-        self.assertEquals(len(substatus_file_data), 1)
+        self.assertEquals(len(substatus_file_data), 2)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_ERROR.lower())
         self.assertEqual(len(json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"]), 2)
+        self.assertTrue(substatus_file_data[1]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
+        self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_SUCCESS.lower())
         runtime.stop()
 
+    #ToDO: check with team for telemetry error in configurepatching
     def test_assessment_operation_fail_due_to_no_telemetry(self):
         argument_composer = ArgumentComposer()
         argument_composer.operation = Constants.ASSESSMENT
@@ -273,11 +292,12 @@ class TestCoreMain(unittest.TestCase):
 
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
-        self.assertEquals(len(substatus_file_data), 1)
+        self.assertEquals(len(substatus_file_data), 2)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_ERROR.lower())
         self.assertEqual(len(json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"]), 1)
-        self.assertTrue(Constants.TELEMETRY_AT_AGENT_NOT_COMPATIBLE_ERROR_MSG in json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"][0]["message"])
+        #todo: uncomment after checking with team on how to handle telemetry unavailable in configure patching
+        #self.assertTrue(Constants.TELEMETRY_AT_AGENT_NOT_COMPATIBLE_ERROR_MSG in json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"][0]["message"])
         runtime.stop()
 
     def test_installation_operation_fail_due_to_no_telemetry(self):
@@ -291,13 +311,18 @@ class TestCoreMain(unittest.TestCase):
 
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
-        self.assertEquals(len(substatus_file_data), 3)
+        self.assertEquals(len(substatus_file_data), 4)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_ERROR.lower())
         self.assertEqual(len(json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"]), 1)
-        self.assertTrue(Constants.TELEMETRY_AT_AGENT_NOT_COMPATIBLE_ERROR_MSG in json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"][0]["message"])
+        #todo: discuss with team and decide
+        #self.assertTrue(Constants.TELEMETRY_AT_AGENT_NOT_COMPATIBLE_ERROR_MSG in json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"][0]["message"])
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
         self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_ERROR.lower())
+        self.assertTrue(substatus_file_data[2]["name"] == Constants.PATCH_METADATA_FOR_HEALTHSTORE)
+        self.assertTrue(substatus_file_data[2]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[3]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
+        self.assertTrue(substatus_file_data[3]["status"] == Constants.STATUS_ERROR.lower())
         runtime.stop()
 
     def test_operation_success_for_configure_patching_request(self):
@@ -346,7 +371,7 @@ class TestCoreMain(unittest.TestCase):
         # check status file
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
-        self.assertEquals(len(substatus_file_data), 3)
+        self.assertEquals(len(substatus_file_data), 4)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
@@ -367,6 +392,8 @@ class TestCoreMain(unittest.TestCase):
         substatus_file_data_patch_metadata_summary = json.loads(substatus_file_data[2]["formattedMessage"]["message"])
         self.assertEqual(substatus_file_data_patch_metadata_summary["patchVersion"], "2020.09.28")
         self.assertTrue(substatus_file_data_patch_metadata_summary["shouldReportToHealthStore"])
+        self.assertTrue(substatus_file_data[3]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
+        self.assertTrue(substatus_file_data[3]["status"] == Constants.STATUS_SUCCESS.lower())
         runtime.stop()
 
         LegacyEnvLayerExtensions.LegacyPlatform.linux_distribution = backup_envlayer_platform_linux_distribution
@@ -392,7 +419,7 @@ class TestCoreMain(unittest.TestCase):
         # check status file
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
-        self.assertEquals(len(substatus_file_data), 3)
+        self.assertEquals(len(substatus_file_data), 4)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
@@ -419,6 +446,8 @@ class TestCoreMain(unittest.TestCase):
         substatus_file_data_patch_metadata_summary = json.loads(substatus_file_data[2]["formattedMessage"]["message"])
         self.assertEqual(substatus_file_data_patch_metadata_summary["patchVersion"], "2020.09.28")
         self.assertTrue(substatus_file_data_patch_metadata_summary["shouldReportToHealthStore"])
+        self.assertTrue(substatus_file_data[3]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
+        self.assertTrue(substatus_file_data[3]["status"] == Constants.STATUS_SUCCESS.lower())
         runtime.stop()
 
         LegacyEnvLayerExtensions.LegacyPlatform.linux_distribution = backup_envlayer_platform_linux_distribution

--- a/src/core/tests/library/ArgumentComposer.py
+++ b/src/core/tests/library/ArgumentComposer.py
@@ -50,6 +50,7 @@ class ArgumentComposer(object):
         self.patches_to_include = []
         self.patches_to_exclude = []
         self.maintenance_run_id = None  # Since this is optional, all possible inputs for this are added in respective tests
+        self.patch_mode = None
 
         # REAL environment settings
         self.emulator_enabled = False
@@ -72,7 +73,8 @@ class ArgumentComposer(object):
             "classificationsToInclude": self.classifications_to_include,
             "patchesToInclude": self.patches_to_include,
             "patchesToExclude": self.patches_to_exclude,
-            "maintenanceRunId": self.maintenance_run_id
+            "maintenanceRunId": self.maintenance_run_id,
+            "patchMode": self.patch_mode
         }
 
         return str(self.__ARG_TEMPLATE.format(self.__EXEC, Constants.ARG_SEQUENCE_NUMBER, self.sequence_number,

--- a/src/core/tests/library/RuntimeCompositor.py
+++ b/src/core/tests/library/RuntimeCompositor.py
@@ -64,7 +64,9 @@ class RuntimeCompositor(object):
         # Business logic components
         self.execution_config = self.container.get('execution_config')
         self.package_manager = self.container.get('package_manager')
+        self.backup_get_current_auto_os_patch_state = None
         self.reconfigure_package_manager()
+        self.configure_patching = self.container.get('configure_patching')
         self.reboot_manager = self.container.get('reboot_manager')
         self.reconfigure_reboot_manager()
         self.package_filter = self.container.get('package_filter')

--- a/src/core/tests/library/RuntimeCompositor.py
+++ b/src/core/tests/library/RuntimeCompositor.py
@@ -64,6 +64,7 @@ class RuntimeCompositor(object):
         # Business logic components
         self.execution_config = self.container.get('execution_config')
         self.package_manager = self.container.get('package_manager')
+        self.reconfigure_package_manager()
         self.reboot_manager = self.container.get('reboot_manager')
         self.reconfigure_reboot_manager()
         self.package_filter = self.container.get('package_filter')
@@ -105,11 +106,18 @@ class RuntimeCompositor(object):
     def start_reboot(self, message="Test initiated reboot mock"):
         self.status_handler.set_installation_reboot_status(Constants.RebootStatus.STARTED)
 
+    def reconfigure_package_manager(self):
+        self.backup_get_current_auto_os_patch_state = self.package_manager.get_current_auto_os_patch_state
+        self.package_manager.get_current_auto_os_patch_state = self.get_current_auto_os_patch_state
+
     def mock_sleep(self, seconds):
         pass
 
     def check_sudo_status(self, raise_if_not_sudo=True):
         return True
+
+    def get_current_auto_os_patch_state(self):
+        return Constants.PATCH_STATE_DISABLED
 
     @staticmethod
     def write_to_file(path, data):

--- a/src/extension/src/Constants.py
+++ b/src/extension/src/Constants.py
@@ -152,6 +152,7 @@ class Constants(object):
         internal_settings = "internalSettings"
         maintenance_run_id = "maintenanceRunId"
         patch_rollout_id = "patchRolloutId"
+        patch_mode = "patchMode"
 
     # ExtState.json keys
     class ExtStateFields(EnumBackport):

--- a/src/extension/src/EnableCommandHandler.py
+++ b/src/extension/src/EnableCommandHandler.py
@@ -74,11 +74,6 @@ class EnableCommandHandler(object):
             self.ext_state_handler.create_file(self.seq_no, operation, prev_patch_max_end_time)
             core_state_content = self.core_state_handler.read_file()
 
-            # If ConfigurePatching is requested, do nothing, will be implemented in future
-            # if operation == Constants.CONFIGURE_PATCHING:
-            #     self.logger.log("Received a configure patching request, no action will be taken as it is not supported for now. [Operation Sequence={0}]".format(str(self.seq_no)))
-            #     exit(Constants.ExitCode.Okay)
-
             # if NoOperation is requested, terminate all running processes from previous operation and update status file
             if operation == Constants.NOOPERATION:
                 self.process_nooperation(config_settings, core_state_content)

--- a/src/extension/src/EnableCommandHandler.py
+++ b/src/extension/src/EnableCommandHandler.py
@@ -67,12 +67,12 @@ class EnableCommandHandler(object):
             core_state_content = self.core_state_handler.read_file()
 
             # If ConfigurePatching is requested, do nothing, will be implemented in future
-            if operation == Constants.CONFIGURE_PATCHING:
-                self.logger.log("Received a configure patching request, no action will be taken as it is not supported for now. [Operation Sequence={0}]".format(str(self.seq_no)))
-                exit(Constants.ExitCode.Okay)
+            # if operation == Constants.CONFIGURE_PATCHING:
+            #     self.logger.log("Received a configure patching request, no action will be taken as it is not supported for now. [Operation Sequence={0}]".format(str(self.seq_no)))
+            #     exit(Constants.ExitCode.Okay)
 
             # if NoOperation is requested, terminate all running processes from previous operation and update status file
-            elif operation == Constants.NOOPERATION:
+            if operation == Constants.NOOPERATION:
                 self.process_nooperation(config_settings, core_state_content)
             else:
                 # if any of the other operations are requested, verify if request is a new request or a re-enable, by comparing sequence number from the prev request and current one

--- a/src/extension/src/EnvHealthManager.py
+++ b/src/extension/src/EnvHealthManager.py
@@ -57,7 +57,6 @@ class EnvHealthManager(object):
             if tty_required:
                 self.disable_tty_for_current_user()
         except Exception as error:
-            # todo: raise error?
             print("Error occurred while ensuring tty is disabled. [Error={0}]".format(repr(error)))
 
     def disable_tty_for_current_user(self):

--- a/src/extension/src/EnvLayer.py
+++ b/src/extension/src/EnvLayer.py
@@ -36,7 +36,6 @@ class EnvLayer(object):
         self.etc_sudoers_linux_patch_extension_file_path = "/etc/sudoers.d/linuxpatchextension"
         self.require_tty_setting = "requiretty"
 
-    # todo: change the other run command call source in handler too
     def run_command_output(self, cmd, no_output=False, chk_err=False):
         code, output = self.__run_command_output_raw(cmd, no_output, chk_err)
         return code, output

--- a/src/extension/src/ProcessHandler.py
+++ b/src/extension/src/ProcessHandler.py
@@ -47,7 +47,8 @@ class ProcessHandler(object):
                                            public_settings_keys.include_patches: config_settings.__getattribute__(public_settings_keys.include_patches),
                                            public_settings_keys.exclude_patches: config_settings.__getattribute__(public_settings_keys.exclude_patches),
                                            public_settings_keys.internal_settings: config_settings.__getattribute__(public_settings_keys.internal_settings),
-                                           public_settings_keys.maintenance_run_id: config_settings.__getattribute__(public_settings_keys.maintenance_run_id)})
+                                           public_settings_keys.maintenance_run_id: config_settings.__getattribute__(public_settings_keys.maintenance_run_id),
+                                           public_settings_keys.patch_mode: config_settings.__getattribute__(public_settings_keys.patch_mode)})
         return public_config_settings
 
     @staticmethod

--- a/src/extension/src/file_handlers/ExtConfigSettingsHandler.py
+++ b/src/extension/src/file_handlers/ExtConfigSettingsHandler.py
@@ -129,11 +129,12 @@ class ExtConfigSettingsHandler(object):
                     # read maintenenacerunId first, if that doesn't exist,read patch rollout id and pass it through as maintenance run id
                     # todo: remove patch rollout id later
                     maintenance_run_id = self.get_ext_config_value_safely(config_settings_json, self.public_settings_all_keys.patch_rollout_id, raise_if_not_found=False)
+                patch_mode = self.get_ext_config_value_safely(config_settings_json, self.public_settings_all_keys.patch_mode, raise_if_not_found=False)
                 config_settings_values = collections.namedtuple("config_settings", [self.public_settings_all_keys.operation, self.public_settings_all_keys.activity_id, self.public_settings_all_keys.start_time,
                                                                                     self.public_settings_all_keys.maximum_duration, self.public_settings_all_keys.reboot_setting, self.public_settings_all_keys.include_classifications,
                                                                                     self.public_settings_all_keys.include_patches, self.public_settings_all_keys.exclude_patches, self.public_settings_all_keys.internal_settings,
-                                                                                    self.public_settings_all_keys.maintenance_run_id])
-                return config_settings_values(operation, activity_id, start_time, max_duration, reboot_setting, include_classifications, include_patches, exclude_patches, internal_settings, maintenance_run_id)
+                                                                                    self.public_settings_all_keys.maintenance_run_id, self.public_settings_all_keys.patch_mode])
+                return config_settings_values(operation, activity_id, start_time, max_duration, reboot_setting, include_classifications, include_patches, exclude_patches, internal_settings, maintenance_run_id, patch_mode)
             else:
                 config_invalid_due_to = "no content found in the file" if config_settings_json is None else "settings not in expected format"
                 raise Exception("Config Settings json file invalid due to " + config_invalid_due_to)

--- a/src/extension/tests/TestEnableCommandHandler.py
+++ b/src/extension/tests/TestEnableCommandHandler.py
@@ -159,6 +159,11 @@ class TestEnableCommandHandler(unittest.TestCase):
         with self.assertRaises(SystemExit) as sys_exit:
             enable_command_handler.execute_handler_action()
         self.assertEqual(sys_exit.exception.code, Constants.ExitCode.Okay)
+        status_json = self.ext_output_status_handler.read_file('12')
+        parent_key = Constants.StatusFileFields.status
+        self.assertEqual(status_json[0][parent_key][Constants.StatusFileFields.status_name], "Azure Patch Management")
+        self.assertEqual(status_json[0][parent_key][Constants.StatusFileFields.status_operation], Constants.CONFIGURE_PATCHING)
+        self.assertEqual(status_json[0][parent_key][Constants.StatusFileFields.status_status], Constants.Status.Transitioning.lower())
 
     def test_process_invalid_request(self):
         # setup to mock environment when enable is triggered with an invalid request
@@ -267,6 +272,10 @@ class TestEnableCommandHandler(unittest.TestCase):
         self.ext_config_settings_handler.config_folder = config_folder_complete_path
         self.core_state_handler.dir_path = config_folder_complete_path
         self.ext_state_handler.dir_path = config_folder_complete_path
+
+        # Re-initializing ExtOutputStatusHandler with complete status folder dir path
+        self.ext_output_status_handler = ExtOutputStatusHandler(self.logger, self.utility, self.json_file_handler, status_folder_complete_path)
+        self.enable_command_handler.ext_output_status_handler = self.ext_output_status_handler
 
         return config_file_path, config_folder_complete_path
 

--- a/src/extension/tests/TestExtConfigSettingsHandler.py
+++ b/src/extension/tests/TestExtConfigSettingsHandler.py
@@ -231,7 +231,8 @@ class TestExtConfigSettingsHandler(unittest.TestCase):
                         self.config_public_settings_fields.include_patches: ["*", "test*", "*ern*=1.2*", "kern*=1.23.45"],
                         self.config_public_settings_fields.exclude_patches: ["*", "test", "*test"],
                         self.config_public_settings_fields.internal_settings: "<serialized-json>",
-                        self.config_public_settings_fields.maintenance_run_id: "2019-07-20T12:12:14Z"
+                        self.config_public_settings_fields.maintenance_run_id: "2019-07-20T12:12:14Z",
+                        self.config_public_settings_fields.patch_mode: "AutomaticByPlatform"
                     }
                 }
             }]
@@ -342,6 +343,10 @@ class TestExtConfigSettingsHandler(unittest.TestCase):
         # verify internalSettings is read successfully
         self.assertNotEqual(config_settings.__getattribute__(self.config_public_settings_fields.internal_settings), None)
         self.assertEqual(config_settings.__getattribute__(self.config_public_settings_fields.internal_settings), "test")
+
+        # verify patchMode is read successfully
+        self.assertNotEqual(config_settings.__getattribute__(self.config_public_settings_fields.patch_mode), None)
+        self.assertEqual(config_settings.__getattribute__(self.config_public_settings_fields.patch_mode), "AutomaticByPlatform")
 
         # verify maintenanceRunId is read successfully
         self.assertNotEqual(config_settings.__getattribute__(self.config_public_settings_fields.maintenance_run_id), None)

--- a/src/extension/tests/TestProcessHandler.py
+++ b/src/extension/tests/TestProcessHandler.py
@@ -95,6 +95,7 @@ class TestProcessHandler(unittest.TestCase):
         self.assertTrue(public_config_settings is not None)
         self.assertEqual(public_config_settings.get(Constants.ConfigPublicSettingsFields.operation), "Installation")
         self.assertEqual(public_config_settings.get(Constants.ConfigPublicSettingsFields.maintenance_run_id), "2019-07-20T12:12:14Z")
+        self.assertEqual(public_config_settings.get(Constants.ConfigPublicSettingsFields.patch_mode), "AutomaticByPlatform")
 
     def test_get_env_settings(self):
         handler_env_file_path = os.path.join(os.path.pardir, "tests", "helpers")

--- a/src/extension/tests/helpers/1234.settings
+++ b/src/extension/tests/helpers/1234.settings
@@ -13,7 +13,8 @@
                 "patchesToInclude": ["*ern*=1.2*", "kern*=1.23.45"],
                 "patchesToExclude": ["test", "*test"],
                 "internalSettings": "test",
-                "maintenanceRunId": "2019-07-20T12:12:14Z"
+                "maintenanceRunId": "2019-07-20T12:12:14Z",
+                "patchMode": "AutomaticByPlatform"
             }
         }
     }]


### PR DESCRIPTION
Includes 

- Processing Configure patching requests in handler and passing down patchMode to Core
- Core reading patchMode from config settings
- Configure Patching will always run irrespective of the operation
- Handling configure patching requests
   Approach:
       - Get the current auto OS updates set on the machine and add it to ConfigurePatchingSummary substatus
       - If patchMode is AutomaticByPlatform and auto OS updates are enabled on the machine, disable those
       - Update ConfigurePatchingSummary substatus after disabling auto OS updates
 - If the uber-operation is not configure patching, continue with the uber-operation
    NOTE: in this case, any errors thrown by configure patching will be logged in configure patch summary substatus and the uber-operation will continue without any blocks. No error reporting for configure patching within other substatuses

Questions:
- Read this later in our common doc for Windows and Linux, about ConfigurePatchingSummary substatus: "/*This substatus will be shown in all operation to show the current configuration setting the machine*/ " ---- Does this mean even Assessment or Installation requests will have ConfigurePatchingSummary substatus?
   A. Yes, ConfigurePatchingSummary substatus will be shown for all operations, including Assessment and Installation
- In this approach, though auto OS updates will only be disabled for patchMode="AutomaticByPlatform", ConfigurePatchingSummary substatus will always be set, read for ImageDefault/DefaultForImage patchMode as well. Does this follow our expected proposal? 
  A. Yes

