### PR TITLE
Bug fixes: in ConfigurePatching error reporting and disabling auto updates in yum via packagekit

### DIFF
--- a/src/core/src/core_logic/ConfigurePatchingProcessor.py
+++ b/src/core/src/core_logic/ConfigurePatchingProcessor.py
@@ -73,7 +73,7 @@ class ConfigurePatchingProcessor(object):
 
             self.current_auto_os_patch_state = self.package_manager.get_current_auto_os_patch_state()
 
-            if self.current_auto_os_patch_state == Constants.AutomaticOSPatchStates.UNKNOWN:
+            if self.execution_config.patch_mode == Constants.PatchModes.AUTOMATIC_BY_PLATFORM and self.current_auto_os_patch_state == Constants.AutomaticOSPatchStates.UNKNOWN:
                 # NOTE: only sending details in error objects for customer visibility on why patch state is unknown, overall configurepatching status will remain successful
                 self.__report_consolidated_configure_patch_status(error="Extension attempted but could not disable some of the auto OS update service. Please check if the auto OS services are configured correctly")
             else:
@@ -128,8 +128,6 @@ class ConfigurePatchingProcessor(object):
             error_msg = 'Error: ' + repr(error)
             self.composite_logger.log_error(error_msg)
             self.status_handler.add_error_to_status(error_msg, Constants.PatchOperationErrorCodes.DEFAULT_ERROR)
-            if Constants.ERROR_ADDED_TO_STATUS not in repr(error):
-                error.args = (error.args, "[{0}]".format(Constants.ERROR_ADDED_TO_STATUS))
 
         # write consolidated status
         self.status_handler.set_configure_patching_substatus_json(status=status,

--- a/src/core/src/core_logic/ConfigurePatchingProcessor.py
+++ b/src/core/src/core_logic/ConfigurePatchingProcessor.py
@@ -75,7 +75,7 @@ class ConfigurePatchingProcessor(object):
 
             if self.execution_config.patch_mode == Constants.PatchModes.AUTOMATIC_BY_PLATFORM and self.current_auto_os_patch_state == Constants.AutomaticOSPatchStates.UNKNOWN:
                 # NOTE: only sending details in error objects for customer visibility on why patch state is unknown, overall configurepatching status will remain successful
-                self.__report_consolidated_configure_patch_status(error="Extension attempted but could not disable some of the auto OS update service. Please check if the auto OS services are configured correctly")
+                self.__report_consolidated_configure_patch_status(error="Extension attempted but could not disable one or more automatic OS update services. Please check if the auto OS services are configured correctly")
             else:
                 self.__report_consolidated_configure_patch_status()
 

--- a/src/core/src/package_managers/YumPackageManager.py
+++ b/src/core/src/package_managers/YumPackageManager.py
@@ -583,9 +583,9 @@ class YumPackageManager(PackageManager):
         #todo: uncomment after finding the correct value
         # self.update_os_patch_configuration_sub_setting(self.download_updates_identifier_text, "false", self.packagekit_config_pattern_match_text)
         self.update_os_patch_configuration_sub_setting(self.apply_updates_identifier_text, "false", self.packagekit_config_pattern_match_text)
-        self.disable_auto_update_on_reboot(self.dnf_automatic_disable_on_reboot_cmd)
+        self.disable_auto_update_on_reboot(self.packagekit_disable_on_reboot_cmd)
 
-        self.composite_logger.log("Successfully disabled auto OS updates using dnf-automatic")
+        self.composite_logger.log("Successfully disabled auto OS updates using packagekit")
 
     def is_service_set_to_enable_on_reboot(self, command):
         """ Checking if auto update is enable_on_reboot on the machine. An enable_on_reboot service will be activated (if currently inactive) on machine reboot """
@@ -593,9 +593,9 @@ class YumPackageManager(PackageManager):
         code, out = self.env_layer.run_command_output(command, False, False)
         self.composite_logger.log_debug(" - Code: " + str(code) + ", Output: \n|\t" + "\n|\t".join(out.splitlines()))
         if len(out.strip()) > 0 and code == 0 and 'enabled' in out:
-            self.composite_logger.log_debug("Auto OS update will enable on reboot")
+            self.composite_logger.log_debug("Auto OS update service will enable on reboot")
             return True
-        self.composite_logger.log_debug("Auto OS update will NOT enable on reboot")
+        self.composite_logger.log_debug("Auto OS update service will NOT enable on reboot")
         return False
 
     def backup_image_default_patch_configuration_if_not_exists(self):
@@ -721,7 +721,6 @@ class YumPackageManager(PackageManager):
 
             # get install state
             if not self.is_auto_update_service_installed(self.install_check_cmd):
-                self.composite_logger.log_debug("Auto OS service is not installed on the machine")
                 return is_service_installed, enable_on_reboot_value, download_updates_value, apply_updates_value
 
             is_service_installed = True
@@ -806,10 +805,10 @@ class YumPackageManager(PackageManager):
         code, out = self.env_layer.run_command_output(install_check_cmd, False, False)
         self.composite_logger.log_debug(" - Code: " + str(code) + ", Output: \n|\t" + "\n|\t".join(out.splitlines()))
         if len(out.strip()) > 0 and code == 0:
-            self.composite_logger.log_debug("Auto OS update is installed on the machine")
+            self.composite_logger.log_debug("Auto OS update service is installed on the machine")
             return True
         else:
-            self.composite_logger.log_debug("Auto OS update is NOT installed on the machine")
+            self.composite_logger.log_debug("Auto OS update service is NOT installed on the machine")
             return False
 
     # endregion


### PR DESCRIPTION
Contains
- Code change to report an error, if AutoOSPatchState remains Unknown after an attempt is made to disable auto OS updates, only when patch_mode is AutomaticByPlatform. Earlier it was reporting an error even when patch_mode was not AutomaticByPlatform (i.e. when disable auto OS updates were not attempted)

- Removed the statement to add Constants.ERROR_ADDED_TO_STATUS tag the error object in__report_consolidated_configure_patch_status() in ConfigurePatchingProcessor, because we only add the tag when there is a possibility of the same error getting added again to error objects from some other place. Since we do not raise or call any other function from within __report_consolidated_configure_patch_status(), this error will not be duplicated in error objects
 
- Some references for packagekit in YumPackageManager were wrong. 

- Minor: modified some log statements