### PR TITLE
Fix for patch install marked failed before implicit assessment

### DIFF
--- a/src/core/src/CoreMain.py
+++ b/src/core/src/CoreMain.py
@@ -84,6 +84,7 @@ class CoreMain(object):
                 if patch_assessment_successful and patch_installation_successful:
                     patch_installer.mark_installation_completed()
                     overall_patch_installation_operation_successful = True
+                self.update_patch_substatus_if_pending(patch_operation_requested, overall_patch_installation_operation_successful, patch_assessment_successful, configure_patching_successful, status_handler, composite_logger)
 
         except Exception as error:
             # Privileged operation handling for non-production use
@@ -129,6 +130,7 @@ class CoreMain(object):
             if not patch_assessment_successful:
                 status_handler.add_error_to_status("Installation failed due to assessment failure. Please refer the error details in assessment substatus")
             status_handler.set_installation_substatus_json(status=Constants.STATUS_ERROR)
+            # NOTE: For auto patching requests, no need to report patch metadata to health store in case of failure
             composite_logger.log_debug('  -- Persisted failed installation substatus.')
         if not patch_assessment_successful and patch_operation_requested != Constants.CONFIGURE_PATCHING.lower():
             status_handler.set_assessment_substatus_json(status=Constants.STATUS_ERROR)

--- a/src/core/src/core_logic/PatchInstaller.py
+++ b/src/core/src/core_logic/PatchInstaller.py
@@ -95,10 +95,6 @@ class PatchInstaller(object):
         # Combining maintenance
         overall_patch_installation_successful = bool(update_run_successful and not maintenance_window_exceeded)
 
-        if not overall_patch_installation_successful:
-            self.status_handler.set_installation_substatus_json(status=Constants.STATUS_ERROR)
-            # NOTE: For auto patching requests, no need to report patch metadata to healthstore in case of failure
-
         return overall_patch_installation_successful
 
     def raise_if_agent_incompatible(self):

--- a/src/core/src/core_logic/PatchInstaller.py
+++ b/src/core/src/core_logic/PatchInstaller.py
@@ -94,6 +94,7 @@ class PatchInstaller(object):
 
         # Combining maintenance
         overall_patch_installation_successful = bool(update_run_successful and not maintenance_window_exceeded)
+        # NOTE: Not updating installation substatus at this point because we need to wait for the implicit/second assessment to complete first, as per CRP's instructions
 
         return overall_patch_installation_successful
 


### PR DESCRIPTION
Related to the 1st point mentioned in the description/1st comment in this PR: https://github.com/Azure/LinuxPatchExtension/pull/70

Change was made earlier to only update patch installation substatus if the second/implicit assessment is completed. We missed out  one place where the patch install status is marked 'Failed' before implicit assessment is complete. This again leads to the same issue at CRP where the availablePatchSummary remains 'InProgress' since the last status CRP reads is when Patch Install is marked Failed and while assessment is in progress.

Changes in this PR:
- Removed setting patch install to failed within PatchInstaller, so patch install remains in Transitioning state 
- Calling update status in the success path of CoreMain, so patch install is marked appropriately in case of failure after implicit assessment