### PR TITLE
Bug fixes and improvements

### DIFF
--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -189,8 +189,9 @@ class Constants(object):
         LogAlways = "LogAlways"
 
     TELEMETRY_TASK_NAME = "ExtensionCoreLog"
-    TELEMETRY_AT_AGENT_NOT_COMPATIBLE_ERROR_MSG = "The minimum Azure Linux Agent version prerequisite for Linux patching was not met. Please update the Azure Linux Agent on this machine following instructions here: http://aka.ms/UpdateLinuxAgent"
-    TELEMETRY_AT_AGENT_COMPATIBLE_MSG = "The minimum Azure Linux Agent version prerequisite for Linux patching was met."
+
+    TELEMETRY_AT_AGENT_NOT_COMPATIBLE_ERROR_MSG = "Minimum Linux Agent version prerequisite not met. Resolution: http://aka.ms/UpdateLinuxAgent"
+    TELEMETRY_AT_AGENT_COMPATIBLE_MSG = "Minimum Linux Agent version prerequisite met"
 
     UTC_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 

--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -190,7 +190,7 @@ class Constants(object):
 
     TELEMETRY_TASK_NAME = "ExtensionCoreLog"
 
-    TELEMETRY_AT_AGENT_NOT_COMPATIBLE_ERROR_MSG = "Minimum Linux Agent version prerequisite not met. Resolution: http://aka.ms/UpdateLinuxAgent"
+    TELEMETRY_AT_AGENT_NOT_COMPATIBLE_ERROR_MSG = "Unsupported older Azure Linux Agent version. To resolve: http://aka.ms/UpdateLinuxAgent"
     TELEMETRY_AT_AGENT_COMPATIBLE_MSG = "Minimum Linux Agent version prerequisite met"
 
     UTC_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"

--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -191,7 +191,7 @@ class Constants(object):
     TELEMETRY_TASK_NAME = "ExtensionCoreLog"
 
     TELEMETRY_AT_AGENT_NOT_COMPATIBLE_ERROR_MSG = "Unsupported older Azure Linux Agent version. To resolve: http://aka.ms/UpdateLinuxAgent"
-    TELEMETRY_AT_AGENT_COMPATIBLE_MSG = "Minimum Linux Agent version prerequisite met"
+    TELEMETRY_AT_AGENT_COMPATIBLE_MSG = "Minimum Azure Linux Agent version prerequisite met"
 
     UTC_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 

--- a/src/core/src/core_logic/PatchInstaller.py
+++ b/src/core/src/core_logic/PatchInstaller.py
@@ -94,22 +94,8 @@ class PatchInstaller(object):
 
         # Combining maintenance
         overall_patch_installation_successful = bool(update_run_successful and not maintenance_window_exceeded)
-        if overall_patch_installation_successful:
-            self.status_handler.set_installation_substatus_json(status=Constants.STATUS_SUCCESS)
-            # update patch metadata in status for auto patching request, to be reported to healthstore
-            if self.execution_config.maintenance_run_id is not None:
-                try:
-                    #todo: temp fix to test auto patching, this will be reset to using the maintenanceRunId string as is, once the corresponding changes in RSM are made
-                    # patch_version = str(self.execution_config.maintenance_run_id)
-                    patch_version = datetime.datetime.strptime(self.execution_config.maintenance_run_id.split(" ")[0], "%m/%d/%Y").strftime('%Y.%m.%d')
-                    self.status_handler.set_patch_metadata_for_healthstore_substatus_json(patch_version=patch_version if patch_version is not None and patch_version != "" else Constants.PATCH_VERSION_UNKNOWN,
-                                                                                          report_to_healthstore=True,
-                                                                                          wait_after_update=False)
-                except ValueError as e:
-                    error_message = "Maintenance Run Id is in incorrect format. Expected=[DateTimeUTC]. Actual=[{0}]. Error=[{1}]".format(str(self.execution_config.maintenance_run_id), repr(e))
-                    self.composite_logger.log_error(error_message)
-                    raise Exception(error_message)
-        else:
+
+        if not overall_patch_installation_successful:
             self.status_handler.set_installation_substatus_json(status=Constants.STATUS_ERROR)
             # NOTE: For auto patching requests, no need to report patch metadata to healthstore in case of failure
 
@@ -281,6 +267,26 @@ class PatchInstaller(object):
         except Exception as error:
             self.composite_logger.log_error('Error while checking for reboot pending: ' + repr(error))
             return True     # defaults for safety
+
+    def mark_installation_completed(self):
+        """ Marks Installation operation as completed by updating the status of PatchInstallationSummary as success and patch metadata to be sent to healthstore.
+        This is set outside of start_installation function to a restriction in CRP, where installation substatus should be marked as completed only after the implicit (2nd) assessment operation """
+        self.status_handler.set_current_operation(Constants.INSTALLATION)  # Required for status handler to log errors, that occur during marking installation completed, in installation substatus
+
+        self.status_handler.set_installation_substatus_json(status=Constants.STATUS_SUCCESS)
+        # update patch metadata in status for auto patching request, to be reported to healthstore
+        if self.execution_config.maintenance_run_id is not None:
+            try:
+                # todo: temp fix to test auto patching, this will be reset to using the maintenanceRunId string as is, once the corresponding changes in RSM are made
+                # patch_version = str(self.execution_config.maintenance_run_id)
+                patch_version = datetime.datetime.strptime(self.execution_config.maintenance_run_id.split(" ")[0], "%m/%d/%Y").strftime('%Y.%m.%d')
+                self.status_handler.set_patch_metadata_for_healthstore_substatus_json(patch_version=patch_version if patch_version is not None and patch_version != "" else Constants.PATCH_VERSION_UNKNOWN,
+                                                                                      report_to_healthstore=True,
+                                                                                      wait_after_update=False)
+            except ValueError as e:
+                error_message = "Maintenance Run Id is in incorrect format. Expected=[DateTimeUTC]. Actual=[{0}]. Error=[{1}]".format(str(self.execution_config.maintenance_run_id), repr(e))
+                self.composite_logger.log_error(error_message)
+                raise Exception(error_message)
 
     # region Installation Progress support
     def perform_status_reconciliation_conditionally(self, package_manager, condition=True):

--- a/src/core/src/service_interfaces/StatusHandler.py
+++ b/src/core/src/service_interfaces/StatusHandler.py
@@ -507,6 +507,9 @@ class StatusHandler(object):
     def set_current_operation(self, operation):
         self.__current_operation = operation
 
+    def get_current_operation(self):
+        return self.__current_operation
+
     def __get_total_error_count_from_prev_status(self, error_message):
         try:
             return int(re.search('(.+?) error/s reported.', error_message).group(1))

--- a/src/core/tests/TestCoreMain.py
+++ b/src/core/tests/TestCoreMain.py
@@ -277,7 +277,7 @@ class TestCoreMain(unittest.TestCase):
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_ERROR.lower())
         self.assertEqual(len(json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"]), 1)
-        self.assertTrue("The minimum Azure Linux Agent version prerequisite for Linux patching was not met" in json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"][0]["message"])
+        self.assertTrue(Constants.TELEMETRY_AT_AGENT_NOT_COMPATIBLE_ERROR_MSG in json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"][0]["message"])
         runtime.stop()
 
     def test_installation_operation_fail_due_to_no_telemetry(self):
@@ -295,7 +295,7 @@ class TestCoreMain(unittest.TestCase):
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_ERROR.lower())
         self.assertEqual(len(json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"]), 1)
-        self.assertTrue("The minimum Azure Linux Agent version prerequisite for Linux patching was not met" in json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"][0]["message"])
+        self.assertTrue(Constants.TELEMETRY_AT_AGENT_NOT_COMPATIBLE_ERROR_MSG in json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"][0]["message"])
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
         self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_ERROR.lower())
         runtime.stop()


### PR DESCRIPTION
Contains:

- Fix for bug where the last status read in CRP for an installation operation has availablePatchSummary marked as 'In Progress'.
  This was due to the status for PatchInstallationSummary in status blob. CRP considers this status as the terminal state. So once PatchInstallationSummary is marked as 'success', CRP stops polling substatus and does not wait for the implicit (or 2nd) assessment to complete, if that is pending. 
Changed the implementation to only mark PatchInstallationSummary as 'success' once the implicit assessment is completed.
code change includes: removing substatus set to success in PatchInstaller and adding that in CoreMain after implicit assessment has competed

- Updated error message text for when Linux agent does not support telemetry, to ensure the error object within status blob includes the complete message
Code change in Constants.py

- For an installation operation, adding error details in installation substatus also if assessment fails. The error within installation substatus just mentions that an error occurred due to assessment failure and to refer the assessment substatus for more details.
Code change in CoreMain: Added a new variable to track overall installation substatus (var: overall_patch_installation_operation_successful), which includes implicit assessment, and using this to determine if failure occurred during assessment, in function update_patch_substatus_if_pending()

- Fix for adding error details in substatus, when failure occurs during core setup. 
Code change in CoreMain: Moved execution config read above any actions and adding all setup errors in assessment substatus. For an installation operation, a generic error ~ install failed due to assessment fail will be added in installation substatus due to the change in point 3 above.