### PR TITLE
Bug fix for error in telemetry error- execution could not complete, internal error

### DIFF
--- a/src/core/src/service_interfaces/TelemetryWriter.py
+++ b/src/core/src/service_interfaces/TelemetryWriter.py
@@ -14,6 +14,7 @@
 #
 # Requires Python 2.7+
 import datetime
+import errno
 import json
 import os
 import re
@@ -273,8 +274,16 @@ class TelemetryWriter(object):
         """ Returns total size, in bytes, of the events folder """
         total_dir_size = 0
         for f in os.listdir(self.events_folder_path):
-            file_path = os.path.join(self.events_folder_path, f)
-            total_dir_size += os.path.getsize(file_path) if os.path.isfile(file_path) else 0
+            try:
+                file_path = os.path.join(self.events_folder_path, f)
+                total_dir_size += os.path.getsize(file_path)
+            except OSError as error:
+                # ENOENT is for 'No such file or directory' error. Ignore if exception is raised for file not found, since Guest Agent can delete the file any time
+                if error.errno == errno.ENOENT:
+                    continue
+                else:
+                    self.composite_logger.log_telemetry_module_error("Error occurred while fetching event directory size. [Error={0}].".format(repr(error)))
+                    raise
         return total_dir_size
 
     @staticmethod
@@ -287,15 +296,18 @@ class TelemetryWriter(object):
         """ Returns the size of a file. Extracted out for mocking in unit test """
         return os.path.getsize(file_path)
 
-    @staticmethod
-    def __fetch_events_from_previous_file(file_path):
-        """ Fetch contents from the file """
-        if not os.path.exists(file_path):
-            return []
-
-        with open(file_path, 'r') as file_handle:
-            file_contents = file_handle.read()
-            return json.loads(file_contents)
+    def __fetch_events_from_previous_file(self, file_path):
+        """ Fetch contents from the file, return empty if file doesn't exist """
+        try:
+            with open(file_path, 'r') as file_handle:
+                file_contents = file_handle.read()
+                return json.loads(file_contents)
+        except OSError as error:
+            if error.errno == errno.ENOENT:
+                return []
+            else:
+                self.composite_logger.log_telemetry_module_error("Error occurred while fetching contents from existing event file. [File={0}] [Error={1}].".format(repr(file_path), repr(error)))
+                raise
 
     def set_operation_id(self, operation_id):
         self.__operation_id = operation_id

--- a/src/core/src/service_interfaces/TelemetryWriter.py
+++ b/src/core/src/service_interfaces/TelemetryWriter.py
@@ -273,8 +273,8 @@ class TelemetryWriter(object):
         """ Returns total size, in bytes, of the events folder """
         total_dir_size = 0
         for f in os.listdir(self.events_folder_path):
-            if os.path.isfile(os.path.join(self.events_folder_path, f)):
-                total_dir_size += os.path.getsize(os.path.join(self.events_folder_path, f))
+            file_path = os.path.join(self.events_folder_path, f)
+            total_dir_size += os.path.getsize(file_path) if os.path.exists(file_path) and os.path.isfile(file_path) else 0
         return total_dir_size
 
     @staticmethod
@@ -290,6 +290,9 @@ class TelemetryWriter(object):
     @staticmethod
     def __fetch_events_from_previous_file(file_path):
         """ Fetch contents from the file """
+        if not os.path.exists(file_path):
+            return []
+
         with open(file_path, 'r') as file_handle:
             file_contents = file_handle.read()
             return json.loads(file_contents)

--- a/src/core/src/service_interfaces/TelemetryWriter.py
+++ b/src/core/src/service_interfaces/TelemetryWriter.py
@@ -274,7 +274,7 @@ class TelemetryWriter(object):
         total_dir_size = 0
         for f in os.listdir(self.events_folder_path):
             file_path = os.path.join(self.events_folder_path, f)
-            total_dir_size += os.path.getsize(file_path) if os.path.exists(file_path) and os.path.isfile(file_path) else 0
+            total_dir_size += os.path.getsize(file_path) if os.path.isfile(file_path) else 0
         return total_dir_size
 
     @staticmethod

--- a/src/core/tests/TestTelemetryWriter.py
+++ b/src/core/tests/TestTelemetryWriter.py
@@ -43,6 +43,9 @@ class TestTelemetryWriter(unittest.TestCase):
     def mock_get_file_size(self, file_path):
         return Constants.TELEMETRY_EVENT_FILE_SIZE_LIMIT_IN_CHARS + 10
 
+    def mock_os_listdir(self, file_path):
+        return ['testevent1.json', 'testevent2.json', 'testevent3.json', 'testevent4.json']
+
     def test_write_event(self):
         self.runtime.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task")
         latest_event_file = [pos_json for pos_json in os.listdir(self.runtime.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)][-1]
@@ -205,6 +208,12 @@ class TestTelemetryWriter(unittest.TestCase):
         Constants.TELEMETRY_MAX_TIME_IN_SECONDS_FOR_EVENT_COUNT_THROTTLE = max_time_for_event_count_throttle_backup
 
         Constants.TELEMETRY_MAX_EVENT_COUNT_THROTTLE = event_count_max_throttle_backup
+
+    def test_events_deleted_outside_of_extension_while_extension_is_running(self):
+        backup_os_listdir = os.listdir
+        os.listdir = self.mock_os_listdir
+        self.runtime.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task")
+        os.listdir = backup_os_listdir
 
 
 if __name__ == '__main__':

--- a/src/extension/src/TelemetryWriter.py
+++ b/src/extension/src/TelemetryWriter.py
@@ -140,8 +140,8 @@ class TelemetryWriter(object):
         """ Returns total size, in bytes, of the events folder """
         total_dir_size = 0
         for f in os.listdir(self.events_folder_path):
-            if os.path.isfile(os.path.join(self.events_folder_path, f)):
-                total_dir_size += os.path.getsize(os.path.join(self.events_folder_path, f))
+            file_path = os.path.join(self.events_folder_path, f)
+            total_dir_size += os.path.getsize(file_path) if os.path.exists(file_path) and os.path.isfile(file_path) else 0
         return total_dir_size
 
     @staticmethod
@@ -157,6 +157,9 @@ class TelemetryWriter(object):
     @staticmethod
     def __fetch_events_from_previous_file(file_path):
         """ Fetch contents from the file """
+        if not os.path.exists(file_path):
+            return []
+
         with open(file_path, 'r') as file_handle:
             file_contents = file_handle.read()
             return json.loads(file_contents)

--- a/src/extension/src/TelemetryWriter.py
+++ b/src/extension/src/TelemetryWriter.py
@@ -141,7 +141,7 @@ class TelemetryWriter(object):
         total_dir_size = 0
         for f in os.listdir(self.events_folder_path):
             file_path = os.path.join(self.events_folder_path, f)
-            total_dir_size += os.path.getsize(file_path) if os.path.exists(file_path) and os.path.isfile(file_path) else 0
+            total_dir_size += os.path.getsize(file_path) if os.path.isfile(file_path) else 0
         return total_dir_size
 
     @staticmethod

--- a/src/extension/tests/TestTelemetryWriter.py
+++ b/src/extension/tests/TestTelemetryWriter.py
@@ -34,6 +34,9 @@ class TestTelemetryWriter(unittest.TestCase):
     def mock_get_file_size(self, file_path):
         return Constants.TELEMETRY_EVENT_FILE_SIZE_LIMIT_IN_CHARS + 10
 
+    def mock_os_listdir(self, file_path):
+        return ['testevent1.json', 'testevent2.json', 'testevent3.json', 'testevent4.json']
+
     def test_write_event(self):
         self.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task")
         with open(os.path.join(self.telemetry_writer.events_folder_path, os.listdir(self.telemetry_writer.events_folder_path)[0]), 'r+') as f:
@@ -140,6 +143,12 @@ class TestTelemetryWriter(unittest.TestCase):
         Constants.TELEMETRY_DIR_SIZE_LIMIT_IN_CHARS = telemetry_dir_size_backup
         Constants.TELEMETRY_EVENT_FILE_SIZE_LIMIT_IN_CHARS = telemetry_event_size_backup
         os.remove = os_remove_backup
+
+    def test_events_deleted_outside_of_extension_while_extension_is_running(self):
+        backup_os_listdir = os.listdir
+        os.listdir = self.mock_os_listdir
+        self.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task")
+        os.listdir = backup_os_listdir
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Error reported in our logs is "Internal reporting error. Execution could not complete". Debugging revealed this happens while the extension is trying to access a file that was recently deleted by the agent. 
NOTE: Agent reads all events every 5 mins and deletes them at the end of each run, independent from our extension's run

Added a file exists check in all the possible missing places before processing the event file in TelemetryWriter.