### PR TITLE
Installing all patches on an Auto Patching request on CentOS

### DIFF
--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -114,13 +114,12 @@ class Constants(object):
     MAX_ASSESSMENT_RETRY_COUNT = 5
     MAX_INSTALLATION_RETRY_COUNT = 3
 
-    # Package Classifications
-    PACKAGE_CLASSIFICATIONS = {
-        0: 'Unclassified',           # doesn't serve a functional purpose in bit mask, but stands in for 'All' in code
-        1: 'Critical',
-        2: 'Security',
-        4: 'Other'
-    }
+    class PackageClassification(EnumBackport):
+        UNCLASSIFIED = 'Unclassified'
+        CRITICAL = 'Critical'
+        SECURITY = 'Security'
+        OTHER = 'Other'
+
     PKG_MGR_SETTING_FILTER_CRITSEC_ONLY = 'FilterCritSecOnly'
     PKG_MGR_SETTING_IDENTITY = 'PackageManagerIdentity'
     PKG_MGR_SETTING_IGNORE_PKG_FILTER = 'IgnorePackageFilter'

--- a/src/core/src/core_logic/PackageFilter.py
+++ b/src/core/src/core_logic/PackageFilter.py
@@ -15,6 +15,7 @@
 # Requires Python 2.7+
 
 """Package Filter"""
+
 from core.src.bootstrap.Constants import Constants
 import fnmatch
 
@@ -159,7 +160,8 @@ class PackageFilter(object):
 
     def is_msft_all_classification_included(self):
         """Returns true if all classifications were individually selected *OR* (nothing was selected AND no inclusion list is present) -- business logic"""
-        all_classifications_explicitly_selected = bool((len(self.installation_included_classifications) == len(Constants.PACKAGE_CLASSIFICATIONS) - 1))
+        all_classifications = [key for key in Constants.PackageClassification.__dict__.keys() if not key.startswith('__')]
+        all_classifications_explicitly_selected = bool(len(self.installation_included_classifications) == (len(all_classifications) - 1))
         no_classifications_selected = bool(len(self.installation_included_classifications) == 0)
         only_unclassified_selected = bool('Unclassified' in self.installation_included_classifications and len(self.installation_included_classifications) == 1)
         return all_classifications_explicitly_selected or ((no_classifications_selected or only_unclassified_selected) and not self.is_inclusion_list_present())

--- a/src/core/src/package_managers/YumPackageManager.py
+++ b/src/core/src/package_managers/YumPackageManager.py
@@ -60,9 +60,9 @@ class YumPackageManager(PackageManager):
         installation_included_classifications = [] if execution_config.included_classifications_list is None else execution_config.included_classifications_list
         if execution_config.maintenance_run_id is not None and execution_config.operation.lower() == Constants.INSTALLATION.lower() \
                 and 'CentOS' in str(env_layer.platform.linux_distribution()) \
-                and ('Critical' in installation_included_classifications or 'Security' in installation_included_classifications):
+                and 'Critical' in installation_included_classifications and 'Security' in installation_included_classifications:
             self.composite_logger.log_debug("Updating classifications list to install all patches for the Auto Patching request since classification based patching is not available on CentOS machines")
-            execution_config.included_classifications_list = [Constants.PACKAGE_CLASSIFICATIONS.__getitem__(1), Constants.PACKAGE_CLASSIFICATIONS.__getitem__(2), Constants.PACKAGE_CLASSIFICATIONS.__getitem__(4)]
+            execution_config.included_classifications_list = [Constants.PackageClassification.CRITICAL, Constants.PackageClassification.SECURITY, Constants.PackageClassification.OTHER]
 
     def refresh_repo(self):
         pass  # Refresh the repo is no ops in YUM

--- a/src/core/src/package_managers/YumPackageManager.py
+++ b/src/core/src/package_managers/YumPackageManager.py
@@ -56,6 +56,14 @@ class YumPackageManager(PackageManager):
         self.set_package_manager_setting(Constants.PKG_MGR_SETTING_IDENTITY, Constants.YUM)
         self.STR_TOTAL_DOWNLOAD_SIZE = "Total download size: "
 
+        # if an Auto Patching request comes in on a CentOS machine with Security and/or Critical classifications selected, we need to install all patches
+        installation_included_classifications = [] if execution_config.included_classifications_list is None else execution_config.included_classifications_list
+        if execution_config.maintenance_run_id is not None and execution_config.operation.lower() == Constants.INSTALLATION.lower() \
+                and 'CentOS' in str(env_layer.platform.linux_distribution()) \
+                and ('Critical' in installation_included_classifications or 'Security' in installation_included_classifications):
+            self.composite_logger.log_debug("Updating classifications list to install all patches for the Auto Patching request since classification based patching is not available on CentOS machines")
+            execution_config.included_classifications_list = [Constants.PACKAGE_CLASSIFICATIONS.__getitem__(1), Constants.PACKAGE_CLASSIFICATIONS.__getitem__(2), Constants.PACKAGE_CLASSIFICATIONS.__getitem__(4)]
+
     def refresh_repo(self):
         pass  # Refresh the repo is no ops in YUM
 

--- a/src/core/tests/TestCoreMain.py
+++ b/src/core/tests/TestCoreMain.py
@@ -21,6 +21,7 @@ import unittest
 from core.src.CoreMain import CoreMain
 from core.src.bootstrap.Constants import Constants
 from core.tests.library.ArgumentComposer import ArgumentComposer
+from core.tests.library.LegacyEnvLayerExtensions import LegacyEnvLayerExtensions
 from core.tests.library.RuntimeCompositor import RuntimeCompositor
 
 
@@ -35,6 +36,12 @@ class TestCoreMain(unittest.TestCase):
     def tearDown(self):
         # self.runtime.stop()
         pass
+
+    def mock_linux_distribution_to_return_centos(self):
+        return ['CentOS Linux', '7.9.2009', 'Core']
+
+    def mock_linux_distribution_to_return_redhat(self):
+        return ['Red Hat Enterprise Linux Server', '7.5', 'Maipo']
 
     def test_operation_fail_for_non_autopatching_request(self):
         # Test for non auto patching request
@@ -292,6 +299,104 @@ class TestCoreMain(unittest.TestCase):
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
         self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_ERROR.lower())
         runtime.stop()
+
+    def test_install_all_packages_for_centos_autopatching(self):
+        """Unit test for auto patching request on CentOS, should install all patches irrespective of classification"""
+
+        backup_envlayer_platform_linux_distribution = LegacyEnvLayerExtensions.LegacyPlatform.linux_distribution
+        LegacyEnvLayerExtensions.LegacyPlatform.linux_distribution = self.mock_linux_distribution_to_return_centos
+
+        argument_composer = ArgumentComposer()
+        maintenance_run_id = "9/28/2020 02:00:00 PM +00:00"
+        classifications_to_include = ["Security", "Critical"]
+        argument_composer.maintenance_run_id = str(maintenance_run_id)
+        argument_composer.classifications_to_include = classifications_to_include
+        runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.YUM)
+        runtime.set_legacy_test_type("HappyPath")
+        CoreMain(argument_composer.get_composed_arguments())
+
+        # check telemetry events
+        self.__check_telemetry_events(runtime)
+
+        # check status file
+        with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
+            substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
+        self.assertEquals(len(substatus_file_data), 3)
+        self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
+        self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
+        self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["installedPatchCount"] == 5)
+        self.assertEqual(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][0]["name"], "selinux-policy.noarch")
+        self.assertTrue("Other" in str(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][0]["classifications"]))
+        self.assertTrue("Installed" == json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][0]["patchInstallationState"])
+        self.assertEqual(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][1]["name"], "selinux-policy-targeted.noarch")
+        self.assertTrue("Other" in str(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][1]["classifications"]))
+        self.assertTrue("Installed" == json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][1]["patchInstallationState"])
+        self.assertEqual(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][2]["name"], "libgcc.i686")
+        self.assertTrue("libgcc.i686_4.8.5-28.el7_CentOS Linux_7.9.2009" in str(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][2]["patchId"]))
+        self.assertTrue("Security" in str(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][2]["classifications"]))
+        self.assertTrue("Installed" == json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][2]["patchInstallationState"])
+        self.assertTrue(substatus_file_data[2]["name"] == Constants.PATCH_METADATA_FOR_HEALTHSTORE)
+        self.assertTrue(substatus_file_data[2]["status"] == Constants.STATUS_SUCCESS.lower())
+        substatus_file_data_patch_metadata_summary = json.loads(substatus_file_data[2]["formattedMessage"]["message"])
+        self.assertEqual(substatus_file_data_patch_metadata_summary["patchVersion"], "2020.09.28")
+        self.assertTrue(substatus_file_data_patch_metadata_summary["shouldReportToHealthStore"])
+        runtime.stop()
+
+        LegacyEnvLayerExtensions.LegacyPlatform.linux_distribution = backup_envlayer_platform_linux_distribution
+
+    def test_install_only_critical_and_security_packages_for_redhat_autopatching(self):
+        """Unit test for auto patching request on Redhat, should install only critical and security patches"""
+
+        backup_envlayer_platform_linux_distribution = LegacyEnvLayerExtensions.LegacyPlatform.linux_distribution
+        LegacyEnvLayerExtensions.LegacyPlatform.linux_distribution = self.mock_linux_distribution_to_return_redhat
+
+        argument_composer = ArgumentComposer()
+        maintenance_run_id = "9/28/2020 02:00:00 PM +00:00"
+        classifications_to_include = ["Security", "Critical"]
+        argument_composer.maintenance_run_id = str(maintenance_run_id)
+        argument_composer.classifications_to_include = classifications_to_include
+        runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.YUM)
+        runtime.set_legacy_test_type("HappyPath")
+        CoreMain(argument_composer.get_composed_arguments())
+
+        # check telemetry events
+        self.__check_telemetry_events(runtime)
+
+        # check status file
+        with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
+            substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
+        self.assertEquals(len(substatus_file_data), 3)
+        self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
+        self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
+        self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["installedPatchCount"] == 1)
+        self.assertEqual(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][0]["name"], "selinux-policy.noarch")
+        self.assertTrue("Other" in str(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][0]["classifications"]))
+        self.assertTrue("NotSelected" == json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][0]["patchInstallationState"])
+        self.assertEqual(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][1]["name"], "selinux-policy-targeted.noarch")
+        self.assertTrue("Other" in str(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][1]["classifications"]))
+        self.assertTrue("NotSelected" == json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][1]["patchInstallationState"])
+        self.assertEqual(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][2]["name"], "tar.x86_64")
+        self.assertTrue("Other" in str(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][2]["classifications"]))
+        self.assertTrue("NotSelected" == json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][2]["patchInstallationState"])
+        self.assertEqual(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][3]["name"], "tcpdump.x86_64")
+        self.assertTrue("Other" in str(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][3]["classifications"]))
+        self.assertTrue("NotSelected" == json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][3]["patchInstallationState"])
+        self.assertEqual(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][4]["name"], "libgcc.i686")
+        self.assertTrue("libgcc.i686_4.8.5-28.el7_Red Hat Enterprise Linux Server_7.5" in str(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][4]["patchId"]))
+        self.assertTrue("Security" in str(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][4]["classifications"]))
+        self.assertTrue("Installed" == json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][4]["patchInstallationState"])
+        self.assertTrue(substatus_file_data[2]["name"] == Constants.PATCH_METADATA_FOR_HEALTHSTORE)
+        self.assertTrue(substatus_file_data[2]["status"] == Constants.STATUS_SUCCESS.lower())
+        substatus_file_data_patch_metadata_summary = json.loads(substatus_file_data[2]["formattedMessage"]["message"])
+        self.assertEqual(substatus_file_data_patch_metadata_summary["patchVersion"], "2020.09.28")
+        self.assertTrue(substatus_file_data_patch_metadata_summary["shouldReportToHealthStore"])
+        runtime.stop()
+
+        LegacyEnvLayerExtensions.LegacyPlatform.linux_distribution = backup_envlayer_platform_linux_distribution
 
     def __check_telemetry_events(self, runtime):
         all_events = os.listdir(runtime.telemetry_writer.events_folder_path)

--- a/src/core/tests/TestYumPackageManager.py
+++ b/src/core/tests/TestYumPackageManager.py
@@ -248,7 +248,7 @@ class TestYumPackageManager(unittest.TestCase):
         self.runtime.stop()
 
         argument_composer = ArgumentComposer()
-        argument_composer.classifications_to_include = [Constants.PACKAGE_CLASSIFICATIONS[0]]
+        argument_composer.classifications_to_include = [Constants.PackageClassification.UNCLASSIFIED]
         argument_composer.patches_to_exclude = ["ssh*", "test"]
         self.runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.YUM)
         self.container = self.runtime.container
@@ -280,7 +280,7 @@ class TestYumPackageManager(unittest.TestCase):
         self.runtime.stop()
 
         argument_composer = ArgumentComposer()
-        argument_composer.classifications_to_include = [Constants.PACKAGE_CLASSIFICATIONS[1]]
+        argument_composer.classifications_to_include = [Constants.PackageClassification.CRITICAL]
         argument_composer.patches_to_exclude = ["ssh*", "test"]
         argument_composer.patches_to_include = ["ssh", "tar*"]
         self.runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.YUM)
@@ -308,7 +308,7 @@ class TestYumPackageManager(unittest.TestCase):
         self.runtime.stop()
 
         argument_composer = ArgumentComposer()
-        argument_composer.classifications_to_include = [Constants.PACKAGE_CLASSIFICATIONS[4]]
+        argument_composer.classifications_to_include = [Constants.PackageClassification.OTHER]
         argument_composer.patches_to_include = ["ssh", "tcpdump"]
         argument_composer.patches_to_exclude = ["ssh*", "test"]
         self.runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.YUM)
@@ -340,7 +340,7 @@ class TestYumPackageManager(unittest.TestCase):
         self.runtime.stop()
 
         argument_composer = ArgumentComposer()
-        argument_composer.classifications_to_include = [Constants.PACKAGE_CLASSIFICATIONS[0]]
+        argument_composer.classifications_to_include = [Constants.PackageClassification.UNCLASSIFIED]
         argument_composer.patches_to_include = ["ssh", "tar*"]
         argument_composer.patches_to_exclude = ["ssh*", "test"]
         self.runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.YUM)
@@ -366,7 +366,7 @@ class TestYumPackageManager(unittest.TestCase):
         self.runtime.stop()
 
         argument_composer = ArgumentComposer()
-        argument_composer.classifications_to_include = [Constants.PACKAGE_CLASSIFICATIONS[0]]
+        argument_composer.classifications_to_include = [Constants.PackageClassification.UNCLASSIFIED]
         argument_composer.patches_to_include = ["ssh", "selinux-policy-targeted.noarch"]
         argument_composer.patches_to_exclude = ["ssh*", "test"]
         self.runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.YUM)
@@ -392,7 +392,7 @@ class TestYumPackageManager(unittest.TestCase):
         self.runtime.stop()
 
         argument_composer = ArgumentComposer()
-        argument_composer.classifications_to_include = [Constants.PACKAGE_CLASSIFICATIONS[0]]
+        argument_composer.classifications_to_include = [Constants.PackageClassification.UNCLASSIFIED]
         argument_composer.patches_to_include = ["ssh"]
         argument_composer.patches_to_exclude = ["ssh*", "test"]
         self.runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.YUM)

--- a/src/core/tests/TestZypperPackageManager.py
+++ b/src/core/tests/TestZypperPackageManager.py
@@ -69,7 +69,7 @@ class TestZypperPackageManager(unittest.TestCase):
         # legacy_test_type ='Happy Path'
         self.runtime.stop()
         argument_composer = ArgumentComposer()
-        argument_composer.classifications_to_include = [Constants.PACKAGE_CLASSIFICATIONS[2]]
+        argument_composer.classifications_to_include = [Constants.PackageClassification.SECURITY]
         self.runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.ZYPPER)
         self.container = self.runtime.container
         package_manager = self.container.get('package_manager')
@@ -86,7 +86,7 @@ class TestZypperPackageManager(unittest.TestCase):
         # legacy_test_type ='Happy Path'
         self.runtime.stop()
         argument_composer = ArgumentComposer()
-        argument_composer.classifications_to_include = [Constants.PACKAGE_CLASSIFICATIONS[4]]
+        argument_composer.classifications_to_include = [Constants.PackageClassification.OTHER]
         self.runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.ZYPPER)
         self.container = self.runtime.container
         package_manager = self.container.get('package_manager')

--- a/src/core/tests/library/LegacyEnvLayerExtensions.py
+++ b/src/core/tests/library/LegacyEnvLayerExtensions.py
@@ -24,8 +24,7 @@ class LegacyEnvLayerExtensions():
         self.legacy_test_type = "HappyPath"
 
     class LegacyPlatform(object):
-        @staticmethod
-        def linux_distribution():
+        def linux_distribution(self):
             return ['Ubuntu', '16.04', 'Xenial']
 
         @staticmethod
@@ -345,7 +344,7 @@ class LegacyEnvLayerExtensions():
                         code = 0
                         package = cmd.replace('sudo yum list installed ', '')
                         whitelisted_versions = [
-                            '3.13.1-102.el7_3.16']  # any list of versions you want to work for *any* package
+                            '3.13.1-102.el7_3.16', '4.8.5-28.el7', '2:1.26-34.el7', '14:4.9.2-3.el7']  # any list of versions you want to work for *any* package
                         output = "Loaded plugins: product-id, search-disabled-repos, subscription-manager\n" + \
                                  "Installed Packages\n"
                         template = "<PACKAGE>                                                                                     <VERSION>                                                                                      @anaconda/7.3\n"


### PR DESCRIPTION
Includes:

- Change to install all available patches on CentOS for an Auto Patching request
- Unit test to verify the functionality in CentOS
- Unit test to verify Redhat machines are not affected by this change.
- Logs validating this change against different distros added in the task