### PR TITLE
Multiple bug fixes identified in auto Assessment and a few syntax corrections

### DIFF
--- a/src/core/src/CoreMain.py
+++ b/src/core/src/CoreMain.py
@@ -65,15 +65,15 @@ class CoreMain(object):
             configure_patching_processor = container.get('configure_patching_processor')
 
             # Configure patching always runs first, except if it's AUTO_ASSESSMENT
-            if patch_operation_requested != Constants.AUTO_ASSESSMENT.lower():
+            if not execution_config.exec_auto_assess_only:
                 configure_patching_successful = configure_patching_processor.start_configure_patching()
 
-            # Assessment happens if operation requested is not Configure Patching [i.e. AUTO_ASSESSMENT, ASSESSMENT, INSTALLATION]
-            if patch_operation_requested != Constants.CONFIGURE_PATCHING.lower():
+            # Assessment happens for an Auto Assessment request or for Non Auto Assessment operations, if the operation requested is not Configure Patching
+            if execution_config.exec_auto_assess_only or patch_operation_requested != Constants.CONFIGURE_PATCHING.lower():
                 patch_assessment_successful = patch_assessor.start_assessment()
 
-            # Patching + additional assessment occurs if the operation is 'Installation'
-            if patch_operation_requested == Constants.INSTALLATION.lower():
+            # Patching + additional assessment occurs if the operation is 'Installation' and not Auto Assessment. Need to check both since operation_requested from prev run is preserved in Auto Assessment
+            if not execution_config.exec_auto_assess_only and patch_operation_requested == Constants.INSTALLATION.lower():
                 # setting current operation here, to include patch_installer init within installation actions, ensuring any exceptions during patch_installer init are added in installation summary errors object
                 status_handler.set_current_operation(Constants.INSTALLATION)
                 patch_installer = container.get('patch_installer')

--- a/src/core/src/bootstrap/ConfigurationFactory.py
+++ b/src/core/src/bootstrap/ConfigurationFactory.py
@@ -46,6 +46,7 @@ from core.src.service_interfaces.LifecycleManagerArc import LifecycleManagerArc
 from core.src.service_interfaces.StatusHandler import StatusHandler
 from core.src.service_interfaces.TelemetryWriter import TelemetryWriter
 
+# Todo: find a different way to import these
 try:
     import urllib2 as urlreq   #Python 2.x
 except:
@@ -255,18 +256,20 @@ class ConfigurationFactory(object):
         # perform desired modifications to configuration
         return configuration
 
-    def get_lifecycle_manager_component(self, vm_cloud_type):
+    @staticmethod
+    def get_lifecycle_manager_component(vm_cloud_type):
         """ finding life cycle manager based on vm and returning component name added in the prod configuration """
         azure_lifecycle_manager_component = LifecycleManagerAzure
         arc_lifecycle_manager_component = LifecycleManagerArc
-        if (vm_cloud_type == Constants.VMCloudType.AZURE):
+        if vm_cloud_type == Constants.VMCloudType.AZURE:
             return azure_lifecycle_manager_component
-        elif (vm_cloud_type == Constants.VMCloudType.ARC):
+        elif vm_cloud_type == Constants.VMCloudType.ARC:
             return arc_lifecycle_manager_component
         
         return azure_lifecycle_manager_component
-   
-    def get_vm_cloud_type(self):
+
+    @staticmethod
+    def get_vm_cloud_type():
         """ detects vm type. logic taken from HCRP code: https://github.com/PowerShell/DesiredStateConfiguration/blob/dev/src/dsc/dsc_service/service_main.cpp#L115
         Todo:  how to check this only when it is Auto Assessment operation??? """
         metadata_value = "True"
@@ -280,7 +283,7 @@ class ConfigurationFactory(object):
                 print("Connecting to IMDS endpoint...")
                 res = urlreq.urlopen(request, timeout=2)
                 print("Return code from IMDS connection http request: {0}.".format(str(res.getcode())))
-                if(res.getcode() == 200):
+                if res.getcode() == 200:
                     print("Connection to IMDS end point successfully established. VMCloudType is Azure\n")
                     return Constants.VMCloudType.AZURE
                 else:
@@ -294,5 +297,5 @@ class ConfigurationFactory(object):
                 else:
                     print("Failed to connect IMDS end point after 5 retries. This is expected in ARC VM. VMCloudType is Arc\n")
                     return Constants.VMCloudType.ARC
-            
     # endregion
+

--- a/src/core/src/core_logic/ConfigurePatchingProcessor.py
+++ b/src/core/src/core_logic/ConfigurePatchingProcessor.py
@@ -65,6 +65,7 @@ class ConfigurePatchingProcessor(object):
         try:
             self.status_handler.set_current_operation(Constants.CONFIGURE_PATCHING)
             self.current_auto_os_patch_state = self.package_manager.get_current_auto_os_patch_state()
+            self.composite_logger.log_debug("Current Auto OS Patch State is [State={0}]".format(str(self.current_auto_os_patch_state)))
 
             # disable auto OS updates if VM is configured for platform updates only.
             # NOTE: this condition will be false for Assessment operations, since patchMode is not sent in the API request
@@ -72,6 +73,7 @@ class ConfigurePatchingProcessor(object):
                 self.package_manager.disable_auto_os_update()
 
             self.current_auto_os_patch_state = self.package_manager.get_current_auto_os_patch_state()
+            self.composite_logger.log_debug("Current Auto OS Patch State is [State={0}]".format(str(self.current_auto_os_patch_state)))
 
             self.__report_consolidated_configure_patch_status()
             self.composite_logger.log_debug("Completed processing patch mode configuration.")

--- a/src/core/src/core_logic/ExecutionConfig.py
+++ b/src/core/src/core_logic/ExecutionConfig.py
@@ -36,7 +36,7 @@ class ExecutionConfig(object):
         self.sequence_number = self.__get_value_from_argv(self.execution_parameters, Constants.ARG_SEQUENCE_NUMBER)
         self.environment_settings = self.__get_decoded_json_from_argv(self.execution_parameters, Constants.ARG_ENVIRONMENT_SETTINGS)
         self.config_settings = self.__get_decoded_json_from_argv(self.execution_parameters, Constants.ARG_CONFIG_SETTINGS)
-        self.exec_auto_assess_only = True if (self.__get_value_from_argv(self.execution_parameters, Constants.ARG_AUTO_ASSESS_ONLY, False)).lower() == 'true' else False
+        self.exec_auto_assess_only = (self.__get_value_from_argv(self.execution_parameters, Constants.ARG_AUTO_ASSESS_ONLY, False)).lower() == 'true'
 
         # Environment Settings
         self.composite_logger.log_debug(" - Parsing environment settings...")

--- a/src/core/src/core_logic/ExecutionConfig.py
+++ b/src/core/src/core_logic/ExecutionConfig.py
@@ -97,7 +97,7 @@ class ExecutionConfig(object):
         if default_value == Constants.DEFAULT_UNSPECIFIED_VALUE:
             raise Exception("Unable to find key {0} in core arguments: {1}.".format(key, str(argv)))
         else:
-            return default_value
+            return str(default_value)
 
     def __get_decoded_json_from_argv(self, argv, key):
         """ Discovers and decodes the JSON body of a specific base64 encoded JSON object in input arguments. """

--- a/src/core/src/core_logic/ExecutionConfig.py
+++ b/src/core/src/core_logic/ExecutionConfig.py
@@ -36,7 +36,7 @@ class ExecutionConfig(object):
         self.sequence_number = self.__get_value_from_argv(self.execution_parameters, Constants.ARG_SEQUENCE_NUMBER)
         self.environment_settings = self.__get_decoded_json_from_argv(self.execution_parameters, Constants.ARG_ENVIRONMENT_SETTINGS)
         self.config_settings = self.__get_decoded_json_from_argv(self.execution_parameters, Constants.ARG_CONFIG_SETTINGS)
-        self.exec_auto_assess_only = bool(self.__get_value_from_argv(self.execution_parameters, Constants.ARG_AUTO_ASSESS_ONLY, False))
+        self.exec_auto_assess_only = True if (self.__get_value_from_argv(self.execution_parameters, Constants.ARG_AUTO_ASSESS_ONLY, False)).lower() == 'true' else False
 
         # Environment Settings
         self.composite_logger.log_debug(" - Parsing environment settings...")
@@ -78,7 +78,6 @@ class ExecutionConfig(object):
 
     def __transform_execution_config_for_auto_assessment(self):
         self.composite_logger.log_debug("Setting execution configuration values for auto assessment.")
-        self.operation = Constants.AUTO_ASSESSMENT
         self.activity_id = str(uuid.uuid4())
         self.included_classifications_list = self.included_package_name_mask_list = self.excluded_package_name_mask_list = []
         self.maintenance_run_id = None

--- a/src/core/src/core_logic/ServiceManager.py
+++ b/src/core/src/core_logic/ServiceManager.py
@@ -98,7 +98,7 @@ class ServiceManager(object):
 
     def systemctl_daemon_reload(self):
         """ Reloads daemon """
-        code, out = self.__invoke_systemctl(self.systemctl_daemon_reload_cmd)
+        code, out = self.__invoke_systemctl(self.systemctl_daemon_reload_cmd, "Reloading daemon.")
         return code == 0
 
     def __invoke_systemctl(self, command, action_description=None):

--- a/src/core/src/core_logic/TimerManager.py
+++ b/src/core/src/core_logic/TimerManager.py
@@ -126,7 +126,7 @@ class TimerManager(object):
 
     def systemctl_daemon_reload(self):
         """ Reloads daemon """
-        code, out = self.__invoke_systemctl(self.systemctl_daemon_reload_cmd)
+        code, out = self.__invoke_systemctl(self.systemctl_daemon_reload_cmd, "Reloading daemon.")
         return code == 0
 
     def __invoke_systemctl(self, command, action_description=None):

--- a/src/core/src/service_interfaces/LifecycleManager.py
+++ b/src/core/src/service_interfaces/LifecycleManager.py
@@ -125,7 +125,8 @@ class LifecycleManager(object):
         self.composite_logger.log("Processes still running from the previous request: [PIDs={0}]".format(str(running_process_ids)))
         return running_process_ids
 
-    def is_process_running(self, pid):
+    @staticmethod
+    def is_process_running(pid):
         # check to see if the process is still alive
         try:
             # Sending signal 0 to a pid will raise an OSError exception if the pid is not running, and do nothing otherwise.
@@ -146,4 +147,5 @@ class LifecycleManager(object):
     # region - Identity
     def get_vm_cloud_type(self):
         pass
-    #endregion
+    # endregion
+

--- a/src/core/src/service_interfaces/LifecycleManagerArc.py
+++ b/src/core/src/service_interfaces/LifecycleManagerArc.py
@@ -65,7 +65,7 @@ class LifecycleManagerArc(LifecycleManager):
 
             # attempted sequence number is same as recorded core sequence - expected
             if int(self.execution_config.sequence_number) == int(core_sequence['number']):
-                if core_sequence['completed'].lower() == 'false':
+                if core_sequence['completed'].lower() == 'true':
                     self.composite_logger.log_debug("Auto-assessment is safe to start. Existing sequence number marked as completed.")
                     self.update_core_sequence(completed=False)  # signalling core restart with auto-assessment as its safe to do so
                 else:

--- a/src/core/src/service_interfaces/LifecycleManagerArc.py
+++ b/src/core/src/service_interfaces/LifecycleManagerArc.py
@@ -30,9 +30,9 @@ class LifecycleManagerArc(LifecycleManager):
         # Handshake file paths
         self.ext_state_file_path = os.path.join(self.execution_config.config_folder, Constants.EXT_STATE_FILE)
         self.core_state_file_path = os.path.join(self.execution_config.config_folder, Constants.CORE_STATE_FILE)
-        #Writing to log
+        # Writing to log
         self.composite_logger.log_debug("Initializing LifecycleManagerArc")
-        #Variables
+        # Variables
         self.arc_root = "/var/lib/waagent/"
         self.arc_core_state_file_name = "CoreState.json"
         self.arc_extension_folder_pattern = "Microsoft.SoftwareUpdateManagement.LinuxOsUpdateExtension-*"
@@ -50,7 +50,7 @@ class LifecycleManagerArc(LifecycleManager):
             self.update_core_sequence(completed=True)   # forced-to-complete scenario | extension wrapper will be watching for this event
             self.env_layer.exit(0)
 
-        if self.execution_config.operation == Constants.AUTO_ASSESSMENT:
+        if self.execution_config.exec_auto_assess_only:
             # newer sequence number has been observed, do not run
             if int(self.execution_config.sequence_number) < int(extension_sequence['number']) \
                     or int(self.execution_config.sequence_number) < int(core_sequence['number']):
@@ -65,12 +65,12 @@ class LifecycleManagerArc(LifecycleManager):
 
             # attempted sequence number is same as recorded core sequence - expected
             if int(self.execution_config.sequence_number) == int(core_sequence['number']):
-                if bool(core_sequence['completed']):
+                if core_sequence['completed'].lower() == 'false':
                     self.composite_logger.log_debug("Auto-assessment is safe to start. Existing sequence number marked as completed.")
                     self.update_core_sequence(completed=False)  # signalling core restart with auto-assessment as its safe to do so
                 else:
                     self.composite_logger.log_debug("Auto-assessment may not be safe to start yet as core sequence is not marked completed.")
-                    if len(self.identify_running_processes(core_sequence['process_ids'])) != 0:
+                    if len(self.identify_running_processes(core_sequence['processIds'])) != 0:
                         # NOT SAFE TO START
                         # Possible reasons: full core operation is in progress (okay), some previous auto-assessment is still running (bad scheduling, adhoc run, or process stalled)
                         self.composite_logger.log_warning("Auto-assessment is NOT safe to start yet. Existing core process(es) running. Exiting. [LastHeartbeat={0}][Operation={1}]".format(str(core_sequence['lastHeartbeat']), str(core_sequence['action'])))
@@ -84,7 +84,7 @@ class LifecycleManagerArc(LifecycleManager):
                             core_sequence = self.read_core_sequence()
 
                             # Main Core process suddenly started running (expected after reboot) - don't run
-                            if len(self.identify_running_processes(core_sequence['process_ids'])) != 0:
+                            if len(self.identify_running_processes(core_sequence['processIds'])) != 0:
                                 self.composite_logger.log_warning("Auto-assessment is NOT safe to start as core process(es) started running. Exiting. [LastHeartbeat={0}][Operation={1}]".format(str(core_sequence['lastHeartbeat']), str(core_sequence['action'])))
                                 self.env_layer.exit(0)
 
@@ -134,10 +134,10 @@ class LifecycleManagerArc(LifecycleManager):
             ''' Dummy core sequence in case of arc core state is not found '''
             completed = True
             core_sequence = {'number': 0,
-                         'action': self.execution_config.operation,
-                         'completed': str(completed),
-                         'lastHeartbeat': str(self.env_layer.datetime.timestamp()),
-                         'processIds': []}
+                             'action': self.execution_config.operation,
+                             'completed': str(completed),
+                             'lastHeartbeat': str(self.env_layer.datetime.timestamp()),
+                             'processIds': []}
             return core_sequence
         
         # Read (with retries for only IO Errors) - TODO: Refactor common code
@@ -177,5 +177,5 @@ class LifecycleManagerArc(LifecycleManager):
     # region - Identity
     def get_vm_cloud_type(self):
         return Constants.VMCloudType.ARC
-    #endregion
+    # endregion
 

--- a/src/core/src/service_interfaces/StatusHandler.py
+++ b/src/core/src/service_interfaces/StatusHandler.py
@@ -276,10 +276,10 @@ class StatusHandler(object):
                 other_patch_count += 1
 
         # discern started by
-        started_by = Constants.PatchAssessmentSummaryStartedBy.PLATFORM if self.execution_config.operation == Constants.AUTO_ASSESSMENT else Constants.PatchAssessmentSummaryStartedBy.USER
+        started_by = Constants.PatchAssessmentSummaryStartedBy.PLATFORM if self.execution_config.exec_auto_assess_only else Constants.PatchAssessmentSummaryStartedBy.USER
 
         # Compose sub-status message
-        substatus_message =  {
+        substatus_message = {
             "assessmentActivityId": str(self.execution_config.activity_id),
             "rebootPending": self.is_reboot_pending,
             "criticalAndSecurityPatchCount": critsec_patch_count,
@@ -290,7 +290,8 @@ class StatusHandler(object):
             "startedBy": str(started_by),
             "errors": self.__set_errors_json(self.__assessment_total_error_count, self.__assessment_errors)
         }
-        if(self.vm_cloud_type == Constants.VMCloudType.ARC):
+
+        if self.vm_cloud_type == Constants.VMCloudType.ARC:
             substatus_message["patchAssessmentStatus"] = code
             substatus_message["patchAssessmentStatusString"] = status
         return substatus_message
@@ -402,7 +403,7 @@ class StatusHandler(object):
                 Root --> Status --> Substatus [name: "ConfigurePatchingSummary"] --> FormattedMessage --> **Message** """
 
         # Compose substatus message
-        substatus_message =  {
+        substatus_message = {
             "activityId": str(self.execution_config.activity_id),
             "startTime": str(self.execution_config.start_time),
             "lastModifiedTime": str(self.env_layer.datetime.timestamp()),
@@ -413,7 +414,7 @@ class StatusHandler(object):
             },
             "errors": self.__set_errors_json(self.__configure_patching_top_level_error_count, self.__configure_patching_errors)
         }
-        if(self.vm_cloud_type == Constants.VMCloudType.ARC):
+        if self.vm_cloud_type == Constants.VMCloudType.ARC:
             substatus_message["configurePatchStatus"] = code
             substatus_message["configurePatchStatusString"] = status
         return substatus_message
@@ -437,13 +438,12 @@ class StatusHandler(object):
         self.env_layer.file_system.write_with_retry(self.status_file_path, '[{0}]'.format(json.dumps(self.__new_basic_status_json())), mode='w+')
 
     def __new_basic_status_json(self):
-        reported_operation = self.execution_config.operation if self.execution_config.operation != Constants.AUTO_ASSESSMENT else Constants.ASSESSMENT
         return {
             "version": 1.0,
             "timestampUTC": str(self.env_layer.datetime.timestamp()),
             "status": {
                 "name": "Azure Patch Management",
-                "operation": str(reported_operation),
+                "operation": str(self.execution_config.operation),
                 "status": "success",
                 "code": 0,
                 "formattedMessage": {
@@ -523,15 +523,18 @@ class StatusHandler(object):
         for i in range(0, len(status_file_data['status']['substatus'])):
             name = status_file_data['status']['substatus'][i]['name']
             if name == Constants.PATCH_INSTALLATION_SUMMARY:     # if it exists, it must be to spec, or an exception will get thrown
-                message = status_file_data['status']['substatus'][i]['formattedMessage']['message']
-                self.__installation_summary_json = json.loads(message)
-                self.__installation_packages = self.__installation_summary_json['patches']
-                self.__maintenance_window_exceeded = bool(self.__installation_summary_json['maintenanceWindowExceeded'])
-                self.__installation_reboot_status = self.__installation_summary_json['rebootStatus']
-                errors = self.__installation_summary_json['errors']
-                if errors is not None and errors['details'] is not None:
-                    self.__installation_errors = errors['details']
-                    self.__installation_total_error_count = self.__get_total_error_count_from_prev_status(errors['message'])
+                if self.execution_config.exec_auto_assess_only:
+                    self.__installation_substatus_json = status_file_data['status']['substatus'][i]
+                else:
+                    message = status_file_data['status']['substatus'][i]['formattedMessage']['message']
+                    self.__installation_summary_json = json.loads(message)
+                    self.__installation_packages = self.__installation_summary_json['patches']
+                    self.__maintenance_window_exceeded = bool(self.__installation_summary_json['maintenanceWindowExceeded'])
+                    self.__installation_reboot_status = self.__installation_summary_json['rebootStatus']
+                    errors = self.__installation_summary_json['errors']
+                    if errors is not None and errors['details'] is not None:
+                        self.__installation_errors = errors['details']
+                        self.__installation_total_error_count = self.__get_total_error_count_from_prev_status(errors['message'])
             if name == Constants.PATCH_ASSESSMENT_SUMMARY:     # if it exists, it must be to spec, or an exception will get thrown
                 message = status_file_data['status']['substatus'][i]['formattedMessage']['message']
                 self.__assessment_summary_json = json.loads(message)
@@ -541,15 +544,21 @@ class StatusHandler(object):
                     self.__assessment_errors = errors['details']
                     self.__assessment_total_error_count = self.__get_total_error_count_from_prev_status(errors['message'])
             if name == Constants.PATCH_METADATA_FOR_HEALTHSTORE:     # if it exists, it must be to spec, or an exception will get thrown
-                message = status_file_data['status']['substatus'][i]['formattedMessage']['message']
-                self.__metadata_for_healthstore_summary_json = json.loads(message)
-            if name == Constants.CONFIGURE_PATCHING:     # if it exists, it must be to spec, or an exception will get thrown
-                message = status_file_data['status']['substatus'][i]['formattedMessage']['message']
-                self.__configure_patching_summary_json = json.loads(message)
-                errors = self.__configure_patching_summary_json['errors']
-                if errors is not None and errors['details'] is not None:
-                    self.__configure_patching_errors = errors['details']
-                    self.__configure_patching_top_level_error_count = self.__get_total_error_count_from_prev_status(errors['message'])
+                if self.execution_config.exec_auto_assess_only:
+                    self.__metadata_for_healthstore_substatus_json = status_file_data['status']['substatus'][i]
+                else:
+                    message = status_file_data['status']['substatus'][i]['formattedMessage']['message']
+                    self.__metadata_for_healthstore_summary_json = json.loads(message)
+            if name == Constants.CONFIGURE_PATCHING_SUMMARY:     # if it exists, it must be to spec, or an exception will get thrown
+                if self.execution_config.exec_auto_assess_only:
+                    self.__configure_patching_substatus_json = status_file_data['status']['substatus'][i]
+                else:
+                    message = status_file_data['status']['substatus'][i]['formattedMessage']['message']
+                    self.__configure_patching_summary_json = json.loads(message)
+                    errors = self.__configure_patching_summary_json['errors']
+                    if errors is not None and errors['details'] is not None:
+                        self.__configure_patching_errors = errors['details']
+                        self.__configure_patching_top_level_error_count = self.__get_total_error_count_from_prev_status(errors['message'])
 
     def __write_status_file(self):
         """ Composes and writes the status file from **already up-to-date** in-memory data.

--- a/src/core/tests/Test_ConfigurePatchingProcessor.py
+++ b/src/core/tests/Test_ConfigurePatchingProcessor.py
@@ -69,6 +69,8 @@ class TestConfigurePatchingProcessor(unittest.TestCase):
         self.assertEquals(len(substatus_file_data), 1)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
+        message = json.loads(substatus_file_data[0]["formattedMessage"]["message"])
+        self.assertEqual(message["automaticOsPatchState"], Constants.AutomaticOsPatchStates.DISABLED)
 
         # check status file for configure patching assessment state
         message = json.loads(substatus_file_data[0]["formattedMessage"]["message"])
@@ -168,6 +170,91 @@ class TestConfigurePatchingProcessor(unittest.TestCase):
         self.assertEquals(len(substatus_file_data), 1)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_ERROR.lower())
+        runtime.stop()
+
+    def test_configure_patching_with_assessment_mode_by_platform(self):
+
+        # create and adjust arguments
+        argument_composer = ArgumentComposer()
+        argument_composer.operation = Constants.CONFIGURE_PATCHING
+        argument_composer.patch_mode = Constants.PatchModes.IMAGE_DEFAULT
+        argument_composer.assessment_mode = Constants.AssessmentModes.AUTOMATIC_BY_PLATFORM
+
+        # create and patch runtime
+        runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.APT)
+        runtime.package_manager.get_current_auto_os_patch_state = runtime.backup_get_current_auto_os_patch_state
+        runtime.package_manager.os_patch_configuration_settings_file_path = os.path.join(runtime.execution_config.config_folder, "20auto-upgrades")
+        runtime.set_legacy_test_type('HappyPath')
+
+        # mock os patch configuration
+        os_patch_configuration_settings = 'APT::Periodic::Update-Package-Lists "1";\nAPT::Periodic::Unattended-Upgrade "1";\n'
+        runtime.write_to_file(runtime.package_manager.os_patch_configuration_settings_file_path, os_patch_configuration_settings)
+
+        # execute Core
+        CoreMain(argument_composer.get_composed_arguments())
+
+        # check telemetry events
+        self.__check_telemetry_events(runtime)
+
+        # check status file for configure patching patch mode
+        with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
+            substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
+
+        # check status file for configure patching patch state
+        self.assertEquals(len(substatus_file_data), 1)
+        self.assertTrue(substatus_file_data[0]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
+        self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
+        message = json.loads(substatus_file_data[0]["formattedMessage"]["message"])
+        self.assertEqual(message["automaticOsPatchState"], Constants.AutomaticOsPatchStates.ENABLED)  # no change is made on Auto OS updates for patch mode 'ImageDefault'
+
+        # check status file for configure patching assessment state
+        message = json.loads(substatus_file_data[0]["formattedMessage"]["message"])
+        self.assertEqual(message["autoAssessmentStatus"]["autoAssessmentState"], Constants.AutoAssessmentStates.ENABLED)  # auto assessment is enabled
+
+        # stop test runtime
+        runtime.stop()
+
+    def test_configure_patching_with_patch_mode_and_assessment_mode_by_platform(self):
+
+        # create and adjust arguments
+        argument_composer = ArgumentComposer()
+        argument_composer.operation = Constants.CONFIGURE_PATCHING
+        argument_composer.patch_mode = Constants.PatchModes.AUTOMATIC_BY_PLATFORM
+        argument_composer.assessment_mode = Constants.AssessmentModes.AUTOMATIC_BY_PLATFORM
+
+        # create and patch runtime
+        runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.APT)
+        runtime.package_manager.get_current_auto_os_patch_state = runtime.backup_get_current_auto_os_patch_state
+        runtime.package_manager.os_patch_configuration_settings_file_path = os.path.join(runtime.execution_config.config_folder, "20auto-upgrades")
+        runtime.set_legacy_test_type('HappyPath')
+
+        # mock os patch configuration
+        os_patch_configuration_settings = 'APT::Periodic::Update-Package-Lists "1";\nAPT::Periodic::Unattended-Upgrade "1";\n'
+        runtime.write_to_file(runtime.package_manager.os_patch_configuration_settings_file_path, os_patch_configuration_settings)
+
+        # execute Core
+        CoreMain(argument_composer.get_composed_arguments())
+
+        # check telemetry events
+        self.__check_telemetry_events(runtime)
+
+        # check status file for configure patching patch mode
+        with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
+            substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
+
+        # check status file for configure patching patch state
+        self.assertTrue(runtime.package_manager.image_default_patch_configuration_backup_exists())
+        self.assertEquals(len(substatus_file_data), 1)
+        self.assertTrue(substatus_file_data[0]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
+        self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
+        message = json.loads(substatus_file_data[0]["formattedMessage"]["message"])
+        self.assertEqual(message["automaticOsPatchState"], Constants.AutomaticOsPatchStates.DISABLED)  # auto OS updates are disabled on patch mode 'AutomaticByPlatform'
+
+        # check status file for configure patching assessment state
+        message = json.loads(substatus_file_data[0]["formattedMessage"]["message"])
+        self.assertEqual(message["autoAssessmentStatus"]["autoAssessmentState"], Constants.AutoAssessmentStates.ENABLED)  # auto assessment is enabled
+
+        # stop test runtime
         runtime.stop()
 
     def __check_telemetry_events(self, runtime):

--- a/src/core/tests/Test_ConfigurePatchingProcessor.py
+++ b/src/core/tests/Test_ConfigurePatchingProcessor.py
@@ -68,7 +68,7 @@ class TestConfigurePatchingProcessor(unittest.TestCase):
         self.assertTrue(runtime.package_manager.image_default_patch_configuration_backup_exists())
         self.assertEquals(len(substatus_file_data), 1)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
-        self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         message = json.loads(substatus_file_data[0]["formattedMessage"]["message"])
         self.assertEqual(message["automaticOsPatchState"], Constants.AutomaticOsPatchStates.DISABLED)
 
@@ -108,13 +108,13 @@ class TestConfigurePatchingProcessor(unittest.TestCase):
         self.assertTrue('APT::Periodic::Update-Package-Lists "0"' in os_patch_configuration_settings)
         self.assertTrue('APT::Periodic::Unattended-Upgrade "0"' in os_patch_configuration_settings)
         self.assertTrue(substatus_file_data[3]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
-        self.assertTrue(substatus_file_data[3]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[3]["status"].lower() == Constants.STATUS_SUCCESS.lower())
 
         self.assertEquals(len(substatus_file_data), 4)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
-        self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
-        self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         self.assertEqual(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][0]["name"], "python-samba")
         self.assertTrue("Security" in str(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][0]["classifications"]))
         self.assertEqual(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][1]["name"], "samba-common-bin")
@@ -123,7 +123,7 @@ class TestConfigurePatchingProcessor(unittest.TestCase):
         self.assertTrue("python-samba_2:4.4.5+dfsg-2ubuntu5.4" in str(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][0]["patchId"]))
         self.assertTrue("Security" in str(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][2]["classifications"]))
         self.assertTrue(substatus_file_data[2]["name"] == Constants.PATCH_METADATA_FOR_HEALTHSTORE)
-        self.assertTrue(substatus_file_data[2]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[2]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         substatus_file_data_patch_metadata_summary = json.loads(substatus_file_data[2]["formattedMessage"]["message"])
         self.assertEqual(substatus_file_data_patch_metadata_summary["patchVersion"], "2020.09.28")
         self.assertTrue(substatus_file_data_patch_metadata_summary["shouldReportToHealthStore"])
@@ -144,11 +144,11 @@ class TestConfigurePatchingProcessor(unittest.TestCase):
         self.assertEquals(len(substatus_file_data), 1)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
         if runtime.vm_cloud_type == Constants.VMCloudType.AZURE:
-            self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_ERROR.lower())
+            self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_ERROR.lower())
             self.assertTrue(len(json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"]), 1)
             self.assertTrue(Constants.TELEMETRY_AT_AGENT_NOT_COMPATIBLE_ERROR_MSG in json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"][0]["message"])
         else:
-            self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
+            self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         runtime.stop()
 
     def test_operation_fail_for_configure_patching_request_for_apt(self):
@@ -169,7 +169,7 @@ class TestConfigurePatchingProcessor(unittest.TestCase):
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
         self.assertEquals(len(substatus_file_data), 1)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
-        self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_ERROR.lower())
+        self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_ERROR.lower())
         runtime.stop()
 
     def test_configure_patching_with_assessment_mode_by_platform(self):
@@ -203,7 +203,7 @@ class TestConfigurePatchingProcessor(unittest.TestCase):
         # check status file for configure patching patch state
         self.assertEquals(len(substatus_file_data), 1)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
-        self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         message = json.loads(substatus_file_data[0]["formattedMessage"]["message"])
         self.assertEqual(message["automaticOsPatchState"], Constants.AutomaticOsPatchStates.ENABLED)  # no change is made on Auto OS updates for patch mode 'ImageDefault'
 
@@ -246,7 +246,7 @@ class TestConfigurePatchingProcessor(unittest.TestCase):
         self.assertTrue(runtime.package_manager.image_default_patch_configuration_backup_exists())
         self.assertEquals(len(substatus_file_data), 1)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
-        self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         message = json.loads(substatus_file_data[0]["formattedMessage"]["message"])
         self.assertEqual(message["automaticOsPatchState"], Constants.AutomaticOsPatchStates.DISABLED)  # auto OS updates are disabled on patch mode 'AutomaticByPlatform'
 

--- a/src/core/tests/Test_CoreMain.py
+++ b/src/core/tests/Test_CoreMain.py
@@ -17,7 +17,6 @@ import datetime
 import json
 import os
 import re
-import time
 import unittest
 import uuid
 

--- a/src/core/tests/Test_CoreMain.py
+++ b/src/core/tests/Test_CoreMain.py
@@ -17,7 +17,10 @@ import datetime
 import json
 import os
 import re
+import time
 import unittest
+import uuid
+
 from core.src.CoreMain import CoreMain
 from core.src.bootstrap.Constants import Constants
 from core.tests.library.ArgumentComposer import ArgumentComposer
@@ -431,6 +434,214 @@ class TestCoreMain(unittest.TestCase):
         runtime.stop()
 
         LegacyEnvLayerExtensions.LegacyPlatform.linux_distribution = backup_envlayer_platform_linux_distribution
+
+    # test with both assessment mode and patch mode set in configure patching or install patches or assess patches or auto assessment
+    def test_auto_assessment_success_with_configure_patching_in_prev_operation_on_same_sequence(self):
+        """Unit test for auto assessment request with configure patching completed on the sequence before. Result: should retain prev substatus and update only PatchAssessmentSummary"""
+        # operation #1: ConfigurePatching
+        argument_composer = ArgumentComposer()
+        argument_composer.operation = Constants.CONFIGURE_PATCHING
+        argument_composer.patch_mode = Constants.PatchModes.AUTOMATIC_BY_PLATFORM
+        argument_composer.assessment_mode = Constants.AssessmentModes.AUTOMATIC_BY_PLATFORM
+        runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.APT)
+        runtime.set_legacy_test_type("SuccessInstallPath")
+        CoreMain(argument_composer.get_composed_arguments())
+        # check telemetry events
+        self.__check_telemetry_events(runtime)
+        # check status file
+        with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
+            status_file_data = json.load(file_handle)[0]["status"]
+        self.assertTrue(status_file_data["operation"] == Constants.CONFIGURE_PATCHING)
+        substatus_file_data = status_file_data["substatus"]
+        self.assertEquals(len(substatus_file_data), 1)
+        self.assertTrue(substatus_file_data[0]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
+        self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
+        # check status file for configure patching auto updates state
+        message = json.loads(substatus_file_data[0]["formattedMessage"]["message"])
+        self.assertEqual(message["automaticOsPatchState"], Constants.AutomaticOsPatchStates.DISABLED)  # auto OS updates are disabled in RuntimeCompositor
+        # check status file for configure patching assessment state
+        message = json.loads(substatus_file_data[0]["formattedMessage"]["message"])
+        self.assertEqual(message["autoAssessmentStatus"]["autoAssessmentState"], Constants.AutoAssessmentStates.ENABLED)  # auto assessment is enabled
+
+        # operation #2: Auto Assessment
+        argument_composer.activity_id = str(uuid.uuid4())
+        argument_composer.included_classifications_list = self.included_package_name_mask_list = self.excluded_package_name_mask_list = []
+        argument_composer.maintenance_run_id = None
+        argument_composer.start_time = runtime.env_layer.datetime.standard_datetime_to_utc(datetime.datetime.utcnow())
+        argument_composer.duration = Constants.AUTO_ASSESSMENT_MAXIMUM_DURATION
+        argument_composer.reboot_setting = Constants.REBOOT_NEVER
+        argument_composer.patch_mode = None
+        argument_composer.exec_auto_assess_only = True
+        runtime.execution_config.exec_auto_assess_only = True
+        CoreMain(argument_composer.get_composed_arguments())
+        # check telemetry events
+        self.__check_telemetry_events(runtime)
+        # check status file
+        with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
+            status_file_data = json.load(file_handle)[0]["status"]
+        # verifying the original operation name is preserved
+        self.assertTrue(status_file_data["operation"] == Constants.CONFIGURE_PATCHING)
+        substatus_file_data = status_file_data["substatus"]
+        self.assertEquals(len(substatus_file_data), 2)
+        self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
+        self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
+        # check started by set to 'Platform'
+        self.assertTrue(json.loads(substatus_file_data[0]["formattedMessage"]["message"])['startedBy'], Constants.PatchAssessmentSummaryStartedBy.PLATFORM)
+        # verifying the older operation summary is preserved
+        self.assertTrue(substatus_file_data[1]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
+        self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_SUCCESS.lower())
+        message = json.loads(substatus_file_data[1]["formattedMessage"]["message"])
+        self.assertEqual(message["automaticOsPatchState"], Constants.AutomaticOsPatchStates.DISABLED)  # auto OS updates are disabled in RuntimeCompositor
+        # check status file for configure patching assessment state
+        message = json.loads(substatus_file_data[1]["formattedMessage"]["message"])
+        self.assertEqual(message["autoAssessmentStatus"]["autoAssessmentState"], Constants.AutoAssessmentStates.ENABLED)  # auto assessment is enabled
+
+        runtime.stop()
+
+    def test_auto_assessment_success_with_assessment_in_prev_operation_on_same_sequence(self):
+        """Unit test for auto assessment request with assessment completed on the sequence before. Result: should contain PatchAssessmentSummary with an updated timestamp and ConfigurePatchingSummary from the first Assessment operation"""
+        # operation #1: Assessment
+        argument_composer = ArgumentComposer()
+        argument_composer.operation = Constants.ASSESSMENT
+        runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.APT)
+        runtime.set_legacy_test_type("SuccessInstallPath")
+        CoreMain(argument_composer.get_composed_arguments())
+        # check telemetry events
+        self.__check_telemetry_events(runtime)
+        # check status file
+        with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
+            status_file_data = json.load(file_handle)[0]["status"]
+        self.assertTrue(status_file_data["operation"] == Constants.ASSESSMENT)
+        substatus_file_data = status_file_data["substatus"]
+        self.assertEquals(len(substatus_file_data), 2)
+        self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
+        self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
+        # check started by set to 'User'
+        self.assertTrue(json.loads(substatus_file_data[0]["formattedMessage"]["message"])['startedBy'], Constants.PatchAssessmentSummaryStartedBy.USER)
+        last_modified_time_after_user_initiated_assessment = json.loads(substatus_file_data[0]["formattedMessage"]["message"])["lastModifiedTime"]
+        self.assertTrue(substatus_file_data[1]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
+        self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_SUCCESS.lower())
+        # check status file for configure patching auto updates state
+        message = json.loads(substatus_file_data[1]["formattedMessage"]["message"])
+        self.assertEqual(message["automaticOsPatchState"], Constants.AutomaticOsPatchStates.DISABLED)  # auto OS updates are disabled in RuntimeCompositor
+        # check status file for configure patching assessment state
+        message = json.loads(substatus_file_data[1]["formattedMessage"]["message"])
+        self.assertEqual(message["autoAssessmentStatus"]["autoAssessmentState"], Constants.AutoAssessmentStates.UNKNOWN)  # Configure patching for auto assessment did not execute since assessmentMode was not in input
+
+        # operation #2: Auto Assessment
+        argument_composer.activity_id = str(uuid.uuid4())
+        argument_composer.included_classifications_list = self.included_package_name_mask_list = self.excluded_package_name_mask_list = []
+        argument_composer.maintenance_run_id = None
+        argument_composer.start_time = runtime.env_layer.datetime.standard_datetime_to_utc(datetime.datetime.utcnow())
+        argument_composer.duration = Constants.AUTO_ASSESSMENT_MAXIMUM_DURATION
+        argument_composer.reboot_setting = Constants.REBOOT_NEVER
+        argument_composer.patch_mode = None
+        argument_composer.exec_auto_assess_only = True
+        runtime.execution_config.exec_auto_assess_only = True
+        CoreMain(argument_composer.get_composed_arguments())
+        # check telemetry events
+        self.__check_telemetry_events(runtime)
+        # check status file
+        with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
+            status_file_data = json.load(file_handle)[0]["status"]
+
+        # verifying the original operation name is preserved
+        self.assertTrue(status_file_data["operation"] == Constants.ASSESSMENT)
+        substatus_file_data = status_file_data["substatus"]
+        self.assertEquals(len(substatus_file_data), 2)
+        self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
+        self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
+        # check started by set to 'Platform'
+        self.assertTrue(json.loads(substatus_file_data[0]["formattedMessage"]["message"])['startedBy'], Constants.PatchAssessmentSummaryStartedBy.PLATFORM)
+        # verifying the older operation summary is preserved
+        self.assertTrue(substatus_file_data[1]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
+        self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_SUCCESS.lower())
+        # check status file for configure patching auto updates state
+        message = json.loads(substatus_file_data[1]["formattedMessage"]["message"])
+        self.assertEqual(message["automaticOsPatchState"], Constants.AutomaticOsPatchStates.DISABLED)  # auto OS updates are disabled in RuntimeCompositor
+        # check status file for configure patching assessment state
+        message = json.loads(substatus_file_data[1]["formattedMessage"]["message"])
+        self.assertEqual(message["autoAssessmentStatus"]["autoAssessmentState"], Constants.AutoAssessmentStates.UNKNOWN)  # Configure patching for auto assessment did not execute since assessmentMode was not in input
+
+        runtime.stop()
+
+    def test_auto_assessment_success_with_installation_in_prev_operation_on_same_sequence(self):
+        """Unit test for auto assessment request with installation (Auto Patching) completed on the sequence before.
+        Result: should contain PatchAssessmentSummary with an updated timestamp after auto assessment, and retain PatchInstallationSummary, ConfigurePatchingSummary and PatchMetadatForHealthStoreSummary from the installation(Auto Patching) operation"""
+        # operation #1: Assessment
+        argument_composer = ArgumentComposer()
+        argument_composer.operation = Constants.INSTALLATION
+        argument_composer.maintenance_run_id = "8/27/2021 02:00:00 PM +00:00"
+        argument_composer.classifications_to_include = ["Security", "Critical"]
+        runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.APT)
+        runtime.set_legacy_test_type("SuccessInstallPath")
+        CoreMain(argument_composer.get_composed_arguments())
+        # check telemetry events
+        self.__check_telemetry_events(runtime)
+        # check status file
+        with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
+            status_file_data = json.load(file_handle)[0]["status"]
+        self.assertTrue(status_file_data["operation"] == Constants.INSTALLATION)
+        substatus_file_data = status_file_data["substatus"]
+        self.assertEquals(len(substatus_file_data), 4)
+        self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
+        self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
+        # check started by set to 'User'
+        self.assertTrue(json.loads(substatus_file_data[0]["formattedMessage"]["message"])['startedBy'], Constants.PatchAssessmentSummaryStartedBy.USER)
+        last_modified_time_after_user_initiated_installation = json.loads(substatus_file_data[0]["formattedMessage"]["message"])["lastModifiedTime"]
+        self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
+        self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[2]["name"] == Constants.PATCH_METADATA_FOR_HEALTHSTORE)
+        self.assertTrue(substatus_file_data[2]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[3]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
+        self.assertTrue(substatus_file_data[3]["status"] == Constants.STATUS_SUCCESS.lower())
+        # check status file for configure patching auto updates state
+        message = json.loads(substatus_file_data[3]["formattedMessage"]["message"])
+        self.assertEqual(message["automaticOsPatchState"], Constants.AutomaticOsPatchStates.DISABLED)  # auto OS updates are disabled in RuntimeCompositor, this is tested in Test-ConfigurePatchingProcessor
+        # check status file for configure patching assessment state
+        message = json.loads(substatus_file_data[3]["formattedMessage"]["message"])
+        self.assertEqual(message["autoAssessmentStatus"]["autoAssessmentState"], Constants.AutoAssessmentStates.UNKNOWN)  # Configure patching for auto assessment did not execute since assessmentMode was not in input
+
+        # operation #2: Auto Assessment
+        argument_composer.activity_id = str(uuid.uuid4())
+        argument_composer.included_classifications_list = self.included_package_name_mask_list = self.excluded_package_name_mask_list = []
+        argument_composer.maintenance_run_id = None
+        argument_composer.start_time = runtime.env_layer.datetime.standard_datetime_to_utc(datetime.datetime.utcnow())
+        argument_composer.duration = Constants.AUTO_ASSESSMENT_MAXIMUM_DURATION
+        argument_composer.reboot_setting = Constants.REBOOT_NEVER
+        argument_composer.patch_mode = None
+        argument_composer.exec_auto_assess_only = True
+        runtime.execution_config.exec_auto_assess_only = True
+        CoreMain(argument_composer.get_composed_arguments())
+        # check telemetry events
+        self.__check_telemetry_events(runtime)
+        # check status file
+        with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
+            status_file_data = json.load(file_handle)[0]["status"]
+
+        # verifying the original operation name is preserved
+        self.assertTrue(status_file_data["operation"] == Constants.INSTALLATION)
+        substatus_file_data = status_file_data["substatus"]
+        self.assertEquals(len(substatus_file_data), 4)
+        self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
+        self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
+        # check started by set to 'Platform'
+        self.assertTrue(json.loads(substatus_file_data[0]["formattedMessage"]["message"])['startedBy'], Constants.PatchAssessmentSummaryStartedBy.PLATFORM)
+        # verifying the older operation summary is preserved
+        self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
+        self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[2]["name"] == Constants.PATCH_METADATA_FOR_HEALTHSTORE)
+        self.assertTrue(substatus_file_data[2]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[3]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
+        self.assertTrue(substatus_file_data[3]["status"] == Constants.STATUS_SUCCESS.lower())
+        # check status file for configure patching auto updates state
+        message = json.loads(substatus_file_data[3]["formattedMessage"]["message"])
+        self.assertEqual(message["automaticOsPatchState"], Constants.AutomaticOsPatchStates.DISABLED)  # auto OS updates are disabled in RuntimeCompositor
+        # check status file for configure patching assessment state
+        message = json.loads(substatus_file_data[3]["formattedMessage"]["message"])
+        self.assertEqual(message["autoAssessmentStatus"]["autoAssessmentState"], Constants.AutoAssessmentStates.UNKNOWN)  # Configure patching for auto assessment did not execute since assessmentMode was not in input
+
+        runtime.stop()
 
     def __check_telemetry_events(self, runtime):
         all_events = os.listdir(runtime.telemetry_writer.events_folder_path)

--- a/src/core/tests/Test_CoreMain.py
+++ b/src/core/tests/Test_CoreMain.py
@@ -61,12 +61,12 @@ class TestCoreMain(unittest.TestCase):
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
         self.assertEquals(len(substatus_file_data), 3)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
-        self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
-        self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_ERROR.lower())
+        self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_ERROR.lower())
         self.assertEqual(len(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["errors"]["details"]), 1)
         self.assertTrue(substatus_file_data[2]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
-        self.assertTrue(substatus_file_data[2]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[2]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         runtime.stop()
 
     def test_operation_fail_for_autopatching_request(self):
@@ -84,17 +84,17 @@ class TestCoreMain(unittest.TestCase):
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
         self.assertEquals(len(substatus_file_data), 4)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
-        self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
-        self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_ERROR.lower())
+        self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_ERROR.lower())
         self.assertEqual(len(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["errors"]["details"]), 1)
         self.assertTrue(substatus_file_data[2]["name"] == Constants.PATCH_METADATA_FOR_HEALTHSTORE)
-        self.assertTrue(substatus_file_data[2]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[2]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         substatus_file_data_patch_metadata_summary = json.loads(substatus_file_data[2]["formattedMessage"]["message"])
         self.assertTrue(substatus_file_data_patch_metadata_summary["patchVersion"], Constants.PATCH_VERSION_UNKNOWN)
         self.assertFalse(substatus_file_data_patch_metadata_summary["shouldReportToHealthStore"])
         self.assertTrue(substatus_file_data[3]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
-        self.assertTrue(substatus_file_data[3]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[3]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         runtime.stop()
 
     def test_operation_success_for_non_autopatching_request(self):
@@ -111,11 +111,11 @@ class TestCoreMain(unittest.TestCase):
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
         self.assertEquals(len(substatus_file_data), 3)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
-        self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
-        self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[2]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
-        self.assertTrue(substatus_file_data[2]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[2]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         runtime.stop()
 
     def test_operation_success_for_autopatching_request(self):
@@ -135,16 +135,16 @@ class TestCoreMain(unittest.TestCase):
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
         self.assertEquals(len(substatus_file_data), 4)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
-        self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
-        self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[2]["name"] == Constants.PATCH_METADATA_FOR_HEALTHSTORE)
-        self.assertTrue(substatus_file_data[2]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[2]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         substatus_file_data_patch_metadata_summary = json.loads(substatus_file_data[2]["formattedMessage"]["message"])
         self.assertEqual(substatus_file_data_patch_metadata_summary["patchVersion"], "2020.09.28")
         self.assertTrue(substatus_file_data_patch_metadata_summary["shouldReportToHealthStore"])
         self.assertTrue(substatus_file_data[3]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
-        self.assertTrue(substatus_file_data[3]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[3]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         runtime.stop()
 
     def test_operation_success_for_autopatching_request_with_security_classification(self):
@@ -166,9 +166,9 @@ class TestCoreMain(unittest.TestCase):
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
         self.assertEquals(len(substatus_file_data), 4)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
-        self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
-        self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         self.assertEqual(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][0]["name"], "python-samba")
         self.assertTrue("Security" in str(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][0]["classifications"]))
         self.assertEqual(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][1]["name"], "samba-common-bin")
@@ -177,12 +177,12 @@ class TestCoreMain(unittest.TestCase):
         self.assertTrue("python-samba_2:4.4.5+dfsg-2ubuntu5.4" in str(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][0]["patchId"]))
         self.assertTrue("Security" in str(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][2]["classifications"]))
         self.assertTrue(substatus_file_data[2]["name"] == Constants.PATCH_METADATA_FOR_HEALTHSTORE)
-        self.assertTrue(substatus_file_data[2]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[2]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         substatus_file_data_patch_metadata_summary = json.loads(substatus_file_data[2]["formattedMessage"]["message"])
         self.assertEqual(substatus_file_data_patch_metadata_summary["patchVersion"], "2020.09.28")
         self.assertTrue(substatus_file_data_patch_metadata_summary["shouldReportToHealthStore"])
         self.assertTrue(substatus_file_data[3]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
-        self.assertTrue(substatus_file_data[3]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[3]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         runtime.stop()
 
     def test_invalid_maintenance_run_id(self):
@@ -202,16 +202,16 @@ class TestCoreMain(unittest.TestCase):
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
         self.assertEquals(len(substatus_file_data), 4)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
-        self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
-        self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_ERROR.lower())
+        self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_ERROR.lower())
         self.assertTrue(substatus_file_data[2]["name"] == Constants.PATCH_METADATA_FOR_HEALTHSTORE)
-        self.assertTrue(substatus_file_data[2]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[2]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         substatus_file_data_patch_metadata_summary = json.loads(substatus_file_data[2]["formattedMessage"]["message"])
         self.assertEqual(substatus_file_data_patch_metadata_summary["patchVersion"], Constants.PATCH_VERSION_UNKNOWN)
         self.assertFalse(substatus_file_data_patch_metadata_summary["shouldReportToHealthStore"])
         self.assertTrue(substatus_file_data[3]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
-        self.assertTrue(substatus_file_data[3]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[3]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         runtime.stop()
 
         # todo: This will become a valid success operation run once the temp fix for maintenanceRunId is removed
@@ -231,16 +231,16 @@ class TestCoreMain(unittest.TestCase):
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
         self.assertEquals(len(substatus_file_data), 4)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
-        self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
-        self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_ERROR.lower())
+        self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_ERROR.lower())
         self.assertTrue(substatus_file_data[2]["name"] == Constants.PATCH_METADATA_FOR_HEALTHSTORE)
-        self.assertTrue(substatus_file_data[2]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[2]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         substatus_file_data_patch_metadata_summary = json.loads(substatus_file_data[2]["formattedMessage"]["message"])
         self.assertEqual(substatus_file_data_patch_metadata_summary["patchVersion"], Constants.PATCH_VERSION_UNKNOWN)
         self.assertFalse(substatus_file_data_patch_metadata_summary["shouldReportToHealthStore"])
         self.assertTrue(substatus_file_data[3]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
-        self.assertTrue(substatus_file_data[3]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[3]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         runtime.stop()
 
     def test_assessment_operation_success(self):
@@ -258,9 +258,9 @@ class TestCoreMain(unittest.TestCase):
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
         self.assertEquals(len(substatus_file_data), 2)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
-        self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[1]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
-        self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         runtime.stop()
 
     def test_assessment_operation_fail(self):
@@ -278,10 +278,10 @@ class TestCoreMain(unittest.TestCase):
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
         self.assertEquals(len(substatus_file_data), 2)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
-        self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_ERROR.lower())
+        self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_ERROR.lower())
         self.assertEqual(len(json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"]), 2)
         self.assertTrue(substatus_file_data[1]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
-        self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         runtime.stop()
 
     def test_assessment_operation_fail_due_to_no_telemetry(self):
@@ -296,11 +296,11 @@ class TestCoreMain(unittest.TestCase):
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
         self.assertEquals(len(substatus_file_data), 2)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
-        self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_ERROR.lower())
+        self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_ERROR.lower())
         self.assertEqual(len(json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"]), 1)
         self.assertTrue(Constants.TELEMETRY_AT_AGENT_NOT_COMPATIBLE_ERROR_MSG in json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"][0]["message"])
         self.assertTrue(substatus_file_data[1]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
-        self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_ERROR.lower())
+        self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_ERROR.lower())
         self.assertTrue(Constants.TELEMETRY_AT_AGENT_NOT_COMPATIBLE_ERROR_MSG in json.loads(substatus_file_data[1]["formattedMessage"]["message"])["errors"]["details"][0]["message"])
         runtime.stop()
 
@@ -317,18 +317,18 @@ class TestCoreMain(unittest.TestCase):
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
         self.assertEquals(len(substatus_file_data), 4)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
-        self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_ERROR.lower())
+        self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_ERROR.lower())
         self.assertEqual(len(json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"]), 1)
         self.assertTrue(Constants.TELEMETRY_AT_AGENT_NOT_COMPATIBLE_ERROR_MSG in json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"][0]["message"])
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
-        self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_ERROR.lower())
+        self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_ERROR.lower())
         self.assertEqual(len(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["errors"]["details"]), 1)
         self.assertFalse(Constants.TELEMETRY_AT_AGENT_NOT_COMPATIBLE_ERROR_MSG in json.loads(substatus_file_data[1]["formattedMessage"]["message"])["errors"]["details"][0]["message"])
         self.assertTrue("Installation failed due to assessment failure. Please refer the error details in assessment substatus" in json.loads(substatus_file_data[1]["formattedMessage"]["message"])["errors"]["details"][0]["message"])
         self.assertTrue(substatus_file_data[2]["name"] == Constants.PATCH_METADATA_FOR_HEALTHSTORE)
-        self.assertTrue(substatus_file_data[2]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[2]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[3]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
-        self.assertTrue(substatus_file_data[3]["status"] == Constants.STATUS_ERROR.lower())
+        self.assertTrue(substatus_file_data[3]["status"].lower() == Constants.STATUS_ERROR.lower())
         self.assertEqual(len(json.loads(substatus_file_data[3]["formattedMessage"]["message"])["errors"]["details"]), 1)
         self.assertTrue(Constants.TELEMETRY_AT_AGENT_NOT_COMPATIBLE_ERROR_MSG in json.loads(substatus_file_data[3]["formattedMessage"]["message"])["errors"]["details"][0]["message"])
         runtime.stop()
@@ -356,9 +356,9 @@ class TestCoreMain(unittest.TestCase):
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
         self.assertEquals(len(substatus_file_data), 4)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
-        self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
-        self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["installedPatchCount"] == 5)
         self.assertEqual(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][0]["name"], "selinux-policy.noarch")
         self.assertTrue("Other" in str(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][0]["classifications"]))
@@ -371,12 +371,12 @@ class TestCoreMain(unittest.TestCase):
         self.assertTrue("Security" in str(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][2]["classifications"]))
         self.assertTrue("Installed" == json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][2]["patchInstallationState"])
         self.assertTrue(substatus_file_data[2]["name"] == Constants.PATCH_METADATA_FOR_HEALTHSTORE)
-        self.assertTrue(substatus_file_data[2]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[2]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         substatus_file_data_patch_metadata_summary = json.loads(substatus_file_data[2]["formattedMessage"]["message"])
         self.assertEqual(substatus_file_data_patch_metadata_summary["patchVersion"], "2020.09.28")
         self.assertTrue(substatus_file_data_patch_metadata_summary["shouldReportToHealthStore"])
         self.assertTrue(substatus_file_data[3]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
-        self.assertTrue(substatus_file_data[3]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[3]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         runtime.stop()
 
         LegacyEnvLayerExtensions.LegacyPlatform.linux_distribution = backup_envlayer_platform_linux_distribution
@@ -404,9 +404,9 @@ class TestCoreMain(unittest.TestCase):
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
         self.assertEquals(len(substatus_file_data), 4)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
-        self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
-        self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["installedPatchCount"] == 1)
         self.assertEqual(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][0]["name"], "selinux-policy.noarch")
         self.assertTrue("Other" in str(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][0]["classifications"]))
@@ -425,12 +425,12 @@ class TestCoreMain(unittest.TestCase):
         self.assertTrue("Security" in str(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][4]["classifications"]))
         self.assertTrue("Installed" == json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][4]["patchInstallationState"])
         self.assertTrue(substatus_file_data[2]["name"] == Constants.PATCH_METADATA_FOR_HEALTHSTORE)
-        self.assertTrue(substatus_file_data[2]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[2]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         substatus_file_data_patch_metadata_summary = json.loads(substatus_file_data[2]["formattedMessage"]["message"])
         self.assertEqual(substatus_file_data_patch_metadata_summary["patchVersion"], "2020.09.28")
         self.assertTrue(substatus_file_data_patch_metadata_summary["shouldReportToHealthStore"])
         self.assertTrue(substatus_file_data[3]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
-        self.assertTrue(substatus_file_data[3]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[3]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         runtime.stop()
 
         LegacyEnvLayerExtensions.LegacyPlatform.linux_distribution = backup_envlayer_platform_linux_distribution
@@ -455,7 +455,7 @@ class TestCoreMain(unittest.TestCase):
         substatus_file_data = status_file_data["substatus"]
         self.assertEquals(len(substatus_file_data), 1)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
-        self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         # check status file for configure patching auto updates state
         message = json.loads(substatus_file_data[0]["formattedMessage"]["message"])
         self.assertEqual(message["automaticOsPatchState"], Constants.AutomaticOsPatchStates.DISABLED)  # auto OS updates are disabled in RuntimeCompositor
@@ -484,12 +484,12 @@ class TestCoreMain(unittest.TestCase):
         substatus_file_data = status_file_data["substatus"]
         self.assertEquals(len(substatus_file_data), 2)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
-        self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         # check started by set to 'Platform'
         self.assertTrue(json.loads(substatus_file_data[0]["formattedMessage"]["message"])['startedBy'], Constants.PatchAssessmentSummaryStartedBy.PLATFORM)
         # verifying the older operation summary is preserved
         self.assertTrue(substatus_file_data[1]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
-        self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         message = json.loads(substatus_file_data[1]["formattedMessage"]["message"])
         self.assertEqual(message["automaticOsPatchState"], Constants.AutomaticOsPatchStates.DISABLED)  # auto OS updates are disabled in RuntimeCompositor
         # check status file for configure patching assessment state
@@ -515,12 +515,11 @@ class TestCoreMain(unittest.TestCase):
         substatus_file_data = status_file_data["substatus"]
         self.assertEquals(len(substatus_file_data), 2)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
-        self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         # check started by set to 'User'
         self.assertTrue(json.loads(substatus_file_data[0]["formattedMessage"]["message"])['startedBy'], Constants.PatchAssessmentSummaryStartedBy.USER)
-        last_modified_time_after_user_initiated_assessment = json.loads(substatus_file_data[0]["formattedMessage"]["message"])["lastModifiedTime"]
         self.assertTrue(substatus_file_data[1]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
-        self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         # check status file for configure patching auto updates state
         message = json.loads(substatus_file_data[1]["formattedMessage"]["message"])
         self.assertEqual(message["automaticOsPatchState"], Constants.AutomaticOsPatchStates.DISABLED)  # auto OS updates are disabled in RuntimeCompositor
@@ -550,12 +549,12 @@ class TestCoreMain(unittest.TestCase):
         substatus_file_data = status_file_data["substatus"]
         self.assertEquals(len(substatus_file_data), 2)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
-        self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         # check started by set to 'Platform'
         self.assertTrue(json.loads(substatus_file_data[0]["formattedMessage"]["message"])['startedBy'], Constants.PatchAssessmentSummaryStartedBy.PLATFORM)
         # verifying the older operation summary is preserved
         self.assertTrue(substatus_file_data[1]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
-        self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         # check status file for configure patching auto updates state
         message = json.loads(substatus_file_data[1]["formattedMessage"]["message"])
         self.assertEqual(message["automaticOsPatchState"], Constants.AutomaticOsPatchStates.DISABLED)  # auto OS updates are disabled in RuntimeCompositor
@@ -585,16 +584,16 @@ class TestCoreMain(unittest.TestCase):
         substatus_file_data = status_file_data["substatus"]
         self.assertEquals(len(substatus_file_data), 4)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
-        self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         # check started by set to 'User'
         self.assertTrue(json.loads(substatus_file_data[0]["formattedMessage"]["message"])['startedBy'], Constants.PatchAssessmentSummaryStartedBy.USER)
-        last_modified_time_after_user_initiated_installation = json.loads(substatus_file_data[0]["formattedMessage"]["message"])["lastModifiedTime"]
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
-        self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_SUCCESS.lower())
+        last_modified_time_from_installation_substatus_after_user_initiated_installation = json.loads(substatus_file_data[1]["formattedMessage"]["message"])["lastModifiedTime"]
         self.assertTrue(substatus_file_data[2]["name"] == Constants.PATCH_METADATA_FOR_HEALTHSTORE)
-        self.assertTrue(substatus_file_data[2]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[2]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[3]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
-        self.assertTrue(substatus_file_data[3]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[3]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         # check status file for configure patching auto updates state
         message = json.loads(substatus_file_data[3]["formattedMessage"]["message"])
         self.assertEqual(message["automaticOsPatchState"], Constants.AutomaticOsPatchStates.DISABLED)  # auto OS updates are disabled in RuntimeCompositor, this is tested in Test-ConfigurePatchingProcessor
@@ -624,16 +623,19 @@ class TestCoreMain(unittest.TestCase):
         substatus_file_data = status_file_data["substatus"]
         self.assertEquals(len(substatus_file_data), 4)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
-        self.assertTrue(substatus_file_data[0]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         # check started by set to 'Platform'
         self.assertTrue(json.loads(substatus_file_data[0]["formattedMessage"]["message"])['startedBy'], Constants.PatchAssessmentSummaryStartedBy.PLATFORM)
         # verifying the older operation summary is preserved
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
-        self.assertTrue(substatus_file_data[1]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_SUCCESS.lower())
+        # validate lastModifiedTime in InstallationSummary is preserved from the user initiated installation operation
+        last_modified_time_from_installation_substatus_after_platform_initiated_assessment = json.loads(substatus_file_data[1]["formattedMessage"]["message"])["lastModifiedTime"]
+        self.assertEquals(last_modified_time_from_installation_substatus_after_user_initiated_installation, last_modified_time_from_installation_substatus_after_platform_initiated_assessment)
         self.assertTrue(substatus_file_data[2]["name"] == Constants.PATCH_METADATA_FOR_HEALTHSTORE)
-        self.assertTrue(substatus_file_data[2]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[2]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[3]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
-        self.assertTrue(substatus_file_data[3]["status"] == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[3]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         # check status file for configure patching auto updates state
         message = json.loads(substatus_file_data[3]["formattedMessage"]["message"])
         self.assertEqual(message["automaticOsPatchState"], Constants.AutomaticOsPatchStates.DISABLED)  # auto OS updates are disabled in RuntimeCompositor

--- a/src/core/tests/Test_StatusHandler.py
+++ b/src/core/tests/Test_StatusHandler.py
@@ -31,6 +31,7 @@ class TestStatusHandler(unittest.TestCase):
         self.runtime.stop()
 
     def test_set_package_assessment_status(self):
+        # startedBy should be set to User in status for Assessment
         packages, package_versions = self.runtime.package_manager.get_all_updates()
         self.runtime.status_handler.set_package_assessment_status(packages, package_versions)
         with self.runtime.env_layer.file_system.open(self.runtime.execution_config.status_file_path, 'r') as file_handle:
@@ -43,8 +44,9 @@ class TestStatusHandler(unittest.TestCase):
         self.assertTrue("python-samba_2:4.4.5+dfsg-2ubuntu5.4" in str(json.loads(substatus_file_data["formattedMessage"]["message"])["patches"][0]["patchId"]))
         self.assertEqual(json.loads(substatus_file_data["formattedMessage"]["message"])["startedBy"], Constants.PatchAssessmentSummaryStartedBy.USER)
 
-    def test_set_package_assessment_status_started_by(self):
-        self.runtime.execution_config.operation = Constants.AUTO_ASSESSMENT
+    def test_set_package_assessment_status_for_auto_assessment(self):
+        # startedBy should be set to Platform in status for Auto Assessment
+        self.runtime.execution_config.exec_auto_assess_only = True
         packages, package_versions = self.runtime.package_manager.get_all_updates()
         self.runtime.status_handler.set_package_assessment_status(packages, package_versions)
         with self.runtime.env_layer.file_system.open(self.runtime.execution_config.status_file_path, 'r') as file_handle:

--- a/src/core/tests/Test_StatusHandler.py
+++ b/src/core/tests/Test_StatusHandler.py
@@ -222,7 +222,7 @@ class TestStatusHandler(unittest.TestCase):
         self.assertTrue(status_handler is not None)
         self.assertEqual(json.loads(substatus_file_data["formattedMessage"]["message"])["shouldReportToHealthStore"], False)
         self.assertEqual(json.loads(substatus_file_data["formattedMessage"]["message"])["patchVersion"], Constants.PATCH_VERSION_UNKNOWN)
-        self.assertEqual(substatus_file_data["status"], Constants.STATUS_SUCCESS.lower())
+        self.assertEqual(substatus_file_data["status"].lower(), Constants.STATUS_SUCCESS.lower())
 
     def test_set_patch_metadata_for_healthstore_substatus_json(self):
         # setting healthstore properties
@@ -231,7 +231,7 @@ class TestStatusHandler(unittest.TestCase):
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"][0]
         self.assertEqual(json.loads(substatus_file_data["formattedMessage"]["message"])["shouldReportToHealthStore"], True)
         self.assertEqual(json.loads(substatus_file_data["formattedMessage"]["message"])["patchVersion"], "2020-07-08")
-        self.assertEqual(substatus_file_data["status"], Constants.STATUS_SUCCESS.lower())
+        self.assertEqual(substatus_file_data["status"].lower(), Constants.STATUS_SUCCESS.lower())
 
         # using default values
         self.runtime.status_handler.set_patch_metadata_for_healthstore_substatus_json()
@@ -239,7 +239,7 @@ class TestStatusHandler(unittest.TestCase):
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"][0]
         self.assertEqual(json.loads(substatus_file_data["formattedMessage"]["message"])["shouldReportToHealthStore"], False)
         self.assertEqual(json.loads(substatus_file_data["formattedMessage"]["message"])["patchVersion"], Constants.PATCH_VERSION_UNKNOWN)
-        self.assertEqual(substatus_file_data["status"], Constants.STATUS_SUCCESS.lower())
+        self.assertEqual(substatus_file_data["status"].lower(), Constants.STATUS_SUCCESS.lower())
 
 
 if __name__ == '__main__':

--- a/src/core/tests/library/ArgumentComposer.py
+++ b/src/core/tests/library/ArgumentComposer.py
@@ -30,7 +30,7 @@ class ArgumentComposer(object):
         self.__EXEC = "MsftLinuxPatchCore.py"
         self.__TESTS_FOLDER = "tests"
         self.__SCRATCH_FOLDER = "scratch"
-        self.__ARG_TEMPLATE = "{0} {1} {2} {3} \'{4}\' {5} \'{6}\'"
+        self.__ARG_TEMPLATE = "{0} {1} {2} {3} \'{4}\' {5} \'{6}\' {7} {8}"
         self.__EVENTS_FOLDER = "events"
 
         # sequence number
@@ -53,6 +53,8 @@ class ArgumentComposer(object):
         self.patch_mode = None
         self.assessment_mode = None
         self.maximum_assessment_interval = "PT3H"
+
+        self.exec_auto_assess_only = False
 
         # REAL environment settings
         self.emulator_enabled = False
@@ -84,6 +86,7 @@ class ArgumentComposer(object):
         return str(self.__ARG_TEMPLATE.format(self.__EXEC, Constants.ARG_SEQUENCE_NUMBER, self.sequence_number,
                                               Constants.ARG_ENVIRONMENT_SETTINGS, self.__get_encoded_json_str(environment_settings),
                                               Constants.ARG_CONFIG_SETTINGS, self.__get_encoded_json_str(config_settings),
+                                              Constants.ARG_AUTO_ASSESS_ONLY, self.exec_auto_assess_only,
                                               Constants.ARG_INTERNAL_RECORDER_ENABLED, str(False),
                                               Constants.ARG_INTERNAL_EMULATOR_ENABLED, str(self.emulator_enabled))).split(' ')
 

--- a/src/core/tests/library/RuntimeCompositor.py
+++ b/src/core/tests/library/RuntimeCompositor.py
@@ -17,6 +17,7 @@
 import datetime
 import json
 import os
+import socket
 import time
 
 from core.src.service_interfaces.TelemetryWriter import TelemetryWriter
@@ -25,6 +26,16 @@ from core.tests.library.LegacyEnvLayerExtensions import LegacyEnvLayerExtensions
 from core.src.bootstrap.Bootstrapper import Bootstrapper
 from core.src.bootstrap.Constants import Constants
 
+# Todo: find a different way to import these
+try:
+    import urllib2 as urlreq   #Python 2.x
+except:
+    import urllib.request as urlreq   #Python 3.x
+
+try:
+    from StringIO import StringIO ## for Python 2
+except ImportError:
+    from io import StringIO ## for Python 3
 
 class RuntimeCompositor(object):
     def __init__(self, argv=Constants.DEFAULT_UNSPECIFIED_VALUE, legacy_mode=False, package_manager_name=Constants.APT):
@@ -33,9 +44,11 @@ class RuntimeCompositor(object):
         os.environ[Constants.LPE_ENV_VARIABLE] = self.current_env
         self.argv = argv if argv != Constants.DEFAULT_UNSPECIFIED_VALUE else ArgumentComposer().get_composed_arguments()
 
-        # Overriding time.sleep to avoid delays in test execution
+        # Overriding time.sleep and urlopen to avoid delays in test execution
         self.backup_time_sleep = time.sleep
         time.sleep = self.mock_sleep
+        self.backup_url_open = urlreq.urlopen
+        urlreq.urlopen = self.mock_urlopen
 
         # Adapted bootstrapper
         bootstrapper = Bootstrapper(self.argv, capture_stdout=False)
@@ -76,6 +89,16 @@ class RuntimeCompositor(object):
         self.vm_cloud_type = bootstrapper.configuration_factory.vm_cloud_type
         # Extension handler dependency
         self.write_ext_state_file(self.lifecycle_manager.ext_state_file_path, self.execution_config.sequence_number, datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ"), self.execution_config.operation)
+
+        # Mock service and timer creation and removal used for Auto Assessment
+        self.backup_create_and_set_service_idem = self.configure_patching_processor.auto_assess_service_manager.create_and_set_service_idem
+        self.configure_patching_processor.auto_assess_service_manager.create_and_set_service_idem = self.mock_create_and_set_service_idem
+        self.backup_mock_create_and_set_timer_idem = self.configure_patching_processor.auto_assess_timer_manager.create_and_set_timer_idem
+        self.configure_patching_processor.auto_assess_timer_manager.create_and_set_timer_idem = self.mock_create_and_set_timer_idem
+        self.backup_remove_service = self.configure_patching_processor.auto_assess_service_manager.remove_service
+        self.configure_patching_processor.auto_assess_service_manager.remove_service = self.mock_remove_service
+        self.backup_remove_timer = self.configure_patching_processor.auto_assess_timer_manager.remove_timer
+        self.configure_patching_processor.auto_assess_timer_manager.remove_timer = self.mock_remove_timer
 
     def stop(self):
         self.file_logger.close(message_at_close="<Runtime stopped>")
@@ -120,6 +143,24 @@ class RuntimeCompositor(object):
 
     def get_current_auto_os_patch_state(self):
         return Constants.AutomaticOsPatchStates.DISABLED
+
+    def mock_urlopen(url, data=None, timeout=socket._GLOBAL_DEFAULT_TIMEOUT, cafile=None, capath=None, cadefault=False, context=None):
+        resp = urlreq.addinfourl(StringIO("mock file"), "mock message", "mockurl")
+        resp.code = 200
+        resp.msg = "OK"
+        return resp
+
+    def mock_create_and_set_service_idem(self):
+        pass
+
+    def mock_create_and_set_timer_idem(self):
+        pass
+
+    def mock_remove_service(self):
+        pass
+
+    def mock_remove_timer(self):
+        pass
 
     @staticmethod
     def write_to_file(path, data):

--- a/src/extension/src/ProcessHandler.py
+++ b/src/extension/src/ProcessHandler.py
@@ -146,16 +146,21 @@ class ProcessHandler(object):
     def __check_process_state(self, process, seq_no):
         """ Checks if the process is running by polling every second for a certain period and reports an error if the process is not found """
         did_process_start = False
+        retcode = -1
+        output = ""
+        unused_err = ""
         for retry in range(0, Constants.MAX_PROCESS_STATUS_CHECK_RETRIES):
             time.sleep(retry)
-            if process.poll() is None:
+            output, unused_err = process.communicate()
+            retcode = process.poll()
+            if retcode is None:
                 did_process_start = True
                 break
         # if process is not running, log stdout and stderr
         if not did_process_start:
             self.logger.log("Process not running for [sequence={0}]".format(seq_no))
-            self.logger.log("Stdout for the inactive process: [Output={0}]".format(str(process.stdout.read())))
-            self.logger.log("Stderr for the inactive process: [Error={0}]".format(str(process.stderr.read())))
+            self.logger.log("Output for the inactive process: [Output={0}]".format(str(output)))
+            self.logger.log("Error for the inactive process: [Error={0}]".format(str(unused_err)))
         return did_process_start
 
     def identify_running_processes(self, process_ids):

--- a/src/extension/tests/Test_ProcessHandler.py
+++ b/src/extension/tests/Test_ProcessHandler.py
@@ -64,6 +64,9 @@ class TestProcessHandler(unittest.TestCase):
     def mock_get_python_cmd(self):
         return "python"
 
+    def mock_run_command_to_set_auto_assess_shell_file_permission(self, cmd, no_output=False, chk_err=False):
+        return 0, "permissions set"
+
     def mock_subprocess_popen_process_not_running_after_launch(self, command, shell, stdout, stderr):
         self.process.pid = 1
         self.process.poll = self.mock_process_poll_return_Not_None
@@ -168,12 +171,18 @@ class TestProcessHandler(unittest.TestCase):
         # process launched but is not running soon after
         subprocess.Popen = self.mock_subprocess_popen_process_not_running_after_launch
         process_handler = ProcessHandler(self.logger, self.env_layer, self.ext_output_status_handler)
+
+        # mock run command output for Auto Assess shell file permission change
+        run_command_output_backup = process_handler.env_layer.run_command_output
+        process_handler.env_layer.run_command_output = self.mock_run_command_to_set_auto_assess_shell_file_permission
+
         process = process_handler.start_daemon(seq_no, config_settings, ext_env_handler)
         self.assertTrue(process is None)
 
         # resetting mocks
         ProcessHandler.get_python_cmd = get_python_cmd_backup
         subprocess.Popen = subprocess_popen_backup
+        process_handler.env_layer.run_command_output = run_command_output_backup
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Contains:

- Bug fix for summaries from previous operation not preserved after auto assessment in status file. For eg: if the operation order was ConfigurePatching followed by Auto Assessment, status file after Auto Assessment should contain PatchAssessmentSummary (refreshed by Auto Assessment) and ConfigurePatchingSummary.
Included unit tests to cover this usecase

- Bug fix for main/outer operation name overwritten to Assessment by Auto Assessment. For eg: if the operation order was ConfigurePatching followed by Auto Assessment, operation name in status file after Auto Assessment should be 'ConfigurePatching'
 Included unit test to cover this

- Bug fix for reading boolean string values correctly. bool(<str>) which was used earlier, will always return True, even for bool('False')

- Bug fix for reading 'processIds' from CoreState.json. Were using the wrong key earlier

- Syntax corrections in many places as per standard practice

- Tests were taking longer to execute due to IMDS connection retries and were initializing LifecycleManagerArc for Azure tests. Fixed by mocking connection to set cloud type as Azure

- Added additional logging in a few places

- Added unit test for ConfigurePatching with different configs for patchMode and assessmentMode