### PR TITLE
Add package manager return code 102 to zypper success codes

### DIFF
--- a/src/core/src/core_logic/RebootManager.py
+++ b/src/core/src/core_logic/RebootManager.py
@@ -94,7 +94,7 @@ class RebootManager(object):
         reboot_pending = self.package_manager.force_reboot or reboot_pending
 
         if self.package_manager.force_reboot:
-            self.composite_logger.log("Reboot is occurring to mitigate an issue with the package manager.")
+            self.composite_logger.log("A reboot is pending as the package manager required it.")
 
         # return if never
         if self.reboot_setting == Constants.REBOOT_NEVER:


### PR DESCRIPTION
Adds return code 102 as a success code for zypper package manager.

> 102 - ZYPPER_EXIT_INF_REBOOT_NEEDED
Returned after a successful installation of a patch which requires reboot of computer.

Execution still continues normally, but the `force_reboot` flag on the package manager will be set to true so the machine will reboot when available.

Previously, this would be added as an error to the installation summary.