### PR TITLE
Report 'CompletedWithWarnings' instead of 'Failed' if customer picked 'NeverReboots' and reboot is required

### DIFF
--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -197,6 +197,7 @@ class Constants(object):
         REQUIRED = "Required"
         STARTED = "Started"
         COMPLETED = "Completed"
+        COMPLETED_WITH_WARNINGS = "CompletedWithWarnings"
         FAILED = "Failed"
     
     # Enum for VM Cloud Type

--- a/src/core/src/core_logic/RebootManager.py
+++ b/src/core/src/core_logic/RebootManager.py
@@ -100,6 +100,7 @@ class RebootManager(object):
         if self.reboot_setting == Constants.REBOOT_NEVER:
             if reboot_pending:
                 self.composite_logger.log_warning(' - There is a reboot pending, but reboot is blocked, as per patch installation configuration. (' + str(Constants.REBOOT_NEVER) + ')')
+                self.status_handler.set_installation_reboot_status(Constants.RebootStatus.COMPLETED_WITH_WARNINGS)
             else:
                 self.composite_logger.log_warning(' - There is no reboot pending, and reboot is blocked regardless, as per patch installation configuration (' + str(Constants.REBOOT_NEVER) + ').')
             return False

--- a/src/core/src/service_interfaces/StatusHandler.py
+++ b/src/core/src/service_interfaces/StatusHandler.py
@@ -212,7 +212,7 @@ class StatusHandler(object):
 
     def set_installation_reboot_status(self, new_reboot_status):
         """ Valid reboot statuses: NotNeeded, Required, Started, Failed, Completed """
-        if new_reboot_status not in [Constants.RebootStatus.NOT_NEEDED, Constants.RebootStatus.REQUIRED, Constants.RebootStatus.STARTED, Constants.RebootStatus.FAILED, Constants.RebootStatus.COMPLETED]:
+        if new_reboot_status not in [Constants.RebootStatus.NOT_NEEDED, Constants.RebootStatus.REQUIRED, Constants.RebootStatus.STARTED, Constants.RebootStatus.FAILED, Constants.RebootStatus.COMPLETED, Constants.RebootStatus.COMPLETED_WITH_WARNINGS]:
             raise "Invalid reboot status specified. [Status={0}]".format(str(new_reboot_status))
 
         # State transition validation
@@ -220,6 +220,7 @@ class StatusHandler(object):
                 or (new_reboot_status == Constants.RebootStatus.REQUIRED and self.__installation_reboot_status not in [Constants.RebootStatus.NOT_NEEDED, Constants.RebootStatus.REQUIRED, Constants.RebootStatus.COMPLETED])\
                 or (new_reboot_status == Constants.RebootStatus.STARTED and self.__installation_reboot_status not in [Constants.RebootStatus.NOT_NEEDED, Constants.RebootStatus.REQUIRED, Constants.RebootStatus.STARTED])\
                 or (new_reboot_status == Constants.RebootStatus.FAILED and self.__installation_reboot_status not in [Constants.RebootStatus.STARTED, Constants.RebootStatus.FAILED])\
+                or (new_reboot_status == Constants.RebootStatus.COMPLETED_WITH_WARNINGS and self.__installation_reboot_status not in [Constants.RebootStatus.REQUIRED])\
                 or (new_reboot_status == Constants.RebootStatus.COMPLETED and self.__installation_reboot_status not in [Constants.RebootStatus.STARTED, Constants.RebootStatus.COMPLETED]):
             self.composite_logger.log_error("Invalid reboot status transition attempted. [CurrentRebootStatus={0}] [NewRebootStatus={1}]".format(self.__installation_reboot_status, str(new_reboot_status)))
             return

--- a/src/core/tests/Test_CoreMain.py
+++ b/src/core/tests/Test_CoreMain.py
@@ -408,6 +408,7 @@ class TestCoreMain(unittest.TestCase):
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
         self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["installedPatchCount"] == 5)
+        self.assertTrue(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["rebootStatus"] == Constants.RebootStatus.COMPLETED_WITH_WARNINGS)
         self.assertEqual(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][0]["name"], "selinux-policy.noarch")
         self.assertTrue("Other" in str(json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][0]["classifications"]))
         self.assertTrue("Installed" == json.loads(substatus_file_data[1]["formattedMessage"]["message"])["patches"][0]["patchInstallationState"])


### PR DESCRIPTION
Previous behavior was to report 'Completed' in this scenario. Now it reports 'CompletedWithWarnings'.