### PR TITLE
Fix RETRY - 1 issue

### DIFF
--- a/src/core/src/bootstrap/EnvLayer.py
+++ b/src/core/src/bootstrap/EnvLayer.py
@@ -348,7 +348,7 @@ class EnvLayer(object):
                 try:
                     return open(real_path, mode)
                 except Exception as error:
-                    if i < Constants.MAX_FILE_OPERATION_RETRY_COUNT:
+                    if i < Constants.MAX_FILE_OPERATION_RETRY_COUNT - 1:
                         time.sleep(i + 1)
                     else:
                         error_message = "Unable to open file (retries exhausted). [File={0}][Error={1}][RaiseIfNotFound={2}].".format(str(real_path), repr(error), str(raise_if_not_found))
@@ -382,7 +382,7 @@ class EnvLayer(object):
                         self.__write_record(operation, code=0, output=value, delay=0)
                         return value
                     except Exception as error:
-                        if i < Constants.MAX_FILE_OPERATION_RETRY_COUNT:
+                        if i < Constants.MAX_FILE_OPERATION_RETRY_COUNT - 1:
                             time.sleep(i + 1)
                         else:
                             error_message = "Unable to read file (retries exhausted). [File={0}][Error={1}][RaiseIfNotFound={2}].".format(str(file_path_or_handle), repr(error), str(raise_if_not_found))
@@ -404,7 +404,7 @@ class EnvLayer(object):
                     file_handle.write(str(data))
                     break
                 except Exception as error:
-                    if i < Constants.MAX_FILE_OPERATION_RETRY_COUNT:
+                    if i < Constants.MAX_FILE_OPERATION_RETRY_COUNT - 1:
                         time.sleep(i + 1)
                     else:
                         raise Exception("Unable to write to {0} (retries exhausted). Error: {1}.".format(str(file_handle.name), repr(error)))
@@ -423,7 +423,7 @@ class EnvLayer(object):
                     shutil.move(tempname, file_path)
                     break
                 except Exception as error:
-                    if i < Constants.MAX_FILE_OPERATION_RETRY_COUNT:
+                    if i < Constants.MAX_FILE_OPERATION_RETRY_COUNT - 1:
                         time.sleep(i + 1)
                     else:
                         raise Exception("Unable to write to {0} (retries exhausted). Error: {1}.".format(str(file_path), repr(error)))

--- a/src/core/src/core_logic/PatchAssessor.py
+++ b/src/core/src/core_logic/PatchAssessor.py
@@ -62,7 +62,7 @@ class PatchAssessor(object):
                 self.status_handler.set_assessment_substatus_json(status=Constants.STATUS_SUCCESS)
                 break
             except Exception as error:
-                if i < Constants.MAX_ASSESSMENT_RETRY_COUNT:
+                if i < Constants.MAX_ASSESSMENT_RETRY_COUNT - 1:
                     error_msg = 'Retryable error retrieving available patches: ' + repr(error)
                     self.composite_logger.log_warning(error_msg)
                     self.status_handler.add_error_to_status(error_msg, Constants.PatchOperationErrorCodes.DEFAULT_ERROR)

--- a/src/core/src/service_interfaces/LifecycleManager.py
+++ b/src/core/src/service_interfaces/LifecycleManager.py
@@ -56,7 +56,7 @@ class LifecycleManager(object):
                 with self.env_layer.file_system.open(self.ext_state_file_path, mode="r") as file_handle:
                     return json.load(file_handle)['extensionSequence']
             except Exception as error:
-                if i < Constants.MAX_FILE_OPERATION_RETRY_COUNT:
+                if i < Constants.MAX_FILE_OPERATION_RETRY_COUNT - 1:
                     self.composite_logger.log_warning("Exception on extension sequence read. [Exception={0}] [RetryCount={1}]".format(repr(error), str(i)))
                     time.sleep(i+1)
                 else:
@@ -115,7 +115,7 @@ class LifecycleManager(object):
 
                 return core_sequence
             except Exception as error:
-                if i < Constants.MAX_FILE_OPERATION_RETRY_COUNT:
+                if i < Constants.MAX_FILE_OPERATION_RETRY_COUNT - 1:
                     self.composite_logger.log_warning("Exception on core sequence read. [Exception={0}] [RetryCount={1}]".format(repr(error), str(i)))
                     time.sleep(i + 1)
                 else:
@@ -145,7 +145,7 @@ class LifecycleManager(object):
                 with self.env_layer.file_system.open(self.core_state_file_path, 'w+') as file_handle:
                     file_handle.write(core_state_payload)
             except Exception as error:
-                if i < Constants.MAX_FILE_OPERATION_RETRY_COUNT:
+                if i < Constants.MAX_FILE_OPERATION_RETRY_COUNT - 1:
                     self.composite_logger.log_warning("Exception on core sequence update. [Exception={0}] [RetryCount={1}]".format(repr(error), str(i)))
                     time.sleep(i + 1)
                 else:

--- a/src/core/src/service_interfaces/StatusHandler.py
+++ b/src/core/src/service_interfaces/StatusHandler.py
@@ -504,7 +504,7 @@ class StatusHandler(object):
                 with self.env_layer.file_system.open(self.status_file_path, 'r') as file_handle:
                     status_file_data_raw = json.load(file_handle)[0]    # structure is array of 1
             except Exception as error:
-                if i < Constants.MAX_FILE_OPERATION_RETRY_COUNT:
+                if i < Constants.MAX_FILE_OPERATION_RETRY_COUNT - 1:
                     time.sleep(i + 1)
                 else:
                     self.composite_logger.log_error("Unable to read status file (retries exhausted). Error: {0}.".format(repr(error)))

--- a/src/core/tests/Test_LifecycleManagerArc.py
+++ b/src/core/tests/Test_LifecycleManagerArc.py
@@ -54,7 +54,7 @@ class TestLifecycleManagerArc(unittest.TestCase):
         # file open throws exception
         self.lifecycle_manager.ext_state_file_path = old_ext_state_file_path
         self.runtime.env_layer.file_system.open = self.mock_file_open_throw_exception
-        ext_state_json = self.lifecycle_manager.read_extension_sequence()
+        ext_state_json = self.assertRaises(Exception, self.lifecycle_manager.read_extension_sequence)
         self.assertEquals(ext_state_json, None)
 
     def test_read_extension_sequence_success(self):
@@ -65,7 +65,7 @@ class TestLifecycleManagerArc(unittest.TestCase):
     def test_read_core_sequence_fail(self):
         # file open throws exception
         self.runtime.env_layer.file_system.open = self.mock_file_open_throw_exception
-        core_sequence_json = self.lifecycle_manager.read_core_sequence()
+        core_sequence_json = self.assertRaises(Exception, self.lifecycle_manager.read_core_sequence)
         self.assertEquals(core_sequence_json, None)
 
     def test_read_core_sequence_success(self):

--- a/src/core/tests/Test_LifecycleManagerAzure.py
+++ b/src/core/tests/Test_LifecycleManagerAzure.py
@@ -51,7 +51,7 @@ class TestLifecycleManagerAzure(unittest.TestCase):
         # file open throws exception
         self.lifecycle_manager.ext_state_file_path = old_ext_state_file_path
         self.runtime.env_layer.file_system.open = self.mock_file_open_throw_exception
-        ext_state_json = self.lifecycle_manager.read_extension_sequence()
+        ext_state_json = self.assertRaises(Exception, self.lifecycle_manager.read_extension_sequence)
         self.assertEquals(ext_state_json, None)
 
     def test_read_extension_sequence_success(self):
@@ -61,9 +61,21 @@ class TestLifecycleManagerAzure(unittest.TestCase):
 
     def test_read_core_sequence_fail(self):
         # file open throws exception
+        backup_open = self.runtime.env_layer.file_system.open
         self.runtime.env_layer.file_system.open = self.mock_file_open_throw_exception
-        core_sequence_json = self.lifecycle_manager.read_core_sequence()
+        core_sequence_json = self.assertRaises(Exception, self.lifecycle_manager.read_core_sequence)
         self.assertEquals(core_sequence_json, None)
+        # Unable to write to core state file (retries exhausted)
+
+        # json throws exception, but in a different area to test retries exhausted
+        import json
+        backup_json_load = json.load
+        json.load = None
+        self.runtime.env_layer.file_system.open = backup_open
+        core_sequence_json = self.assertRaises(Exception, self.lifecycle_manager.read_core_sequence)
+        self.assertEquals(core_sequence_json, None)
+        json.load = backup_json_load
+        # Unable to read core state file (retries exhausted).
 
     def test_read_core_sequence_success(self):
         old_core_state_file_path = self.lifecycle_manager.core_state_file_path

--- a/src/core/tests/Test_PatchAssessor.py
+++ b/src/core/tests/Test_PatchAssessor.py
@@ -46,7 +46,7 @@ class TestPatchAssessor(unittest.TestCase):
     def test_assessment_fail_with_status_update(self):
         self.runtime.package_manager.refresh_repo = self.mock_refresh_repo
         self.runtime.set_legacy_test_type('UnalignedPath')
-        self.runtime.patch_assessor.start_assessment()
+        self.assertRaises(Exception, self.runtime.patch_assessor.start_assessment)
         with open(self.runtime.execution_config.status_file_path, 'r') as file_handle:
             file_contents = json.loads(file_handle.read())
             self.assertTrue('Unexpected return code (100) from package manager on command: LANG=en_US.UTF8 sudo apt-get -s dist-upgrade' in str(file_contents))

--- a/src/extension/src/EnvLayer.py
+++ b/src/extension/src/EnvLayer.py
@@ -202,7 +202,7 @@ class EnvLayer(object):
                 try:
                     return open(file_path, mode)
                 except Exception as error:
-                    if i < self.retry_count:
+                    if i < self.retry_count - 1:
                         time.sleep(i + 1)
                     else:
                         raise Exception("Unable to open {0} (retries exhausted). Error: {1}.".format(str(file_path), repr(error)))
@@ -236,7 +236,7 @@ class EnvLayer(object):
                     file_handle.write(str(data))
                     break
                 except Exception as error:
-                    if i < self.retry_count:
+                    if i < self.retry_count - 1:
                         time.sleep(i + 1)
                     else:
                         raise Exception("Unable to write to {0} (retries exhausted). Error: {1}.".format(str(file_handle.name), repr(error)))

--- a/src/extension/tests/Test_EnvHealthManager.py
+++ b/src/extension/tests/Test_EnvHealthManager.py
@@ -202,6 +202,26 @@ class TestEnvManager(unittest.TestCase):
         # wrap up
         self.__wrap_up_ensure_tty_not_required_test(backup_etc_sudoers_file_path, backup_etc_sudoers_linux_patch_extension_file_path)
 
+    def test_read_with_retry_fail(self):
+        open = None
+        has_error = False
+        try:
+            self.env_layer.file_system.read_with_retry(self.env_layer.etc_sudoers_linux_patch_extension_file_path)
+        except Exception as error:
+            has_error = True
+
+        self.assertTrue(has_error)
+
+    def test_write_with_retry_fail(self):
+        self.env_layer.file_system.open = lambda file_path, mode: None
+        has_error = False
+        try:
+            self.env_layer.file_system.write_with_retry(self.env_layer.etc_sudoers_linux_patch_extension_file_path, "test")
+        except Exception as error:
+            has_error = True
+            
+        self.assertTrue(has_error)
+
     def __ensure_tty_not_required_test_setup(self):
         mock_sudoers_file_path = os.path.join(self.temp_dir, "etc-sudoers")
         backup_etc_sudoers_file_path = self.env_layer.etc_sudoers_file_path


### PR DESCRIPTION
In some cases where retries are applied to an operation, the ending condition (used to log an error or throw an exception) is never reached because python ranges are exclusive of the ending bound. This PR fixes this issue and adds a -1 to the conditions so that the previously unreachable code is now used.