### PR TITLE
Code coverage improvements

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,3 +1,4 @@
+comment: true
 github_checks:
     annotations: false
 coverage:
@@ -6,9 +7,7 @@ coverage:
   range: "70...100"
   status:
     project:
-      default: # This can be anything, but it needs to exist as the name
-        # basic settings
+      default:
         target: 80%
         threshold: 0%
-    patch:
-    changes:
+    patch: true

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -13,4 +13,3 @@ coverage:
         if_ci_failed: error
         if_not_found: failure
     patch: true
-    changes: true

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -12,4 +12,15 @@ coverage:
         threshold: 0%
         if_ci_failed: error
         if_not_found: failure
-    patch: true
+    patch:
+      default:
+        target: 100%
+        threshold: 0%
+        if_ci_failed: error
+        if_not_found: failure
+    changes:
+      default:
+        target: 100%
+        threshold: 0%
+        if_ci_failed: error
+        if_not_found: failure

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,2 +1,14 @@
 github_checks:
     annotations: false
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+  status:
+    project:
+      default: # This can be anything, but it needs to exist as the name
+        # basic settings
+        target: 80%
+        threshold: 0%
+    patch:
+    changes:

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,4 +1,7 @@
-comment: true
+comment: 
+  layout: "reach, diff, flags, files"
+  behavior: new
+  require_changes: false
 github_checks:
     annotations: false
 coverage:

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -8,6 +8,9 @@ coverage:
   status:
     project:
       default:
-        target: 80%
+        target: 75%
         threshold: 0%
+        if_ci_failed: error
+        if_not_found: failure
     patch: true
+    changes: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,36 @@
 name: Workflow for Codecov
-on: [pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 jobs:
-  run:
+  codecov-python-3.9:
     runs-on: windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Set up Python 3.9
+      - name: Set up Python 2.7
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 2.7
+      - name: Install dependencies
+        run: pip install coverage
+      - name: Run tests and collect coverage
+        run: |
+          coverage run -m unittest discover -s src
+          coverage xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2
+  codecov-python-2.7:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Python 2.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: 2.7
       - name: Install dependencies
         run: pip install coverage
       - name: Run tests and collect coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Set up Python 2.7
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:
-          python-version: 2.7
+          python-version: 3.9
       - name: Install dependencies
         run: pip install coverage
       - name: Run tests and collect coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [master]
 jobs:
-  codecov-python-3.9:
+  codecov-python-39:
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -22,7 +22,7 @@ jobs:
           coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
-  codecov-python-2.7:
+  codecov-python-27:
     runs-on: windows-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
 - Fixes code coverage comments in PRs (see below)
 - Blocks merging PRs if coverage goes down (any code added _must_ have UTs)
 - Adds Python 2.7 code coverage (unsure of how this is working right now - will require more time later to investigate)
 - Does not block merging if tests are failing - will need to investigate more on that later