### PR TITLE
Add zypper process tree telemetry

### DIFF
--- a/src/core/src/package_managers/ZypperPackageManager.py
+++ b/src/core/src/package_managers/ZypperPackageManager.py
@@ -86,13 +86,9 @@ class ZypperPackageManager(PackageManager):
         return out
 
     def get_process_tree_from_pid_in_output(self, message):
-        """ When given a string containing a pid, returns a multi-line string with a list of parent/child processes for that pid.
-            See pattern matching inside the function for details on specific strings that are accepted.
-
+        """ Fetches pid from the error message by searching for the text 'pid' and returns the process tree with all details.
             Example:
-                input:
-                    message (string): Output from package manager: | System management is locked by the application with pid 7914 (/usr/bin/zypper).
-
+                input: message (string): Output from package manager: | System management is locked by the application with pid 7914 (/usr/bin/zypper).
                 returns (string):
                       PID CMD
                      7736 /bin/bash
@@ -102,26 +98,19 @@ class ZypperPackageManager(PackageManager):
                      7982  |           \_ /usr/bin/python3 /usr/lib/zypp/plugins/urlresolver/susecloud
                      7984  |               \_ /usr/bin/python3 /usr/bin/azuremetadata --api latest --subscriptionId --billingTag --attestedData --signature
                      7986  \_ python3 package_test.py
-                     8298      \_ sudo LANG=en_US.UTF8 zypper --non-interactive update --dry-run grub2-i386-pc
-        """
+                     8298      \_ sudo LANG=en_US.UTF8 zypper --non-interactive update --dry-run grub2-i386-pc """
 
         """ First find pid xxxxx within output string.
-
             Example: 'Output from package manager: | System management is locked by the application with pid 7914 (/usr/bin/zypper).'
-
-            pid_substr_search will contain: ' pid 7914'
-        """
+            pid_substr_search will contain: ' pid 7914' """
         regex = re.compile(' pid \d+')
         pid_substr_search = regex.search(message)
         if pid_substr_search is None:
             return None
 
         """ Now extract just pid text from pid_substr_search.
-            
-            Example (pid_substr_search): ' pid 7914'
-                
-            pid_search will contain: '7914'
-        """
+            Example (pid_substr_search): ' pid 7914'   
+            pid_search will contain: '7914' """
         regex = re.compile('\d+')
         pid_search = regex.search(pid_substr_search.group())
         if pid_search is None:
@@ -138,11 +127,7 @@ class ZypperPackageManager(PackageManager):
         code, out = self.env_layer.run_command_output(get_process_tree_cmd, False, False)
 
         # Failed to get process tree
-        if code != 0:
-            return None
-
-        # Also failed to get process tree
-        if len(out) == 0:
+        if code != 0 or len(out) == 0:
             return None
 
         return out

--- a/src/core/src/package_managers/ZypperPackageManager.py
+++ b/src/core/src/package_managers/ZypperPackageManager.py
@@ -140,6 +140,10 @@ class ZypperPackageManager(PackageManager):
         if code is not 0:
             return None
 
+        # Also failed to get process tree
+        if len(out) == 0:
+            return None
+
         return out
 
     # region Classification-based (incl. All) update check

--- a/src/core/src/package_managers/ZypperPackageManager.py
+++ b/src/core/src/package_managers/ZypperPackageManager.py
@@ -111,9 +111,9 @@ class ZypperPackageManager(PackageManager):
             Example:
                 'Output from package manager: | System management is locked by the application with pid 7914 (/usr/bin/zypper).'
 
-            pid_substr_search will contain: ' pid 7914 '
+            pid_substr_search will contain: ' pid 7914'
         """
-        regex = re.compile(' pid \d+ ')
+        regex = re.compile(' pid \d+')
         pid_substr_search = regex.search(message)
         if pid_substr_search is None:
             return None
@@ -122,7 +122,7 @@ class ZypperPackageManager(PackageManager):
             Now extract just pid text from pid_substr_search.
             
             Example (pid_substr_search): 
-                ' pid 7914 '
+                ' pid 7914'
                 
             pid_search will contain: '7914'
         """

--- a/src/core/src/package_managers/ZypperPackageManager.py
+++ b/src/core/src/package_managers/ZypperPackageManager.py
@@ -118,9 +118,6 @@ class ZypperPackageManager(PackageManager):
 
         pid = pid_search.group()
 
-        # TODO: Check to make sure the pid is actually a running process
-        # this is because the below command will always return something, even for nonexistent pids
-
         # Gives a process tree so the calling process name(s) can be identified
         # TODO: consider revisiting in the future to reduce the result to this pid only instead of entire tree
         get_process_tree_cmd = self.zypper_get_process_tree_cmd.format(str(pid))
@@ -128,6 +125,11 @@ class ZypperPackageManager(PackageManager):
 
         # Failed to get process tree
         if code != 0 or len(out) == 0:
+            return None
+
+        # The command returned a process tree that did not contain this process
+        # This can happen when the process doesn't exist because a process tree is always returned
+        if out.find(pid + " ") == -1:
             return None
 
         return out

--- a/src/core/src/package_managers/ZypperPackageManager.py
+++ b/src/core/src/package_managers/ZypperPackageManager.py
@@ -43,6 +43,7 @@ class ZypperPackageManager(PackageManager):
 
         # Package manager exit code(s)
         self.zypper_exitcode_ok = 0
+        self.zypper_exitcode_zypper_locked = 7
         self.zypper_exitcode_zypper_updated = 103
 
         # Support to check for processes requiring restart
@@ -66,9 +67,10 @@ class ZypperPackageManager(PackageManager):
             self.composite_logger.log_warning(" - Return code from package manager: " + str(code))
             self.composite_logger.log_warning(" - Output from package manager: \n|\t" + "\n|\t".join(out.splitlines()))
 
-            process_lock_tree = self.get_process_tree_from_package_manager_msg(out)
-            if process_lock_tree is not None:
-                self.composite_logger.log_warning(" - Process tree of package manager locking process: \n{}".format(process_lock_tree))
+            if code == self.zypper_exitcode_zypper_locked:
+                process_lock_tree = self.get_process_tree_from_package_manager_msg(out)
+                if process_lock_tree is not None:
+                    self.composite_logger.log_warning(" - Process tree of package manager locking process: \n{}".format(process_lock_tree))
 
             self.telemetry_writer.write_execution_error(command, code, out)
             error_msg = 'Unexpected return code (' + str(code) + ') from package manager on command: ' + command

--- a/src/core/src/package_managers/ZypperPackageManager.py
+++ b/src/core/src/package_managers/ZypperPackageManager.py
@@ -128,13 +128,17 @@ class ZypperPackageManager(PackageManager):
             return None
 
         pid = pid_search.group()
+
+        # TODO: Check to make sure the pid is actually a running process
+        # this is because the below command will always return something, even for nonexistent pids
+
         # Gives a process tree so the calling process name(s) can be identified
         # TODO: consider revisiting in the future to reduce the result to this pid only instead of entire tree
         get_process_tree_cmd = self.zypper_get_process_tree_cmd.format(str(pid))
         code, out = self.env_layer.run_command_output(get_process_tree_cmd, False, False)
 
         # Failed to get process tree
-        if code is not 0:
+        if code != 0:
             return None
 
         # Also failed to get process tree

--- a/src/core/tests/Test_ZypperPackageManager.py
+++ b/src/core/tests/Test_ZypperPackageManager.py
@@ -196,12 +196,12 @@ class TestZypperPackageManager(unittest.TestCase):
         self.assertIsNotNone(package_manager.get_process_tree_from_pid_in_output(package_manager_output))
 
     def test_get_process_tree_from_package_manager_output_failure_nonexistent_process(self):
-        self.runtime.set_legacy_test_type('SadPath')
+        self.runtime.set_legacy_test_type('HappyPath')
 
         package_manager = self.container.get('package_manager')
         self.assertIsNotNone(package_manager)
 
-        # Create example package manager message and include test pid
+        # Create example package manager message and include pid that isn't expected in the output
         package_manager_output = 'Output from package manager: | System management is locked by the application with pid 9999 (/usr/bin/zypper).'
 
         # Test to make sure nothing was returned from an invalid process

--- a/src/core/tests/Test_ZypperPackageManager.py
+++ b/src/core/tests/Test_ZypperPackageManager.py
@@ -184,50 +184,41 @@ class TestZypperPackageManager(unittest.TestCase):
         # test for unsuccessfully installing a package
         self.assertEquals(package_manager.install_update_and_dependencies('selinux-policy.noarch', '3.13.1-102.el7_3.16', simulate=True), Constants.FAILED)
 
-    def test_get_process_tree_from_package_manager_msg_success(self):
+    def test_get_process_tree_from_package_manager_output_success(self):
         self.runtime.set_legacy_test_type('HappyPath')
 
         package_manager = self.container.get('package_manager')
         self.assertIsNotNone(package_manager)
 
-        # Get this process' pid to test output with a real running process
-        test_process_pid = os.getpid()
-        self.assertIsNotNone(test_process_pid)
-
-        # Create example package manager message and include this process' pid
-        package_manager_msg = 'Output from package manager: | System management is locked by the application with pid {} (/usr/bin/zypper).'
-        package_manager_msg = package_manager_msg.format(str(test_process_pid))
+        # Create example package manager message and include test pid
+        package_manager_output = 'Output from package manager: | System management is locked by the application with pid 7914 (/usr/bin/zypper).'
 
         # Test to make sure a valid string was returned with process information
-        self.assertIsNotNone(package_manager.get_process_tree_from_pid_in_output(package_manager_msg))
+        self.assertIsNotNone(package_manager.get_process_tree_from_pid_in_output(package_manager_output))
 
-    def test_get_process_tree_from_package_manager_msg_failure_nonexistent_process(self):
-        self.runtime.set_legacy_test_type('HappyPath')
+    def test_get_process_tree_from_package_manager_output_failure_nonexistent_process(self):
+        self.runtime.set_legacy_test_type('SadPath')
 
         package_manager = self.container.get('package_manager')
         self.assertIsNotNone(package_manager)
 
-        # Test with a nonexistent pid
-        test_process_pid = -1
-
-        # Create example package manager message and include the test pid
-        package_manager_msg = 'Output from package manager: | System management is locked by the application with pid {} (/usr/bin/zypper).'
-        package_manager_msg = package_manager_msg.format(str(test_process_pid))
+        # Create example package manager message and include test pid
+        package_manager_output = 'Output from package manager: | System management is locked by the application with pid 9999 (/usr/bin/zypper).'
 
         # Test to make sure nothing was returned from an invalid process
-        self.assertIsNone(package_manager.get_process_tree_from_pid_in_output(package_manager_msg))
+        self.assertIsNone(package_manager.get_process_tree_from_pid_in_output(package_manager_output))
 
-    def test_get_process_tree_from_package_manager_msg_failure_no_pid(self):
+    def test_get_process_tree_from_package_manager_output_failure_no_pid(self):
         self.runtime.set_legacy_test_type('HappyPath')
 
         package_manager = self.container.get('package_manager')
         self.assertIsNotNone(package_manager)
 
         # Create example package manager message
-        package_manager_msg = 'Example error message without a valid pid.'
+        package_manager_output = 'Example error message without a valid pid.'
 
         # Test to make sure nothing was returned from an error message that doesn't contain a pid
-        self.assertIsNone(package_manager.get_process_tree_from_pid_in_output(package_manager_msg))
+        self.assertIsNone(package_manager.get_process_tree_from_pid_in_output(package_manager_output))
 
 
 if __name__ == '__main__':

--- a/src/core/tests/Test_ZypperPackageManager.py
+++ b/src/core/tests/Test_ZypperPackageManager.py
@@ -14,7 +14,6 @@
 #
 # Requires Python 2.7+
 
-import os
 import unittest
 from core.src.bootstrap.Constants import Constants
 from core.tests.library.ArgumentComposer import ArgumentComposer

--- a/src/core/tests/Test_ZypperPackageManager.py
+++ b/src/core/tests/Test_ZypperPackageManager.py
@@ -219,6 +219,29 @@ class TestZypperPackageManager(unittest.TestCase):
         # Test to make sure nothing was returned from an error message that doesn't contain a pid
         self.assertIsNone(package_manager.get_process_tree_from_pid_in_output(package_manager_output))
 
+    def test_get_process_tree_from_package_manager_output_failure_cmd_error_code(self):
+        self.runtime.set_legacy_test_type('SadPath')
+
+        package_manager = self.container.get('package_manager')
+        self.assertIsNotNone(package_manager)
+
+        # Create example package manager message
+        package_manager_output = 'Output from package manager: | System management is locked by the application with pid 7914 (/usr/bin/zypper).'
+
+        # Test to make sure nothing was returned from a non-zero command output code
+        self.assertIsNone(package_manager.get_process_tree_from_pid_in_output(package_manager_output))
+
+    def test_get_process_tree_from_package_manager_output_failure_cmd_empty_output(self):
+        self.runtime.set_legacy_test_type('UnalignedPath')
+
+        package_manager = self.container.get('package_manager')
+        self.assertIsNotNone(package_manager)
+
+        # Create example package manager message
+        package_manager_output = 'Output from package manager: | System management is locked by the application with pid 7914 (/usr/bin/zypper).'
+
+        # Test to make sure nothing was returned from an empty string from the command output
+        self.assertIsNone(package_manager.get_process_tree_from_pid_in_output(package_manager_output))
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/core/tests/Test_ZypperPackageManager.py
+++ b/src/core/tests/Test_ZypperPackageManager.py
@@ -199,7 +199,7 @@ class TestZypperPackageManager(unittest.TestCase):
         package_manager_msg = package_manager_msg.format(str(test_process_pid))
 
         # Test to make sure a valid string was returned with process information
-        self.assertIsNotNone(package_manager.get_process_tree_from_package_manager_msg(package_manager_msg))
+        self.assertIsNotNone(package_manager.get_process_tree_from_pid_in_output(package_manager_msg))
 
     def test_get_process_tree_from_package_manager_msg_failure_nonexistent_process(self):
         self.runtime.set_legacy_test_type('HappyPath')
@@ -215,7 +215,7 @@ class TestZypperPackageManager(unittest.TestCase):
         package_manager_msg = package_manager_msg.format(str(test_process_pid))
 
         # Test to make sure nothing was returned from an invalid process
-        self.assertIsNone(package_manager.get_process_tree_from_package_manager_msg(package_manager_msg))
+        self.assertIsNone(package_manager.get_process_tree_from_pid_in_output(package_manager_msg))
 
     def test_get_process_tree_from_package_manager_msg_failure_no_pid(self):
         self.runtime.set_legacy_test_type('HappyPath')
@@ -227,7 +227,7 @@ class TestZypperPackageManager(unittest.TestCase):
         package_manager_msg = 'Example error message without a valid pid.'
 
         # Test to make sure nothing was returned from an error message that doesn't contain a pid
-        self.assertIsNone(package_manager.get_process_tree_from_package_manager_msg(package_manager_msg))
+        self.assertIsNone(package_manager.get_process_tree_from_pid_in_output(package_manager_msg))
 
 
 if __name__ == '__main__':

--- a/src/core/tests/library/LegacyEnvLayerExtensions.py
+++ b/src/core/tests/library/LegacyEnvLayerExtensions.py
@@ -500,6 +500,9 @@ class LegacyEnvLayerExtensions():
                         output = ''
                 elif self.legacy_package_manager_name is Constants.ZYPPER:
                     output = ''
+                    if cmd.find('ps --forest -o pid,cmd -g $(ps -o sid= -p') > -1:
+                        output = 'test'
+                        code = 1
             elif self.legacy_test_type == 'UnalignedPath':
                 if cmd.find("cat /proc/cpuinfo | grep name") > -1:
                     code = 0
@@ -528,6 +531,9 @@ class LegacyEnvLayerExtensions():
                 elif self.legacy_package_manager_name is Constants.ZYPPER:
                     code = 100
                     output = ''
+                    if cmd.find('ps --forest -o pid,cmd -g $(ps -o sid= -p') > -1:
+                        output = ''
+                        code = 0
             elif self.legacy_test_type == 'ExceptionPath':
                 code = -1
                 output = ''

--- a/src/core/tests/library/LegacyEnvLayerExtensions.py
+++ b/src/core/tests/library/LegacyEnvLayerExtensions.py
@@ -215,7 +215,7 @@ class LegacyEnvLayerExtensions():
                                  "\n" + \
                                  "You may wish to restart these processes.\n" + \
                                  "See 'man zypper' for information about the meaning of values in the above table.\n"
-                    elif cmd.find('ps --forest -o pid,cmd -g $(ps -o sid= -p 7914)') > -1:
+                    elif cmd.find('ps --forest -o pid,cmd -g $(ps -o sid= -p') > -1:
                         code = 0
                         output = "PID CMD\n" + \
                                  "7736 /bin/bash\n" + \

--- a/src/core/tests/library/LegacyEnvLayerExtensions.py
+++ b/src/core/tests/library/LegacyEnvLayerExtensions.py
@@ -215,6 +215,17 @@ class LegacyEnvLayerExtensions():
                                  "\n" + \
                                  "You may wish to restart these processes.\n" + \
                                  "See 'man zypper' for information about the meaning of values in the above table.\n"
+                    elif cmd.find('ps --forest -o pid,cmd -g $(ps -o sid= -p 7914)') > -1:
+                        code = 0
+                        output = "PID CMD\n" + \
+                                 "7736 /bin/bash\n" + \
+                                 "7912  \_ python3 package_test.py\n" + \
+                                 "7913  |   \_ sudo LANG=en_US.UTF8 zypper --non-interactive update --dry-run bind-utils\n" + \
+                                 "7914  |       \_ zypper --non-interactive update --dry-run bind-utils\n" + \
+                                 "7982  |           \_ /usr/bin/python3 /usr/lib/zypp/plugins/urlresolver/susecloud\n" + \
+                                 "7984  |               \_ /usr/bin/python3 /usr/bin/azuremetadata --api latest --subscriptionId --billingTag --attestedData --signature\n" + \
+                                 "7986  \_ python3 package_test.py\n" + \
+                                 "8298      \_ sudo LANG=en_US.UTF8 zypper --non-interactive update --dry-run grub2-i386-pc\n"
                 elif self.legacy_package_manager_name is Constants.YUM:
                     if cmd.find("--security check-update") > -1:
                         code = 100


### PR DESCRIPTION
If there is a process that is locking the zypper package manager, then its details (such as process name and call tree) are shown in the logs. Call tree is used because sometimes the name of the process is not enough to determine where the call originated from.