### PR TITLE
Updating extension version to 1.6.22

### DIFF
--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -30,7 +30,7 @@ class Constants(object):
     UNKNOWN = "Unknown"
 
     # Extension version (todo: move to a different file)
-    EXT_VERSION = "1.6.21"
+    EXT_VERSION = "1.6.22"
 
     # Runtime environments
     TEST = 'Test'

--- a/src/extension/src/Constants.py
+++ b/src/extension/src/Constants.py
@@ -28,7 +28,7 @@ class Constants(object):
                         yield item
 
     # Extension version (todo: move to a different file)
-    EXT_VERSION = "1.6.21"
+    EXT_VERSION = "1.6.22"
 
     # Runtime environments
     TEST = 'Test'

--- a/src/extension/src/manifest.xml
+++ b/src/extension/src/manifest.xml
@@ -2,7 +2,7 @@
 <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure">
   <ProviderNameSpace>Microsoft.CPlat.Core</ProviderNameSpace>
   <Type>LinuxPatchExtension</Type>
-  <Version>1.6.21</Version>
+  <Version>1.6.22</Version>
   <Label>Microsoft Azure VM InGuest Patch Extension for Linux Virtual Machines</Label>
   <HostingResources>VmRole</HostingResources>
   <MediaLink></MediaLink>


### PR DESCRIPTION
This version contains:

- Bug fix for summaries from previous operation not preserved after auto assessment in status file. For eg: if the operation order was ConfigurePatching followed by Auto Assessment, status file after Auto Assessment should contain PatchAssessmentSummary (refreshed by Auto Assessment) and ConfigurePatchingSummary. Included unit tests to cover this usecase

- Bug fix for main/outer operation name overwritten to Assessment by Auto Assessment. For eg: if the operation order was ConfigurePatching followed by Auto Assessment, operation name in status file after Auto Assessment should be 'ConfigurePatching' Included unit test to cover this

- Bug fix for reading boolean string values correctly. bool() which was used earlier, will always return True, even for bool('False')

- Bug fix for reading 'processIds' from CoreState.json. Were using the wrong key earlier

- Syntax corrections in many places as per standard practice

- Tests were taking longer to execute due to IMDS connection retries and were initializing LifecycleManagerArc for Azure tests. Fixed by mocking connection to set cloud type as Azure

- Added additional logging in a few places

- Added unit test for ConfigurePatching with different configs for patchMode and assessmentMode

- Adding zypper process tree on package manager failures to telemetry