### PR TITLE
Updating extension version for new release: 1.6.19

### DIFF
--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -30,7 +30,7 @@ class Constants(object):
     UNKNOWN = "Unknown"
 
     # Extension version (todo: move to a different file)
-    EXT_VERSION = "1.6.18"
+    EXT_VERSION = "1.6.19"
 
     # Runtime environments
     TEST = 'Test'

--- a/src/extension/src/Constants.py
+++ b/src/extension/src/Constants.py
@@ -28,7 +28,7 @@ class Constants(object):
                         yield item
 
     # Extension version (todo: move to a different file)
-    EXT_VERSION = "1.6.18"
+    EXT_VERSION = "1.6.19"
 
     # Runtime environments
     TEST = 'Test'

--- a/src/extension/src/manifest.xml
+++ b/src/extension/src/manifest.xml
@@ -2,7 +2,7 @@
 <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure">
   <ProviderNameSpace>Microsoft.CPlat.Core</ProviderNameSpace>
   <Type>LinuxPatchExtension</Type>
-  <Version>1.6.18</Version>
+  <Version>1.6.19</Version>
   <Label>Microsoft Azure VM InGuest Patch Extension for Linux Virtual Machines</Label>
   <HostingResources>VmRole</HostingResources>
   <MediaLink></MediaLink>


### PR DESCRIPTION
This version contains bug fixes for:

- Telemetry error - 'Execution could not complete. Internal reporting error' exception
- Core unable to execute sudo commands, mostly seen in RHEL 7.2
- Updating Installation substatus only after implicit assessment is completed.
- Updates to error message reported when agent does not support telemetry
- Installation should surface if operation exits due to assessment failures
- Adding error details in substatus, when failure occurs during core setup