### PR TITLE
Fix for [Bug] Error during extension enable [Error=ValueError('I/O op…

### DIFF
--- a/src/extension/src/ProcessHandler.py
+++ b/src/extension/src/ProcessHandler.py
@@ -151,12 +151,17 @@ class ProcessHandler(object):
         unused_err = ""
         for retry in range(0, Constants.MAX_PROCESS_STATUS_CHECK_RETRIES):
             time.sleep(retry)
-            output, unused_err = process.communicate()
             retcode = process.poll()
             if retcode is None:
                 did_process_start = True
                 break
         # if process is not running, log stdout and stderr
+        # TASK 10881186 for 'I/O operation on closed file' exception. removed process.communicate from loop and checking only when process do not start
+        try:
+            output, unused_err = process.communicate()
+        except Exception as error:
+            self.logger.log("Exception from process.communicate() while trying to communicate to core process. Exeption:{0}".format(repr(error)))
+
         if not did_process_start:
             self.logger.log("Process not running for [sequence={0}]".format(seq_no))
             self.logger.log("Output for the inactive process: [Output={0}]".format(str(output)))


### PR DESCRIPTION
…eration on closed file',)]

Details about this fix: https://msazure.visualstudio.com/One/_workitems/edit/10881186


Reproduced the issue and tested the fix multiple times using attached sample code

**Sample Core:**
import time
count = 0
while (count < 15):
   time.sleep(10)
   count = count + 1
   f = open("demofile2.txt", "a")
   f.write("hello geek")
   f.close()

**Sample handler:**
import subprocess
import os
import time

def start_script():
    exe_path = os.path.join(os.getcwd(),"script_in_loop.py")
    base_command = "python " +  exe_path
    print("starting background job")
    command = [base_command]
    process = subprocess.Popen(command,shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE)
    if process.pid is not None:
       print("process launched successfully")
       did_process_start = check_process_state(process)
       if did_process_start:
          print("process started")
       else:
          print("process didnot start")
    print("end of start script")

def check_process_state(process):
    did_process_start = False
    retcode = -1
    output = ""
    unused_err = ""
    for retry in range(0, 5):
        print("sleeping in retry loop: "+ str(retry))
        time.sleep(retry)
        print("completed communicate")
        retcode = process.poll()
        print("completed poll")
        if retcode is None:
           print("process has started and verified")
           did_process_start = True
           break
        else:
           print("process start verification failed, retrying")
    # if process is not running, log stdout and stderr
    output, unused_err = process.communicate()
    print("Output for the active process: [Output={0}]".format(str(output)))
    if not did_process_start:
        print("Output for the inactive process: [Output={0}]".format(str(output)))
        print("Error for the inactive process: [Error={0}]".format(str(unused_err)))
    return did_process_start

if __name__ == "__main__":
   start_script()





