### PR TITLE
Output all environment variables in case that agent telemetry features is not found

### DIFF
--- a/src/core/src/service_interfaces/TelemetryWriter.py
+++ b/src/core/src/service_interfaces/TelemetryWriter.py
@@ -132,7 +132,7 @@ class TelemetryWriter(object):
         features_keyvalue_list_str = os.getenv(Constants.AZURE_GUEST_AGENT_EXTENSION_SUPPORTED_FEATURES_ENV_VAR)
         if features_keyvalue_list_str is None:
             self.composite_logger.log_debug('Failed to get guest agent supported features from env var. [Var={0}]'.format(Constants.AZURE_GUEST_AGENT_EXTENSION_SUPPORTED_FEATURES_ENV_VAR))
-            self.composite_logger.log_debug('All environment variables: \n{0}'.format(os.environ()))
+            self.composite_logger.log_debug('All environment variables: \n{0}'.format(os.environ))
             self.agent_env_var_code = Constants.AgentEnvVarStatusCode.FAILED_TO_GET_AGENT_SUPPORTED_FEATURES
             return False
 

--- a/src/core/src/service_interfaces/TelemetryWriter.py
+++ b/src/core/src/service_interfaces/TelemetryWriter.py
@@ -132,6 +132,7 @@ class TelemetryWriter(object):
         features_keyvalue_list_str = os.getenv(Constants.AZURE_GUEST_AGENT_EXTENSION_SUPPORTED_FEATURES_ENV_VAR)
         if features_keyvalue_list_str is None:
             self.composite_logger.log_debug('Failed to get guest agent supported features from env var. [Var={0}]'.format(Constants.AZURE_GUEST_AGENT_EXTENSION_SUPPORTED_FEATURES_ENV_VAR))
+            self.composite_logger.log_debug('All environment variables: \n{0}'.format(os.environ()))
             self.agent_env_var_code = Constants.AgentEnvVarStatusCode.FAILED_TO_GET_AGENT_SUPPORTED_FEATURES
             return False
 

--- a/src/core/src/service_interfaces/TelemetryWriter.py
+++ b/src/core/src/service_interfaces/TelemetryWriter.py
@@ -132,7 +132,7 @@ class TelemetryWriter(object):
         features_keyvalue_list_str = os.getenv(Constants.AZURE_GUEST_AGENT_EXTENSION_SUPPORTED_FEATURES_ENV_VAR)
         if features_keyvalue_list_str is None:
             self.composite_logger.log_debug('Failed to get guest agent supported features from env var. [Var={0}]'.format(Constants.AZURE_GUEST_AGENT_EXTENSION_SUPPORTED_FEATURES_ENV_VAR))
-            self.composite_logger.log_debug('All environment variables: \n{0}'.format(os.environ))
+            self.composite_logger.log_debug('All environment variables: \n{0}'.format(json.dumps(dict(os.environ), indent=4, sort_keys=True)))
             self.agent_env_var_code = Constants.AgentEnvVarStatusCode.FAILED_TO_GET_AGENT_SUPPORTED_FEATURES
             return False
 

--- a/src/core/tests/Test_TelemetryWriter.py
+++ b/src/core/tests/Test_TelemetryWriter.py
@@ -226,6 +226,34 @@ class TestTelemetryWriter(unittest.TestCase):
         self.assertTrue(self.runtime.telemetry_writer.get_agent_version() is None)
         self.assertTrue(self.runtime.telemetry_writer.get_goal_state_agent_version() is None)
 
+    def test_agent_not_supported_env_var_telemetry_key_not_exists(self):
+        backup_os_getenv = os.getenv
+
+        def mock_os_getenv(key, default=None):
+            value = backup_os_getenv(key, default)
+            if key == Constants.AZURE_GUEST_AGENT_EXTENSION_SUPPORTED_FEATURES_ENV_VAR:
+                return '[]'
+            else:
+                return value
+
+        os.getenv = mock_os_getenv
+        self.assertEqual("Diagnostic-code: 2.2.49.2/2.6.0.2/1/0/2", self.runtime.telemetry_writer.get_telemetry_diagnostics())
+        os.getenv = backup_os_getenv
+
+    def test_agent_not_supported_env_var_supported_features_not_exists(self):
+        backup_os_getenv = os.getenv
+
+        def mock_os_getenv(key, default=None):
+            value = backup_os_getenv(key, default)
+            if key == Constants.AZURE_GUEST_AGENT_EXTENSION_SUPPORTED_FEATURES_ENV_VAR:
+                return None
+            else:
+                return value
+
+        os.getenv = mock_os_getenv
+        self.assertEqual("Diagnostic-code: 2.2.49.2/2.6.0.2/1/0/1", self.runtime.telemetry_writer.get_telemetry_diagnostics())
+        os.getenv = backup_os_getenv
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Ouputs all environment variables using `os.environ()` if the environment variable for guest agent supported features is not found.