### PR TITLE
Bug fix for additional reboot check in YUM and inconsistencies with python 2.6

### DIFF
--- a/src/core/src/bootstrap/Container.py
+++ b/src/core/src/bootstrap/Container.py
@@ -149,9 +149,15 @@ class Container(Singleton):
         if inspect.isclass(component):
             component = component.__init__
 
-        if sys.version_info.major == 2:
+        major_version = None
+        if hasattr(sys.version_info, 'major'):
+            major_version = sys.version_info.major
+        else:
+            major_version = sys.version_info[0]  # python 2.6 doesn't have attributes like 'major' within sys.version_info
+
+        if major_version == 2:
             component_args, vargs, vkw, defaults = inspect.getargspec(component)
-        elif sys.version_info.major == 3:
+        elif major_version == 3:
             component_args, vargs, vkw, defaults, kwonlyargs, kwonlydefaults, annotations = inspect.getfullargspec(component)
         else:
             raise Exception("Unknown version of python encountered.")

--- a/src/core/src/bootstrap/EnvLayer.py
+++ b/src/core/src/bootstrap/EnvLayer.py
@@ -162,9 +162,15 @@ class EnvLayer(object):
 
     @staticmethod
     def __convert_process_output_to_ascii(output):
-        if sys.version_info.major == 2:
+        major_version = None
+        if hasattr(sys.version_info, 'major'):
+            major_version = sys.version_info.major
+        else:
+            major_version = sys.version_info[0]  # python 2.6 doesn't have attributes like 'major' within sys.version_info
+
+        if major_version == 2:
             return output.decode('utf8', 'ignore').encode('ascii', 'ignore')
-        elif sys.version_info.major == 3:
+        elif major_version == 3:
             return output.decode('utf8', 'ignore')
         else:
             raise Exception("Unknown version of python encountered.")
@@ -228,7 +234,13 @@ class EnvLayer(object):
         def linux_distribution(self):
             operation = "PLATFORM_LINUX_DISTRIBUTION"
             if not self.__emulator_enabled:
-                if sys.version_info.major == 2:
+                major_version = None
+                if hasattr(sys.version_info, 'major'):
+                    major_version = sys.version_info.major
+                else:
+                    major_version = sys.version_info[0]  # python 2.6 doesn't have attributes like 'major' within sys.version_info
+
+                if major_version == 2:
                     value = platform.linux_distribution()
                 else:
                     value = distro.linux_distribution()

--- a/src/core/src/package_managers/YumPackageManager.py
+++ b/src/core/src/package_managers/YumPackageManager.py
@@ -345,7 +345,7 @@ class YumPackageManager(PackageManager):
 
     def do_processes_require_restart(self):
         """Signals whether processes require a restart due to updates"""
-
+        self.composite_logger.log_debug("Checking if process requires reboot")
         # Checking using yum-utils
         self.composite_logger.log_debug("Ensuring yum-utils is present.")
         code, out = self.env_layer.run_command_output(self.yum_utils_prerequisite, False, False)  # idempotent, doesn't install if already present
@@ -361,13 +361,14 @@ class YumPackageManager(PackageManager):
             return True
 
         # Checking for restart for distro without -r flag such as RHEL 6
-        code, out = self.env_layer.run_command_output(self.needs_restarting, False, False)
-        self.composite_logger.log_debug(" - Code: " + str(code) + ", Output: \n|\t" + "\n|\t".join(out.splitlines()))
-        if len(out.strip()) == 0 and code == 0:
-            self.composite_logger.log_debug(" - Reboot not detected to be required (L2).")
-        else:
-            self.composite_logger.log_debug(" - Reboot is detected to be required (L2).")
-            return True
+        if 'Red Hat Enterprise Linux Server' in str(self.env_layer.platform.linux_distribution()[0]) and '6.' in str(self.env_layer.platform.linux_distribution()[1]):
+            code, out = self.env_layer.run_command_output(self.needs_restarting, False, False)
+            self.composite_logger.log_debug(" - Code: " + str(code) + ", Output: \n|\t" + "\n|\t".join(out.splitlines()))
+            if len(out.strip()) == 0 and code == 0:
+                self.composite_logger.log_debug(" - Reboot not detected to be required (L2).")
+            else:
+                self.composite_logger.log_debug(" - Reboot is detected to be required (L2).")
+                return True
 
         # Double-checking using yum ps (where available)
         self.composite_logger.log_debug("Ensuring yum-plugin-ps is present.")

--- a/src/core/src/service_interfaces/TelemetryWriter.py
+++ b/src/core/src/service_interfaces/TelemetryWriter.py
@@ -232,11 +232,16 @@ class TelemetryWriter(object):
             if not is_event_file_throttling_needed:
                 return
 
-            if (datetime.datetime.utcnow() - self.start_time_for_event_count_throttle_check).total_seconds() < Constants.TELEMETRY_MAX_TIME_IN_SECONDS_FOR_EVENT_COUNT_THROTTLE:
+            time_from_event_count_throttle_check_start = (datetime.datetime.utcnow() - self.start_time_for_event_count_throttle_check)
+            # Computing seconds as per: https://docs.python.org/2/library/datetime.html#datetime.timedelta.total_seconds, since total_seconds() is not supported in python 2.6
+            time_from_throttle_start_check_total_seconds = ((time_from_event_count_throttle_check_start.microseconds + (time_from_event_count_throttle_check_start.seconds + time_from_event_count_throttle_check_start.days * 24 * 3600) * 10 ** 6) / 10 ** 6)
+
+            if time_from_throttle_start_check_total_seconds < Constants.TELEMETRY_MAX_TIME_IN_SECONDS_FOR_EVENT_COUNT_THROTTLE:
                 # If event count limit reached before time period, wait out the remaining time. Checking against one less than max limit to allow room for writing a throttling msg to telemetry
                 if self.event_count >= Constants.TELEMETRY_MAX_EVENT_COUNT_THROTTLE - 1:
                     end_time_for_event_count_throttle_check = self.start_time_for_event_count_throttle_check + datetime.timedelta(seconds=Constants.TELEMETRY_MAX_TIME_IN_SECONDS_FOR_EVENT_COUNT_THROTTLE)
-                    time_to_wait_in_secs = (end_time_for_event_count_throttle_check - datetime.datetime.utcnow()).total_seconds()
+                    time_to_wait = (end_time_for_event_count_throttle_check - datetime.datetime.utcnow())
+                    time_to_wait_in_secs = ((time_to_wait.microseconds + (time_to_wait.seconds + time_to_wait.days * 24 * 3600) * 10 ** 6) / 10 ** 6)  # Computing seconds as per: https://docs.python.org/2/library/datetime.html#datetime.timedelta.total_seconds, since total_seconds() is not supported in python 2.6
                     event_write_throttled_msg = "Max telemetry event file limit reached. Extension will wait until a telemetry event file can be written again. [WaitTimeInSecs={0}]".format(str(time_to_wait_in_secs))
                     self.composite_logger.log_telemetry_module(event_write_throttled_msg)
                     self.write_event(message=event_write_throttled_msg, event_level=Constants.TelemetryEventLevel.Informational, is_event_file_throttling_needed=False)

--- a/src/core/tests/TestYumPackageManager.py
+++ b/src/core/tests/TestYumPackageManager.py
@@ -408,5 +408,6 @@ class TestYumPackageManager(unittest.TestCase):
         self.assertEqual(len(available_updates), 0)
         self.assertEqual(len(package_versions), 0)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/core/tests/library/LegacyEnvLayerExtensions.py
+++ b/src/core/tests/library/LegacyEnvLayerExtensions.py
@@ -803,9 +803,15 @@ class LegacyEnvLayerExtensions():
                         code = 100
                         output = "E: dpkg was interrupted, you must manually run 'sudo dpkg --configure -a' to correct the problem."
 
-            if sys.version_info.major == 2:
+            major_version = None
+            if hasattr(sys.version_info, 'major'):
+                major_version = sys.version_info.major
+            else:
+                major_version = sys.version_info[0]
+
+            if major_version == 2:
                 return code, output.decode('utf8', 'ignore').encode('ascii', 'ignore')
-            elif sys.version_info.major == 3:
+            elif major_version == 3:
                 return code, output.encode('ascii', 'ignore').decode('ascii', 'ignore')
             else:
                 raise Exception("Unknown version of python encountered.")


### PR DESCRIPTION
Contains:

- Bug fix for frequent reboots in RHEL due to an extra reboot check
- Fix for sys.version_info not containing attribute 'major' in python 2.6
- Fix for python 2.6 not containing total_seconds() in datetime 

ToDo: Update results from local tests on different machines in the related tasks