### PR TITLE
Fail if all tests do not pass and fix failing tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
       - name: Run tests and collect coverage
         run: |
           cd src/extension/tests
-          coverage run -m unittest discover -s ../ -t ../ 2>> ../../err.txt
-          cd ../../src/core/tests
-          coverage run -m unittest discover -s ../ -t ../ 2>> ../../err.txt
+          coverage run -m unittest discover -s ../../ -t ../../ 2>> ../../err.txt
+          cd ../../core/tests
+          coverage run -m unittest discover -s ../../ -t ../../ 2>> ../../err.txt
           coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
@@ -51,9 +51,9 @@ jobs:
       - name: Run tests and collect coverage
         run: |
           cd src/extension/tests
-          coverage run -m unittest discover -s ../ -t ../ 2>> ../../err.txt
-          cd ../../src/core/tests
-          coverage run -m unittest discover -s ../ -t ../ 2>> ../../err.txt
+          coverage run -m unittest discover -s ../../ -t ../../ 2>> ../../err.txt
+          cd ../../core/tests
+          coverage run -m unittest discover -s ../../ -t ../../ 2>> ../../err.txt
           coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,10 @@ jobs:
         run: pip install coverage
       - name: Run tests and collect coverage
         run: |
-          coverage run -m unittest discover -s src 2> err.txt
+          cd src/extension/tests
+          coverage run -m unittest discover -s ../ -t ../ 2>> ../../err.txt
+          cd ../../src/core/tests
+          coverage run -m unittest discover -s ../ -t ../ 2>> ../../err.txt
           coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
@@ -47,7 +50,10 @@ jobs:
         run: pip install coverage
       - name: Run tests and collect coverage
         run: |
-          coverage run -m unittest discover -s src 2> err.txt
+          cd src/extension/tests
+          coverage run -m unittest discover -s ../ -t ../ 2>> ../../err.txt
+          cd ../../src/core/tests
+          coverage run -m unittest discover -s ../ -t ../ 2>> ../../err.txt
           coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         run: pip install coverage
       - name: Run tests and collect coverage
         run: |
-          coverage run -m unittest discover -s src > output.txt 2> err.txt
+          coverage run -m unittest discover -s src 2> err.txt
           coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
@@ -45,7 +45,7 @@ jobs:
         run: pip install coverage
       - name: Run tests and collect coverage
         run: |
-          coverage run -m unittest discover -s src > output.txt 2> err.txt
+          coverage run -m unittest discover -s src 2> err.txt
           coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
@@ -56,6 +56,6 @@ jobs:
       - name: Read test output
         id: getoutput
         run: echo "::set-output name=contents::$(cat err.txt)"
-      - name: Check if all tests passed
+      - name: Check if all tests passed. If failed, check the "Run tests and collect coverage" step above for details.
         if: contains( ${{ steps.getoutput.outputs.contents }}, 'FAILED (failures=' )
         run: exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         id: getoutput
         run: echo "::set-output name=contents::$(cat err.txt)"
       - name: Fail if tests failed
-        if: contains( ${{ steps.getoutput.outputs.contents }}, "FAILED (failures=" )
+        if: contains( ${{ steps.getoutput.outputs.contents }}, 'FAILED (failures=' )
         run: exit 1
   codecov-python-27:
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         id: getoutput
         run: echo "::set-output name=contents::$(cat err.txt)"
       - name: Check if all tests passed
-        if: contains( ${{ steps.getoutput.outputs.contents }}, 'failures=' )
+        if: contains( steps.getoutput.outputs.contents , 'FAILED (failures=' )
         run: |
           echo "${{ steps.getoutput.outputs.contents }}"
           exit 1
@@ -75,7 +75,7 @@ jobs:
         id: getoutput
         run: echo "::set-output name=contents::$(cat err.txt)"
       - name: Check if all tests passed
-        if: contains( ${{ steps.getoutput.outputs.contents }}, 'failures=' )
+        if: contains( steps.getoutput.outputs.contents, 'FAILED (failures=' )
         run: |
           echo "${{ steps.getoutput.outputs.contents }}"
           exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,11 @@ jobs:
       - name: Read test output
         id: getoutput
         run: echo "::set-output name=contents::$(cat err.txt)"
-      - name: Check if all tests passed. If failed, check the "Run tests and collect coverage" step above for details.
+      - name: Check if all tests passed
         if: contains( ${{ steps.getoutput.outputs.contents }}, 'FAILED (failures=' )
-        run: exit 1
+        run: |
+          echo ${{ steps.getoutput.outputs.contents }}
+          exit 1
   codecov-python-27:
     runs-on: windows-latest
     steps:
@@ -56,6 +58,8 @@ jobs:
       - name: Read test output
         id: getoutput
         run: echo "::set-output name=contents::$(cat err.txt)"
-      - name: Check if all tests passed. If failed, check the "Run tests and collect coverage" step above for details.
+      - name: Check if all tests passed
         if: contains( ${{ steps.getoutput.outputs.contents }}, 'FAILED (failures=' )
-        run: exit 1
+        run: |
+          echo ${{ steps.getoutput.outputs.contents }}
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: echo "::set-output name=contents::$(cat err.txt)"
       - name: Check if all tests passed
         if: contains( ${{ steps.getoutput.outputs.contents }}, 'FAILED (failures=' )
-        run: exit 0
+        run: exit 1
   codecov-python-27:
     runs-on: windows-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,12 @@ jobs:
           flags: python39
           name: python-39
           fail_ci_if_error: true
-      - name: Read output to determine pass/fail
+      - name: Read test output
         id: getoutput
         run: echo "::set-output name=contents::$(cat err.txt)"
-      - name: Fail if tests failed
+      - name: Check if all tests passed
         if: contains( ${{ steps.getoutput.outputs.contents }}, 'FAILED (failures=' )
-        run: exit 1
+        run: exit 0
   codecov-python-27:
     runs-on: windows-latest
     steps:
@@ -45,7 +45,7 @@ jobs:
         run: pip install coverage
       - name: Run tests and collect coverage
         run: |
-          coverage run -m unittest discover -s src
+          coverage run -m unittest discover -s src > output.txt 2> err.txt
           coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
@@ -53,3 +53,9 @@ jobs:
           flags: python27
           name: python-27
           fail_ci_if_error: true
+      - name: Read test output
+        id: getoutput
+        run: echo "::set-output name=contents::$(cat err.txt)"
+      - name: Check if all tests passed
+        if: contains( ${{ steps.getoutput.outputs.contents }}, 'FAILED (failures=' )
+        run: exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
       - name: Run tests and collect coverage
         run: |
           cd ./src/extension/tests
-          coverage run -m unittest discover -s ../../ -t ../../ 2>> ../../../err.txt
+          coverage run -m unittest discover -s . -t ../../ 2>> ../../../err.txt
           cd ../../core/tests
-          coverage run -m unittest discover -s ../../ -t ../../ 2>> ../../../err.txt
+          coverage run -m unittest discover -s . -t ../../ 2>> ../../../err.txt
           coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
@@ -51,9 +51,9 @@ jobs:
       - name: Run tests and collect coverage
         run: |
           cd ./src/extension/tests
-          coverage run -m unittest discover -s ../../ -t ../../ 2>> ../../../err.txt
+          coverage run -m unittest discover -s . -t ../../ 2>> ../../../err.txt
           cd ../../core/tests
-          coverage run -m unittest discover -s ../../ -t ../../ 2>> ../../../err.txt
+          coverage run -m unittest discover -s . -t ../../ 2>> ../../../err.txt
           coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
           echo '===============START CORE TESTS...===============' >> ../../../err.txt
           coverage run -m unittest discover -s . -t ../../ 2>> ../../../err.txt
           echo '===============FINISH CORE TESTS...===============' >> ../../../err.txt
+          cd ../../
           coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
@@ -62,6 +63,7 @@ jobs:
           echo '===============START CORE TESTS...===============' >> ../../../err2.txt
           coverage run -m unittest discover -s . -t ../../ 2>> ../../../err2.txt
           echo '===============FINISH CORE TESTS...===============' >> ../../../err2.txt
+          cd ../../
           coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,14 @@ jobs:
       - name: Run tests and collect coverage
         run: |
           cd ./src/extension/tests
-          echo '===============\n\nRUNNING EXTENSION TESTS...\n\n===============\n\n' >> ../../../err.txt
+          echo '===============START EXTENSION TESTS...===============' >> ../../../err.txt
           coverage run -m unittest discover -s . -t ../../ 2>> ../../../err.txt
+          echo '===============FINISH EXTENSION TESTS...===============' >> ../../../err.txt
           cd ../../core/tests
-          echo '===============\n\nRUNNING CORE TESTS...\n\n===============\n\n' >> ../../../err.txt
+          echo '===============START CORE TESTS...===============' >> ../../../err.txt
           coverage run -m unittest discover -s . -t ../../ 2>> ../../../err.txt
+          echo '===============FINISH CORE TESTS...===============' >> ../../../err.txt
+          cd ../../../
           coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
@@ -53,11 +56,14 @@ jobs:
       - name: Run tests and collect coverage
         run: |
           cd ./src/extension/tests
-          echo '===============\n\nRUNNING EXTENSION TESTS...\n\n===============\n\n' >> ../../../err.txt
+          echo '===============START EXTENSION TESTS...===============' >> ../../../err.txt
           coverage run -m unittest discover -s . -t ../../ 2>> ../../../err.txt
+          echo '===============FINISH EXTENSION TESTS...===============' >> ../../../err.txt
           cd ../../core/tests
-          echo '===============\n\nRUNNING CORE TESTS...\n\n===============\n\n' >> ../../../err.txt
+          echo '===============START CORE TESTS...===============' >> ../../../err.txt
           coverage run -m unittest discover -s . -t ../../ 2>> ../../../err.txt
+          echo '===============FINISH CORE TESTS...===============' >> ../../../err.txt
+          cd ../../../
           coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     branches: [master]
 jobs:
   codecov-python-39:
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,10 @@ jobs:
       - name: Run tests and collect coverage
         run: |
           cd ./src/extension/tests
+          echo '===============\n\nRUNNING EXTENSION TESTS...\n\n===============\n\n' >> ../../../err.txt
           coverage run -m unittest discover -s . -t ../../ 2>> ../../../err.txt
           cd ../../core/tests
+          echo '===============\n\nRUNNING CORE TESTS...\n\n===============\n\n' >> ../../../err.txt
           coverage run -m unittest discover -s . -t ../../ 2>> ../../../err.txt
           coverage xml
       - name: Upload coverage to Codecov
@@ -51,8 +53,10 @@ jobs:
       - name: Run tests and collect coverage
         run: |
           cd ./src/extension/tests
+          echo '===============\n\nRUNNING EXTENSION TESTS...\n\n===============\n\n' >> ../../../err.txt
           coverage run -m unittest discover -s . -t ../../ 2>> ../../../err.txt
           cd ../../core/tests
+          echo '===============\n\nRUNNING CORE TESTS...\n\n===============\n\n' >> ../../../err.txt
           coverage run -m unittest discover -s . -t ../../ 2>> ../../../err.txt
           coverage xml
       - name: Upload coverage to Codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Read test output
         id: getoutput
         run: echo "::set-output name=contents::$(cat err.txt)"
-      - name: Check if all tests passed
+      - name: Check if all tests passed. If failed, check the "Run tests and collect coverage" step above for details.
         if: contains( ${{ steps.getoutput.outputs.contents }}, 'FAILED (failures=' )
         run: exit 1
   codecov-python-27:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ jobs:
           echo '===============START CORE TESTS...===============' >> ../../../err.txt
           coverage run -m unittest discover -s . -t ../../ 2>> ../../../err.txt
           echo '===============FINISH CORE TESTS...===============' >> ../../../err.txt
-          cd ../../../
           coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
@@ -63,7 +62,6 @@ jobs:
           echo '===============START CORE TESTS...===============' >> ../../../err.txt
           coverage run -m unittest discover -s . -t ../../ 2>> ../../../err.txt
           echo '===============FINISH CORE TESTS...===============' >> ../../../err.txt
-          cd ../../../
           coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         run: pip install coverage
       - name: Run tests and collect coverage
         run: |
-          coverage run -m unittest discover -s src
+          coverage run -m unittest discover -s src > output.txt 2> err.txt
           coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
@@ -26,6 +26,12 @@ jobs:
           flags: python39
           name: python-39
           fail_ci_if_error: true
+      - name: Read output to determine pass/fail
+        id: getoutput
+        run: echo "::set-output name=contents::$(cat err.txt)"
+      - name: Fail if tests failed
+        if: contains( ${{ steps.getoutput.outputs.contents }}, "FAILED (failures=" )
+        run: exit 1
   codecov-python-27:
     runs-on: windows-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,13 +55,13 @@ jobs:
       - name: Run tests and collect coverage
         run: |
           cd ./src/extension/tests
-          echo '===============START EXTENSION TESTS...===============' >> ../../../err.txt
-          coverage run -m unittest discover -s . -t ../../ 2>> ../../../err.txt
-          echo '===============FINISH EXTENSION TESTS...===============' >> ../../../err.txt
+          echo '===============START EXTENSION TESTS...===============' >> ../../../err2.txt
+          coverage run -m unittest discover -s . -t ../../ 2>> ../../../err2.txt
+          echo '===============FINISH EXTENSION TESTS...===============' >> ../../../err2.txt
           cd ../../core/tests
-          echo '===============START CORE TESTS...===============' >> ../../../err.txt
-          coverage run -m unittest discover -s . -t ../../ 2>> ../../../err.txt
-          echo '===============FINISH CORE TESTS...===============' >> ../../../err.txt
+          echo '===============START CORE TESTS...===============' >> ../../../err2.txt
+          coverage run -m unittest discover -s . -t ../../ 2>> ../../../err2.txt
+          echo '===============FINISH CORE TESTS...===============' >> ../../../err2.txt
           coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
@@ -71,7 +71,7 @@ jobs:
           fail_ci_if_error: true
       - name: Read test output
         id: getoutput
-        run: echo "::set-output name=contents::$(cat err.txt)"
+        run: echo "::set-output name=contents::$(cat err2.txt)"
       - name: Check if all tests passed
         if: contains( steps.getoutput.outputs.contents, 'FAILED (failures=' )
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     branches: [master]
 jobs:
   codecov-python-39:
-    runs-on: windows-2019
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -27,7 +27,7 @@ jobs:
           name: python-39
           fail_ci_if_error: true
   codecov-python-27:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     branches: [master]
 jobs:
   codecov-python-39:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -27,7 +27,7 @@ jobs:
           name: python-39
           fail_ci_if_error: true
   codecov-python-27:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   codecov-python-39:
     runs-on: windows-latest
+    env:
+      working-directory: ./src
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -18,10 +20,10 @@ jobs:
         run: pip install coverage
       - name: Run tests and collect coverage
         run: |
-          cd src/extension/tests
-          coverage run -m unittest discover -s ../../ -t ../../ 2>> ../../../err.txt
+          cd ./extension/tests
+          coverage run -m unittest discover -s ../../ -t ../../ 2>> ../../err.txt
           cd ../../core/tests
-          coverage run -m unittest discover -s ../../ -t ../../ 2>> ../../../err.txt
+          coverage run -m unittest discover -s ../../ -t ../../ 2>> ../../err.txt
           coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
@@ -39,6 +41,8 @@ jobs:
           exit 1
   codecov-python-27:
     runs-on: windows-latest
+    env:
+      working-directory: ./src
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -50,10 +54,10 @@ jobs:
         run: pip install coverage
       - name: Run tests and collect coverage
         run: |
-          cd src/extension/tests
-          coverage run -m unittest discover -s ../../ -t ../../ 2>> ../../../err.txt
+          cd ./extension/tests
+          coverage run -m unittest discover -s ../../ -t ../../ 2>> ../../err.txt
           cd ../../core/tests
-          coverage run -m unittest discover -s ../../ -t ../../ 2>> ../../../err.txt
+          coverage run -m unittest discover -s ../../ -t ../../ 2>> ../../err.txt
           coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Check if all tests passed
         if: contains( ${{ steps.getoutput.outputs.contents }}, 'FAILED (failures=' )
         run: |
-          echo ${{ steps.getoutput.outputs.contents }}
+          echo "${{ steps.getoutput.outputs.contents }}"
           exit 1
   codecov-python-27:
     runs-on: windows-latest
@@ -61,5 +61,5 @@ jobs:
       - name: Check if all tests passed
         if: contains( ${{ steps.getoutput.outputs.contents }}, 'FAILED (failures=' )
         run: |
-          echo ${{ steps.getoutput.outputs.contents }}
+          echo "${{ steps.getoutput.outputs.contents }}"
           exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ jobs:
           echo '===============START CORE TESTS...===============' >> ../../../err.txt
           coverage run -m unittest discover -s . -t ../../ 2>> ../../../err.txt
           echo '===============FINISH CORE TESTS...===============' >> ../../../err.txt
-          cd ../../
           coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
@@ -63,7 +62,6 @@ jobs:
           echo '===============START CORE TESTS...===============' >> ../../../err2.txt
           coverage run -m unittest discover -s . -t ../../ 2>> ../../../err2.txt
           echo '===============FINISH CORE TESTS...===============' >> ../../../err2.txt
-          cd ../../
           coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
       - name: Run tests and collect coverage
         run: |
           cd src/extension/tests
-          coverage run -m unittest discover -s ../../ -t ../../ 2>> ../../err.txt
+          coverage run -m unittest discover -s ../../ -t ../../ 2>> ../../../err.txt
           cd ../../core/tests
-          coverage run -m unittest discover -s ../../ -t ../../ 2>> ../../err.txt
+          coverage run -m unittest discover -s ../../ -t ../../ 2>> ../../../err.txt
           coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
@@ -51,9 +51,9 @@ jobs:
       - name: Run tests and collect coverage
         run: |
           cd src/extension/tests
-          coverage run -m unittest discover -s ../../ -t ../../ 2>> ../../err.txt
+          coverage run -m unittest discover -s ../../ -t ../../ 2>> ../../../err.txt
           cd ../../core/tests
-          coverage run -m unittest discover -s ../../ -t ../../ 2>> ../../err.txt
+          coverage run -m unittest discover -s ../../ -t ../../ 2>> ../../../err.txt
           coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,6 @@ on:
 jobs:
   codecov-python-39:
     runs-on: windows-latest
-    env:
-      working-directory: ./src
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -20,10 +18,10 @@ jobs:
         run: pip install coverage
       - name: Run tests and collect coverage
         run: |
-          cd ./extension/tests
-          coverage run -m unittest discover -s ../../ -t ../../ 2>> ../../err.txt
+          cd ./src/extension/tests
+          coverage run -m unittest discover -s ../../ -t ../../ 2>> ../../../err.txt
           cd ../../core/tests
-          coverage run -m unittest discover -s ../../ -t ../../ 2>> ../../err.txt
+          coverage run -m unittest discover -s ../../ -t ../../ 2>> ../../../err.txt
           coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
@@ -41,8 +39,6 @@ jobs:
           exit 1
   codecov-python-27:
     runs-on: windows-latest
-    env:
-      working-directory: ./src
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -54,10 +50,10 @@ jobs:
         run: pip install coverage
       - name: Run tests and collect coverage
         run: |
-          cd ./extension/tests
-          coverage run -m unittest discover -s ../../ -t ../../ 2>> ../../err.txt
+          cd ./src/extension/tests
+          coverage run -m unittest discover -s ../../ -t ../../ 2>> ../../../err.txt
           cd ../../core/tests
-          coverage run -m unittest discover -s ../../ -t ../../ 2>> ../../err.txt
+          coverage run -m unittest discover -s ../../ -t ../../ 2>> ../../../err.txt
           coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         id: getoutput
         run: echo "::set-output name=contents::$(cat err.txt)"
       - name: Check if all tests passed
-        if: contains( ${{ steps.getoutput.outputs.contents }}, 'FAILED (failures=' )
+        if: contains( ${{ steps.getoutput.outputs.contents }}, 'failures=' )
         run: |
           echo "${{ steps.getoutput.outputs.contents }}"
           exit 1
@@ -69,7 +69,7 @@ jobs:
         id: getoutput
         run: echo "::set-output name=contents::$(cat err.txt)"
       - name: Check if all tests passed
-        if: contains( ${{ steps.getoutput.outputs.contents }}, 'FAILED (failures=' )
+        if: contains( ${{ steps.getoutput.outputs.contents }}, 'failures=' )
         run: |
           echo "${{ steps.getoutput.outputs.contents }}"
           exit 1


### PR DESCRIPTION
Fixes tests failing in the GitHub actions runner and GitHub actions for test coverage now fail and block merging if all tests do not pass.

Note: there are some flaky tests on GitHub runners caused by different processes trying to read the same files at once. 