### PR TITLE
Add zypper package manager retries

### DIFF
--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -30,7 +30,7 @@ class Constants(object):
     UNKNOWN = "Unknown"
 
     # Extension version (todo: move to a different file)
-    EXT_VERSION = "1.6.27"
+    EXT_VERSION = "1.6.28"
 
     # Runtime environments
     TEST = 'Test'

--- a/src/core/src/bootstrap/EnvLayer.py
+++ b/src/core/src/bootstrap/EnvLayer.py
@@ -83,7 +83,7 @@ class EnvLayer(object):
 
         return ret
 
-    def set_env_var(self, var_name, var_value=None):
+    def set_env_var(self, var_name, var_value=None, raise_if_not_success=False):
         """ Sets an environment variable with var_name and var_value in /etc/environment. If it already exists, it is overwriten. """
         try:
             environment_vars = self.file_system.read_with_retry(self.etc_environment_file_path)
@@ -124,9 +124,10 @@ class EnvLayer(object):
 
         except Exception as error:
             print("Error occurred while setting environment variable [Variable={0}] [Value={1}] [Exception={2}]".format(str(var_name), str(var_value), repr(error)))
-            raise
+            if raise_if_not_success:
+                raise
 
-    def get_env_var(self, var_name):
+    def get_env_var(self, var_name, raise_if_not_success=False):
         """ Returns the value of an environment variable with var_name in /etc/environment. Returns None if it does not exist. """
         try:
             environment_vars = self.file_system.read_with_retry(self.etc_environment_file_path)
@@ -152,7 +153,8 @@ class EnvLayer(object):
 
         except Exception as error:
             print("Error occurred while getting environment variable [Variable={0}] [Exception={1}]".format(str(var_name), repr(error)))
-            raise
+            if raise_if_not_success:
+                raise
 
     def run_command_output(self, cmd, no_output=False, chk_err=False):
         operation = "RUN_CMD_OUT"

--- a/src/core/src/bootstrap/EnvLayer.py
+++ b/src/core/src/bootstrap/EnvLayer.py
@@ -99,7 +99,7 @@ class EnvLayer(object):
                 regex = re.compile('{0}=.+'.format(var_name))
                 search = regex.search(environment_vars)
                 if search is None:
-                    return None
+                    return
 
                 group = search.group()
                 environment_vars = environment_vars.replace(group, '').replace("\n\n", "\n")

--- a/src/core/src/bootstrap/EnvLayer.py
+++ b/src/core/src/bootstrap/EnvLayer.py
@@ -91,9 +91,11 @@ class EnvLayer(object):
                 print("Error occurred while setting environment variable: File not found. [Variable={0}] [Value={1}] [Path={2}]".format(str(var_name), str(var_value), self.etc_environment_file_path))
                 return
 
+            environment_vars_lines = environment_vars.strip().split("\n")
+
             if var_value is None:
                 # remove environment variable
-                if not var_name in environment_vars:
+                if var_name not in environment_vars:
                     return
 
                 regex = re.compile('{0}=.+'.format(var_name))
@@ -107,15 +109,16 @@ class EnvLayer(object):
                 return
 
             formatted_env_var = "{0}={1}".format(var_name, str(var_value))
-            if not var_name in environment_vars:
+            if var_name not in environment_vars:
                 self.file_system.write_with_retry(self.etc_environment_file_path, "\n" + formatted_env_var)
             else:
                 # Update the value of the existing setting
-                for env_var in environment_vars:
+                for env_var in environment_vars_lines:
                     if var_name not in str(env_var):
                         continue
 
-                    environment_vars.replace(str(env_var), formatted_env_var)
+                    environment_vars = environment_vars.replace(str(env_var), formatted_env_var)
+                    break
 
                 self.file_system.write_with_retry(self.etc_environment_file_path, environment_vars, 'w')
 
@@ -133,7 +136,7 @@ class EnvLayer(object):
 
             settings = environment_vars.strip().split('\n')
 
-            if not var_name in settings:
+            if var_name not in environment_vars:
                 return None
             else:
                 # get specific environment variable value
@@ -142,8 +145,8 @@ class EnvLayer(object):
                         continue
 
                     env_var_split = env_var.split("=")
-                    if len(env_var_split) == 2:
-                        return env_var_split[1]
+                    if len(env_var_split) == 2 and env_var_split[0].strip() == var_name:
+                        return env_var_split[1].strip()
 
             return None
 

--- a/src/core/src/bootstrap/EnvLayer.py
+++ b/src/core/src/bootstrap/EnvLayer.py
@@ -132,21 +132,14 @@ class EnvLayer(object):
                 print("Error occurred while getting environment variable: File not found. [Variable={0}] [Path={1}]".format(str(var_name), self.etc_environment_file_path))
                 return None
 
-            settings = environment_vars.strip().split('\n')
-
-            if var_name not in environment_vars:
+            # get specific environment variable value
+            regex = re.compile('{0}=.+'.format(var_name))
+            search = regex.search(environment_vars)
+            if search is None:
                 return None
-            else:
-                # get specific environment variable value
-                for env_var in settings:
-                    if var_name not in str(env_var):
-                        continue
 
-                    env_var_split = env_var.split("=")
-                    if len(env_var_split) == 2 and env_var_split[0].strip() == var_name:
-                        return env_var_split[1].strip()
-
-            return None
+            group = search.group()
+            return group[group.index("=")+1:]
 
         except Exception as error:
             print("Error occurred while getting environment variable [Variable={0}] [Exception={1}]".format(str(var_name), repr(error)))

--- a/src/core/src/bootstrap/EnvLayer.py
+++ b/src/core/src/bootstrap/EnvLayer.py
@@ -95,9 +95,6 @@ class EnvLayer(object):
 
             if var_value is None:
                 # remove environment variable
-                if var_name not in environment_vars:
-                    return
-
                 regex = re.compile('{0}=.+'.format(var_name))
                 search = regex.search(environment_vars)
                 if search is None:

--- a/src/core/src/bootstrap/EnvLayer.py
+++ b/src/core/src/bootstrap/EnvLayer.py
@@ -87,6 +87,10 @@ class EnvLayer(object):
         try:
             formatted_env_var = "{0}={1}".format(var_name, var_value)
             environment_vars = self.file_system.read_with_retry(self.etc_environment_file_path)
+            if environment_vars is None:
+                print("Error occurred while setting environment variable: File not found. [Variable={0}] [Value={1}] [Path={2}]".format(str(var_name), str(var_value), self.etc_environment_file_path))
+                return
+
             settings = environment_vars.strip().split('\n')
 
             if not var_name in settings:

--- a/src/core/src/package_managers/ZypperPackageManager.py
+++ b/src/core/src/package_managers/ZypperPackageManager.py
@@ -60,7 +60,6 @@ class ZypperPackageManager(PackageManager):
         # self.invoke_package_manager(self.repo_clean)  # purges local metadata for rebuild - addresses a possible customer environment error
         try:
             self.invoke_package_manager(self.repo_refresh)
-            return
         except Exception as error:
             # Reboot if not already done
             if self.status_handler.get_installation_reboot_status() == Constants.RebootStatus.COMPLETED:

--- a/src/core/src/package_managers/ZypperPackageManager.py
+++ b/src/core/src/package_managers/ZypperPackageManager.py
@@ -90,10 +90,10 @@ class ZypperPackageManager(PackageManager):
         self.composite_logger.log_debug('\nInvoking package manager using: ' + command)
 
         for i in range(0, self.package_manager_max_retries):
-            zypp_lock_timeout = None
+            zypp_lock_timeout_backup = None
             try:
-                zypp_lock_timeout = self.env_layer.get_env_var('ZYPP_LOCK_TIMEOUT')
-                self.composite_logger.log_debug("Original value of ZYPP_LOCK_TIMEOUT env var: {0}".format(str(zypp_lock_timeout)))
+                zypp_lock_timeout_backup = self.env_layer.get_env_var('ZYPP_LOCK_TIMEOUT')
+                self.composite_logger.log_debug("Original value of ZYPP_LOCK_TIMEOUT env var: {0}".format(str(zypp_lock_timeout_backup)))
                 self.env_layer.set_env_var('ZYPP_LOCK_TIMEOUT', 5)
 
                 code, out = self.env_layer.run_command_output(command, False, False)
@@ -138,7 +138,7 @@ class ZypperPackageManager(PackageManager):
                     raise Exception(error_msg, "[{0}]".format(Constants.ERROR_ADDED_TO_STATUS))
             finally:
                 # Restore original env var, if it existed
-                self.env_layer.set_env_var('ZYPP_LOCK_TIMEOUT', zypp_lock_timeout)
+                self.env_layer.set_env_var('ZYPP_LOCK_TIMEOUT', zypp_lock_timeout_backup)
 
     def get_process_tree_from_pid_in_output(self, message):
         """ Fetches pid from the error message by searching for the text 'pid' and returns the process tree with all details.

--- a/src/core/src/package_managers/ZypperPackageManager.py
+++ b/src/core/src/package_managers/ZypperPackageManager.py
@@ -58,31 +58,26 @@ class ZypperPackageManager(PackageManager):
     def refresh_repo(self):
         self.composite_logger.log("Refreshing local repo...")
         # self.invoke_package_manager(self.repo_clean)  # purges local metadata for rebuild - addresses a possible customer environment error
-        for i in range(0, Constants.MAX_ZYPPER_REPO_REFRESH_RETRY_COUNT):
-            try:
-                self.invoke_package_manager(self.repo_refresh)
-                return
-            except Exception as error:
-                if i < Constants.MAX_ZYPPER_REPO_REFRESH_RETRY_COUNT - 1:
-                    self.composite_logger.log_warning("Exception on package manager refresh repo. [Exception={0}] [RetryCount={1}]".format(repr(error), str(i)))
-                    time.sleep(pow(2, i) + 1)
-                else:
-                    if Constants.ERROR_ADDED_TO_STATUS in repr(error):
-                        error.args = error.args[:1]  # remove Constants.ERROR_ADDED_TO_STATUS flag to add new message to status
+        try:
+            self.invoke_package_manager(self.repo_refresh)
+            return
+        except Exception as error:
+            if Constants.ERROR_ADDED_TO_STATUS in repr(error):
+                error.args = error.args[:1]  # remove Constants.ERROR_ADDED_TO_STATUS flag to add new message to status
 
-                    error_msg = "Unable to refresh repo (retries exhausted). [{0}] [RetryCount={1}]".format(repr(error), str(i))
+            error_msg = "Unable to refresh repo (retries exhausted). [{0}]".format(repr(error))
 
-                    # Reboot if not already done
-                    if self.status_handler.get_installation_reboot_status() == Constants.RebootStatus.COMPLETED:
-                        error_msg = "Unable to refresh repo (retries exhausted after reboot). [{0}] [RetryCount={1}]".format(repr(error), str(i))
-                    else:
-                        self.composite_logger.log_warning("Setting force_reboot flag to True.")
-                        self.force_reboot = True
-                        
-                    self.composite_logger.log_warning(error_msg)
-                    self.status_handler.add_error_to_status(error_msg, Constants.PatchOperationErrorCodes.PACKAGE_MANAGER_FAILURE)
+            # Reboot if not already done
+            if self.status_handler.get_installation_reboot_status() == Constants.RebootStatus.COMPLETED:
+                error_msg = "Unable to refresh repo (retries exhausted after reboot). [{0}]".format(repr(error))
+            else:
+                self.composite_logger.log_warning("Setting force_reboot flag to True.")
+                self.force_reboot = True
+                
+            self.composite_logger.log_warning(error_msg)
+            self.status_handler.add_error_to_status(error_msg, Constants.PatchOperationErrorCodes.PACKAGE_MANAGER_FAILURE)
 
-                    raise Exception(error_msg)
+            raise Exception(error_msg)
 
     # region Get Available Updates
     def invoke_package_manager(self, command):

--- a/src/core/src/package_managers/ZypperPackageManager.py
+++ b/src/core/src/package_managers/ZypperPackageManager.py
@@ -93,6 +93,7 @@ class ZypperPackageManager(PackageManager):
             zypp_lock_timeout = None
             try:
                 zypp_lock_timeout = self.env_layer.get_env_var('ZYPP_LOCK_TIMEOUT')
+                self.composite_logger.log_debug("Original value of ZYPP_LOCK_TIMEOUT env var: {0}".format(str(zypp_lock_timeout)))
                 self.env_layer.set_env_var('ZYPP_LOCK_TIMEOUT', 5)
 
                 code, out = self.env_layer.run_command_output(command, False, False)

--- a/src/core/src/package_managers/ZypperPackageManager.py
+++ b/src/core/src/package_managers/ZypperPackageManager.py
@@ -51,6 +51,7 @@ class ZypperPackageManager(PackageManager):
         # Miscellaneous
         self.set_package_manager_setting(Constants.PKG_MGR_SETTING_IDENTITY, Constants.ZYPPER)
         self.zypper_get_process_tree_cmd = 'ps --forest -o pid,cmd -g $(ps -o sid= -p {})'
+        self.env_layer.ensure_env_var_is_set('ZYPP_LOCK_TIMEOUT', 5)
 
     def refresh_repo(self):
         self.composite_logger.log("Refreshing local repo...")

--- a/src/core/tests/Test_CoreMain.py
+++ b/src/core/tests/Test_CoreMain.py
@@ -278,7 +278,7 @@ class TestCoreMain(unittest.TestCase):
         self.assertEquals(len(substatus_file_data), 2)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_ERROR.lower())
-        self.assertEqual(len(json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"]), 2)
+        self.assertEqual(len(json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"]), 3)
         self.assertTrue(substatus_file_data[1]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
         self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         runtime.stop()

--- a/src/core/tests/Test_CoreMain.py
+++ b/src/core/tests/Test_CoreMain.py
@@ -278,7 +278,7 @@ class TestCoreMain(unittest.TestCase):
         self.assertEquals(len(substatus_file_data), 2)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_ERROR.lower())
-        self.assertEqual(len(json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"]), 3)
+        self.assertEqual(len(json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"]), 2)
         self.assertTrue(substatus_file_data[1]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
         self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         runtime.stop()

--- a/src/core/tests/Test_CoreMain.py
+++ b/src/core/tests/Test_CoreMain.py
@@ -278,7 +278,7 @@ class TestCoreMain(unittest.TestCase):
         self.assertEquals(len(substatus_file_data), 2)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_ERROR.lower())
-        self.assertEqual(len(json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"]), 5)
+        self.assertEqual(len(json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"]), 2)
         self.assertTrue(substatus_file_data[1]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
         self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         runtime.stop()

--- a/src/core/tests/Test_ZypperPackageManager.py
+++ b/src/core/tests/Test_ZypperPackageManager.py
@@ -335,7 +335,7 @@ class TestZypperPackageManager(unittest.TestCase):
         self.runtime.env_layer.set_env_var(zypp_lock_timeout_var_name, 5)
 
         self.runtime.env_layer.file_system.read_with_retry = self.mock_read_with_retry_has_zypper_lock_var_10_wrong_format
-        self.assertIsNone(self.runtime.env_layer.get_env_var(zypp_lock_timeout_var_name))
+        self.assertEqual(self.runtime.env_layer.get_env_var(zypp_lock_timeout_var_name), "=10")
         self.runtime.env_layer.set_env_var(zypp_lock_timeout_var_name, 5)
 
 if __name__ == '__main__':

--- a/src/core/tests/Test_ZypperPackageManager.py
+++ b/src/core/tests/Test_ZypperPackageManager.py
@@ -321,12 +321,12 @@ class TestZypperPackageManager(unittest.TestCase):
 
         # test exceptions
         self.runtime.env_layer.file_system.read_with_retry = self.mock_read_with_retry_raises_exception
-        self.assertRaises(Exception, lambda: self.runtime.env_layer.set_env_var(zypp_lock_timeout_var_name, 5))
-        self.assertRaises(Exception, lambda: self.runtime.env_layer.get_env_var(zypp_lock_timeout_var_name))
+        self.assertRaises(Exception, lambda: self.runtime.env_layer.set_env_var(zypp_lock_timeout_var_name, 5, raise_if_not_success=True))
+        self.assertRaises(Exception, lambda: self.runtime.env_layer.get_env_var(zypp_lock_timeout_var_name, raise_if_not_success=True))
 
         self.runtime.env_layer.file_system.read_with_retry = self.mock_read_with_retry_not_has_zypper_lock_var
         self.runtime.env_layer.file_system.write_with_retry = self.mock_write_with_retry_raises_exception
-        self.assertRaises(Exception, lambda: self.runtime.env_layer.set_env_var(zypp_lock_timeout_var_name, 5))
+        self.assertRaises(Exception, lambda: self.runtime.env_layer.set_env_var(zypp_lock_timeout_var_name, 5, raise_if_not_success=True))
 
         # test return nones
         self.runtime.env_layer.file_system.read_with_retry = self.mock_read_with_retry_returns_none

--- a/src/core/tests/Test_ZypperPackageManager.py
+++ b/src/core/tests/Test_ZypperPackageManager.py
@@ -277,7 +277,6 @@ class TestZypperPackageManager(unittest.TestCase):
         self.assertEqual(data.find("ZYPP_LOCK_TIMEOUT"), -1)
 
     def mock_write_with_retry_assert_is_5(self, file_path_or_handle, data, mode='a+'):
-        print(data)
         self.assertNotEqual(data.find("ZYPP_LOCK_TIMEOUT=5"), -1)
 
     def test_env_var_set_get(self):

--- a/src/extension/src/Constants.py
+++ b/src/extension/src/Constants.py
@@ -28,7 +28,7 @@ class Constants(object):
                         yield item
 
     # Extension version (todo: move to a different file)
-    EXT_VERSION = "1.6.27"
+    EXT_VERSION = "1.6.28"
 
     # Runtime environments
     TEST = 'Test'

--- a/src/extension/src/EnvLayer.py
+++ b/src/extension/src/EnvLayer.py
@@ -34,7 +34,6 @@ class EnvLayer(object):
         # components for tty config
         self.etc_sudoers_file_path = "/etc/sudoers"
         self.etc_sudoers_linux_patch_extension_file_path = "/etc/sudoers.d/linuxpatchextension"
-        self.etc_environment_file_path = "/etc/environment"
         self.require_tty_setting = "requiretty"
 
     def run_command_output(self, cmd, no_output=False, chk_err=False):
@@ -129,29 +128,6 @@ class EnvLayer(object):
             return sys.version_info.major
         else:
             return sys.version_info[0]  # python 2.6 doesn't have attributes like 'major' within sys.version_info
-
-    def ensure_env_var_is_set(self, var_name, var_value):
-        """ Checks if an environment variable is set with var_name and var_value in /etc/environment. If not, the environment variable is set to var_value. """
-        try:
-            formatted_env_var = "{0}={1}".format(var_name, var_value)
-            environment_vars = self.file_system.read_with_retry(self.etc_environment_file_path)
-            settings = environment_vars.strip().split('\n')
-
-            if not var_name in settings:
-                self.file_system.write_with_retry(self.etc_environment_file_path, "\n" + formatted_env_var)
-            else:
-                # ensure the setting is the proper value
-                for env_var in settings:
-                    if var_name not in str(env_var):
-                        continue
-
-                    environment_vars.replace(str(env_var), formatted_env_var)
-
-                self.file_system.write_with_retry(self.etc_environment_file_path, environment_vars, 'w')
-
-        except Exception as error:
-            print("Error occurred while setting environment variable [Variable={0}] [Value={1}] [Exception={2}]".format(str(var_name), str(var_value), repr(error)))
-            raise
 
     def is_tty_required(self):
         """ Checks if tty is set to required within the VM and will be applicable to the current user (either via a generic config or a user specific one) """

--- a/src/extension/src/manifest.xml
+++ b/src/extension/src/manifest.xml
@@ -2,7 +2,7 @@
 <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure">
   <ProviderNameSpace>Microsoft.CPlat.Core</ProviderNameSpace>
   <Type>LinuxPatchExtension</Type>
-  <Version>1.6.27</Version>
+  <Version>1.6.28</Version>
   <Label>Microsoft Azure VM InGuest Patch Extension for Linux Virtual Machines</Label>
   <HostingResources>VmRole</HostingResources>
   <MediaLink></MediaLink>


### PR DESCRIPTION
- Add retries for all invocations to the package manager
- Ensure ZYPP_LOCK_TIMEOUT environment variable is set so it will be used
- Update version to 1.6.28