### PR TITLE
Fix SUSE error codes 6 and 106

### DIFF
--- a/src/core/src/package_managers/ZypperPackageManager.py
+++ b/src/core/src/package_managers/ZypperPackageManager.py
@@ -107,11 +107,10 @@ class ZypperPackageManager(PackageManager):
             # Reboot if not already done
             if self.status_handler.get_installation_reboot_status() == Constants.RebootStatus.COMPLETED:
                 self.composite_logger.log_warning("Unable to refresh repo services (retries exhausted after reboot).")
+                raise
             else:
                 self.composite_logger.log_warning("Setting force_reboot flag to True after refreshing repo services.")
                 self.force_reboot = True
-                
-            raise
 
     # region Get Available Updates
     def invoke_package_manager(self, command):

--- a/src/core/src/package_managers/ZypperPackageManager.py
+++ b/src/core/src/package_managers/ZypperPackageManager.py
@@ -62,6 +62,7 @@ class ZypperPackageManager(PackageManager):
         self.zypper_exitcode_zypper_updated = 103
         self.zypper_exitcode_repos_skipped = 106
         self.zypper_success_exit_codes = [self.zypper_exitcode_ok, self.zypper_exitcode_zypper_updated, self.zypper_exitcode_reboot_required]
+        self.zypper_retriable_exit_codes = [self.zypper_exitcode_zypp_locked, self.zypper_exitcode_zypp_lib_exit_err, self.zypper_exitcode_repos_skipped]
 
         # Support to check for processes requiring restart
         self.zypper_ps = "sudo zypper ps -s"
@@ -70,7 +71,6 @@ class ZypperPackageManager(PackageManager):
         self.set_package_manager_setting(Constants.PKG_MGR_SETTING_IDENTITY, Constants.ZYPPER)
         self.zypper_get_process_tree_cmd = 'ps --forest -o pid,cmd -g $(ps -o sid= -p {})'
         self.package_manager_max_retries = 5
-        self.error_codes_to_retry = [self.zypper_exitcode_zypp_locked, self.zypper_exitcode_zypp_lib_exit_err, self.zypper_exitcode_repos_skipped]
         self.zypp_lock_timeout_backup = None
 
         # auto OS updates
@@ -135,7 +135,7 @@ class ZypperPackageManager(PackageManager):
                 self.status_handler.add_error_to_status(error_msg, Constants.PatchOperationErrorCodes.PACKAGE_MANAGER_FAILURE)
 
                 # Not a retriable error code, so raise an exception
-                if code not in self.error_codes_to_retry:
+                if code not in self.zypper_retriable_exit_codes:
                     raise Exception(error_msg, "[{0}]".format(Constants.ERROR_ADDED_TO_STATUS))
 
                 # Retriable error code, so check number of retries and wait then retry if applicable; otherwise, raise error after max retries

--- a/src/core/src/package_managers/ZypperPackageManager.py
+++ b/src/core/src/package_managers/ZypperPackageManager.py
@@ -92,11 +92,10 @@ class ZypperPackageManager(PackageManager):
             # Reboot if not already done
             if self.status_handler.get_installation_reboot_status() == Constants.RebootStatus.COMPLETED:
                 self.composite_logger.log_warning("Unable to refresh repo (retries exhausted after reboot).")
+                raise
             else:
                 self.composite_logger.log_warning("Setting force_reboot flag to True.")
                 self.force_reboot = True
-                
-            raise
 
     def __refresh_repo_services(self):
         """ Similar to refresh_repo, but refreshes services in case no repos are defined. """

--- a/src/core/src/package_managers/ZypperPackageManager.py
+++ b/src/core/src/package_managers/ZypperPackageManager.py
@@ -99,7 +99,7 @@ class ZypperPackageManager(PackageManager):
             raise
 
     def __refresh_repo_services(self):
-        ''' Similar to refresh_repo, but refreshes services in case no repos are defined. '''
+        """ Similar to refresh_repo, but refreshes services in case no repos are defined. """
         self.composite_logger.log("Refreshing local repo services...")
         try:
             self.invoke_package_manager(self.repo_refresh_services)

--- a/src/core/tests/library/LegacyEnvLayerExtensions.py
+++ b/src/core/tests/library/LegacyEnvLayerExtensions.py
@@ -231,6 +231,10 @@ class LegacyEnvLayerExtensions():
                                  "7984  |               \_ /usr/bin/python3 /usr/bin/azuremetadata --api latest --subscriptionId --billingTag --attestedData --signature\n" + \
                                  "7986  \_ python3 package_test.py\n" + \
                                  "8298      \_ sudo LANG=en_US.UTF8 zypper --non-interactive update --dry-run grub2-i386-pc\n"
+                    elif cmd.find('sudo zypper refresh --services') > -1:
+                        code = 0
+                        output = "Refreshing service \'Web_and_Scripting_Module_x86_64\'." + \
+                                 "All services have been refreshed."
                     elif cmd.find('sudo zypper refresh') > -1:
                         code = 0
                         output = "Retrieving repository 'SLE-Module-Basesystem15-SP3-Pool' metadata ................................................................[done]\n" + \
@@ -570,6 +574,11 @@ class LegacyEnvLayerExtensions():
                     if cmd.find('sudo zypper refresh') > -1:
                         code = 999999
                         output = 'Unexpected return code (100) from package manager on command: LANG=en_US.UTF8 sudo apt-get -s dist-upgrade'
+            elif self.legacy_test_type == 'AnotherSadPath':
+                if self.legacy_package_manager_name is Constants.ZYPPER:
+                    if cmd.find('sudo zypper refresh') > -1:
+                        code = 6
+                        output = 'Warning: There are no enabled repositories defined. | Use \'zypper addrepo\' or \'zypper modifyrepo\' commands to add or enable repositories.'
             elif self.legacy_test_type == 'ExceptionPath':
                 code = -1
                 output = ''


### PR DESCRIPTION
Zypper package manager exit code 6 is `ZYPPER_EXIT_NO_REPOS`. This means that no repositories are defined. A refresh services command might be able to fix it: `sudo zypper refresh --services`. 

After failing with exit code 6, the services are refreshed, and the command is tried again. 

Exit code 106 is `ZYPPER_EXIT_INF_REPOS_SKIPPED`, which means that a repository failed to refresh for some reason and was skipped/disabled. This exit code has been added to the list of codes to retry since this might be a transient error.

Also includes:
 - Reorganization of zypper exit codes to be in ascending order for better readability
 - Moved `raise` in `refresh_repo` to inside the block that runs if it is still failing after a reboot. Previously, the reboot would never complete since an error was raised before trying to reboot