### PR TITLE
Fix AssertEquals deprecation warnings

### DIFF
--- a/src/core/tests/Test_AptitudePackageManager.py
+++ b/src/core/tests/Test_AptitudePackageManager.py
@@ -87,7 +87,7 @@ class TestAptitudePackageManager(unittest.TestCase):
         self.assertIsNotNone(package_manager)
 
         # test for successfully installing a package
-        self.assertEquals(package_manager.install_update_and_dependencies('selinux-policy.noarch', '3.13.1-102.el7_3.16', simulate=True), Constants.INSTALLED)  # needs to be fixed
+        self.assertEqual(package_manager.install_update_and_dependencies('selinux-policy.noarch', '3.13.1-102.el7_3.16', simulate=True), Constants.INSTALLED)  # needs to be fixed
 
     def test_is_installed_check_with_dpkg(self):
         self.runtime.set_legacy_test_type('SuccessInstallPath')
@@ -96,8 +96,8 @@ class TestAptitudePackageManager(unittest.TestCase):
         self.assertIsNotNone(package_manager)
 
         # test for successfully installing a package
-        self.assertEquals(package_manager.is_package_version_installed('mysql-server', '5.7.25-0ubuntu0.16.04.2'), True)
-        self.assertEquals(package_manager.is_package_version_installed('mysql-client', '5.7.25-0ubuntu0.16.04.2'), False)
+        self.assertEqual(package_manager.is_package_version_installed('mysql-server', '5.7.25-0ubuntu0.16.04.2'), True)
+        self.assertEqual(package_manager.is_package_version_installed('mysql-client', '5.7.25-0ubuntu0.16.04.2'), False)
 
     def test_install_package_failure(self):
         self.runtime.set_legacy_test_type('FailInstallPath')
@@ -106,7 +106,7 @@ class TestAptitudePackageManager(unittest.TestCase):
         self.assertIsNotNone(package_manager)
 
         # test for unsuccessfully installing a package
-        self.assertEquals(package_manager.install_update_and_dependencies('selinux-policy.noarch', '3.13.1-102.el7_3.16', simulate=True), Constants.FAILED)
+        self.assertEqual(package_manager.install_update_and_dependencies('selinux-policy.noarch', '3.13.1-102.el7_3.16', simulate=True), Constants.FAILED)
         self.assertRaises(Exception, lambda: package_manager.invoke_package_manager('sudo apt-get -y --only-upgrade true install force-dpkg-failure'))
 
     def test_install_package_only_upgrades(self):
@@ -116,7 +116,7 @@ class TestAptitudePackageManager(unittest.TestCase):
         self.assertIsNotNone(package_manager)
 
         # test for unsuccessfully installing a package
-        self.assertEquals(package_manager.install_update_and_dependencies('iucode-tool', '1.5.1-1ubuntu0.1', simulate=True), Constants.PENDING)
+        self.assertEqual(package_manager.install_update_and_dependencies('iucode-tool', '1.5.1-1ubuntu0.1', simulate=True), Constants.PENDING)
 
     def test_disable_auto_os_update_with_two_patch_modes_enabled_success(self):
         package_manager = self.container.get('package_manager')

--- a/src/core/tests/Test_ConfigurePatchingProcessor.py
+++ b/src/core/tests/Test_ConfigurePatchingProcessor.py
@@ -66,7 +66,7 @@ class TestConfigurePatchingProcessor(unittest.TestCase):
 
         # check status file for configure patching patch state
         self.assertTrue(runtime.package_manager.image_default_patch_configuration_backup_exists())
-        self.assertEquals(len(substatus_file_data), 1)
+        self.assertEqual(len(substatus_file_data), 1)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         message = json.loads(substatus_file_data[0]["formattedMessage"]["message"])
@@ -110,7 +110,7 @@ class TestConfigurePatchingProcessor(unittest.TestCase):
         self.assertTrue(substatus_file_data[3]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
         self.assertTrue(substatus_file_data[3]["status"].lower() == Constants.STATUS_SUCCESS.lower())
 
-        self.assertEquals(len(substatus_file_data), 4)
+        self.assertEqual(len(substatus_file_data), 4)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
@@ -141,7 +141,7 @@ class TestConfigurePatchingProcessor(unittest.TestCase):
         # check status file
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
-        self.assertEquals(len(substatus_file_data), 1)
+        self.assertEqual(len(substatus_file_data), 1)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
         if runtime.vm_cloud_type == Constants.VMCloudType.AZURE:
             self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_ERROR.lower())
@@ -167,7 +167,7 @@ class TestConfigurePatchingProcessor(unittest.TestCase):
         # check status file
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
-        self.assertEquals(len(substatus_file_data), 1)
+        self.assertEqual(len(substatus_file_data), 1)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_ERROR.lower())
         runtime.stop()
@@ -201,7 +201,7 @@ class TestConfigurePatchingProcessor(unittest.TestCase):
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
 
         # check status file for configure patching patch state
-        self.assertEquals(len(substatus_file_data), 1)
+        self.assertEqual(len(substatus_file_data), 1)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         message = json.loads(substatus_file_data[0]["formattedMessage"]["message"])
@@ -244,7 +244,7 @@ class TestConfigurePatchingProcessor(unittest.TestCase):
 
         # check status file for configure patching patch state
         self.assertTrue(runtime.package_manager.image_default_patch_configuration_backup_exists())
-        self.assertEquals(len(substatus_file_data), 1)
+        self.assertEqual(len(substatus_file_data), 1)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         message = json.loads(substatus_file_data[0]["formattedMessage"]["message"])

--- a/src/core/tests/Test_CoreMain.py
+++ b/src/core/tests/Test_CoreMain.py
@@ -59,7 +59,7 @@ class TestCoreMain(unittest.TestCase):
         # check status file
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
-        self.assertEquals(len(substatus_file_data), 3)
+        self.assertEqual(len(substatus_file_data), 3)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
@@ -82,7 +82,7 @@ class TestCoreMain(unittest.TestCase):
         # check status file
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
-        self.assertEquals(len(substatus_file_data), 4)
+        self.assertEqual(len(substatus_file_data), 4)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
@@ -109,7 +109,7 @@ class TestCoreMain(unittest.TestCase):
         # check status file
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
-        self.assertEquals(len(substatus_file_data), 3)
+        self.assertEqual(len(substatus_file_data), 3)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
@@ -133,7 +133,7 @@ class TestCoreMain(unittest.TestCase):
         # check status file
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
-        self.assertEquals(len(substatus_file_data), 4)
+        self.assertEqual(len(substatus_file_data), 4)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
@@ -164,7 +164,7 @@ class TestCoreMain(unittest.TestCase):
         # check status file
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
-        self.assertEquals(len(substatus_file_data), 4)
+        self.assertEqual(len(substatus_file_data), 4)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
@@ -200,7 +200,7 @@ class TestCoreMain(unittest.TestCase):
         # check status file
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
-        self.assertEquals(len(substatus_file_data), 4)
+        self.assertEqual(len(substatus_file_data), 4)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
@@ -228,7 +228,7 @@ class TestCoreMain(unittest.TestCase):
         # check status file
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
-        self.assertEquals(len(substatus_file_data), 4)
+        self.assertEqual(len(substatus_file_data), 4)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
@@ -255,7 +255,7 @@ class TestCoreMain(unittest.TestCase):
         # check status file
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
-        self.assertEquals(len(substatus_file_data), 2)
+        self.assertEqual(len(substatus_file_data), 2)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[1]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
@@ -275,7 +275,7 @@ class TestCoreMain(unittest.TestCase):
         # check status file
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
-        self.assertEquals(len(substatus_file_data), 2)
+        self.assertEqual(len(substatus_file_data), 2)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_ERROR.lower())
         self.assertEqual(len(json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"]), 2)
@@ -293,7 +293,7 @@ class TestCoreMain(unittest.TestCase):
 
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
-        self.assertEquals(len(substatus_file_data), 2)
+        self.assertEqual(len(substatus_file_data), 2)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_ERROR.lower())
         self.assertEqual(len(json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"]), 1)
@@ -314,7 +314,7 @@ class TestCoreMain(unittest.TestCase):
 
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
-        self.assertEquals(len(substatus_file_data), 4)
+        self.assertEqual(len(substatus_file_data), 4)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_ERROR.lower())
         self.assertEqual(len(json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"]), 1)
@@ -342,7 +342,7 @@ class TestCoreMain(unittest.TestCase):
 
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
-        self.assertEquals(len(substatus_file_data), 2)
+        self.assertEqual(len(substatus_file_data), 2)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_ERROR.lower())
         self.assertEqual(len(json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"]), 1)
@@ -363,7 +363,7 @@ class TestCoreMain(unittest.TestCase):
 
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
-        self.assertEquals(len(substatus_file_data), 4)
+        self.assertEqual(len(substatus_file_data), 4)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_ERROR.lower())
         self.assertEqual(len(json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"]), 1)
@@ -402,7 +402,7 @@ class TestCoreMain(unittest.TestCase):
         # check status file
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
-        self.assertEquals(len(substatus_file_data), 4)
+        self.assertEqual(len(substatus_file_data), 4)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
@@ -450,7 +450,7 @@ class TestCoreMain(unittest.TestCase):
         # check status file
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
-        self.assertEquals(len(substatus_file_data), 4)
+        self.assertEqual(len(substatus_file_data), 4)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
@@ -501,7 +501,7 @@ class TestCoreMain(unittest.TestCase):
             status_file_data = json.load(file_handle)[0]["status"]
         self.assertTrue(status_file_data["operation"] == Constants.CONFIGURE_PATCHING)
         substatus_file_data = status_file_data["substatus"]
-        self.assertEquals(len(substatus_file_data), 1)
+        self.assertEqual(len(substatus_file_data), 1)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         # check status file for configure patching auto updates state
@@ -528,7 +528,7 @@ class TestCoreMain(unittest.TestCase):
         # verifying the original operation name is preserved
         self.assertTrue(status_file_data["operation"] == Constants.CONFIGURE_PATCHING)
         substatus_file_data = status_file_data["substatus"]
-        self.assertEquals(len(substatus_file_data), 2)
+        self.assertEqual(len(substatus_file_data), 2)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         # check started by set to 'Platform'
@@ -561,7 +561,7 @@ class TestCoreMain(unittest.TestCase):
             status_file_data = json.load(file_handle)[0]["status"]
         self.assertTrue(status_file_data["operation"] == Constants.CONFIGURE_PATCHING)
         substatus_file_data = status_file_data["substatus"]
-        self.assertEquals(len(substatus_file_data), 1)
+        self.assertEqual(len(substatus_file_data), 1)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         # check status file for configure patching auto updates state
@@ -590,7 +590,7 @@ class TestCoreMain(unittest.TestCase):
         # verifying the original operation name is preserved
         self.assertTrue(status_file_data["operation"] == Constants.CONFIGURE_PATCHING)
         substatus_file_data = status_file_data["substatus"]
-        self.assertEquals(len(substatus_file_data), 2)
+        self.assertEqual(len(substatus_file_data), 2)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         # check started by set to 'Platform'
@@ -621,7 +621,7 @@ class TestCoreMain(unittest.TestCase):
             status_file_data = json.load(file_handle)[0]["status"]
         self.assertTrue(status_file_data["operation"] == Constants.ASSESSMENT)
         substatus_file_data = status_file_data["substatus"]
-        self.assertEquals(len(substatus_file_data), 2)
+        self.assertEqual(len(substatus_file_data), 2)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         # check started by set to 'User'
@@ -655,7 +655,7 @@ class TestCoreMain(unittest.TestCase):
         # verifying the original operation name is preserved
         self.assertTrue(status_file_data["operation"] == Constants.ASSESSMENT)
         substatus_file_data = status_file_data["substatus"]
-        self.assertEquals(len(substatus_file_data), 2)
+        self.assertEqual(len(substatus_file_data), 2)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         # check started by set to 'Platform'
@@ -690,7 +690,7 @@ class TestCoreMain(unittest.TestCase):
             status_file_data = json.load(file_handle)[0]["status"]
         self.assertTrue(status_file_data["operation"] == Constants.INSTALLATION)
         substatus_file_data = status_file_data["substatus"]
-        self.assertEquals(len(substatus_file_data), 4)
+        self.assertEqual(len(substatus_file_data), 4)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         # check started by set to 'User'
@@ -729,7 +729,7 @@ class TestCoreMain(unittest.TestCase):
         # verifying the original operation name is preserved
         self.assertTrue(status_file_data["operation"] == Constants.INSTALLATION)
         substatus_file_data = status_file_data["substatus"]
-        self.assertEquals(len(substatus_file_data), 4)
+        self.assertEqual(len(substatus_file_data), 4)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         # check started by set to 'Platform'
@@ -739,7 +739,7 @@ class TestCoreMain(unittest.TestCase):
         self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         # validate lastModifiedTime in InstallationSummary is preserved from the user initiated installation operation
         last_modified_time_from_installation_substatus_after_platform_initiated_assessment = json.loads(substatus_file_data[1]["formattedMessage"]["message"])["lastModifiedTime"]
-        self.assertEquals(last_modified_time_from_installation_substatus_after_user_initiated_installation, last_modified_time_from_installation_substatus_after_platform_initiated_assessment)
+        self.assertEqual(last_modified_time_from_installation_substatus_after_user_initiated_installation, last_modified_time_from_installation_substatus_after_platform_initiated_assessment)
         self.assertTrue(substatus_file_data[2]["name"] == Constants.PATCH_METADATA_FOR_HEALTHSTORE)
         self.assertTrue(substatus_file_data[2]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[3]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
@@ -779,7 +779,7 @@ class TestCoreMain(unittest.TestCase):
         # check status file
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
-        self.assertEquals(len(substatus_file_data), 3)
+        self.assertEqual(len(substatus_file_data), 3)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_ERROR.lower())
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)
@@ -815,7 +815,7 @@ class TestCoreMain(unittest.TestCase):
         # check status file
         with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
-        self.assertEquals(len(substatus_file_data), 3)
+        self.assertEqual(len(substatus_file_data), 3)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[1]["name"] == Constants.PATCH_INSTALLATION_SUMMARY)

--- a/src/core/tests/Test_LifecycleManagerArc.py
+++ b/src/core/tests/Test_LifecycleManagerArc.py
@@ -55,7 +55,7 @@ class TestLifecycleManagerArc(unittest.TestCase):
         self.lifecycle_manager.ext_state_file_path = old_ext_state_file_path
         self.runtime.env_layer.file_system.open = self.mock_file_open_throw_exception
         ext_state_json = self.assertRaises(Exception, self.lifecycle_manager.read_extension_sequence)
-        self.assertEquals(ext_state_json, None)
+        self.assertEqual(ext_state_json, None)
 
     def test_read_extension_sequence_success(self):
         ext_state_json = self.lifecycle_manager.read_extension_sequence()
@@ -66,7 +66,7 @@ class TestLifecycleManagerArc(unittest.TestCase):
         # file open throws exception
         self.runtime.env_layer.file_system.open = self.mock_file_open_throw_exception
         core_sequence_json = self.assertRaises(Exception, self.lifecycle_manager.read_core_sequence)
-        self.assertEquals(core_sequence_json, None)
+        self.assertEqual(core_sequence_json, None)
 
     def test_read_core_sequence_success(self):
         old_core_state_file_path = self.lifecycle_manager.core_state_file_path
@@ -95,7 +95,7 @@ class TestLifecycleManagerArc(unittest.TestCase):
         # file open throws exception
         self.runtime.env_layer.file_system.open = self.mock_file_open_throw_exception
         core_sequence_json = self.lifecycle_manager.update_core_sequence()
-        self.assertEquals(core_sequence_json, None)
+        self.assertEqual(core_sequence_json, None)
 
     def test_update_core_sequence_success(self):    # failing test - needs to be corrected with Arc code changes
         old_core_state_file_path = self.lifecycle_manager.core_state_file_path
@@ -137,7 +137,7 @@ class TestLifecycleManagerArc(unittest.TestCase):
         self.lifecycle_manager.arc_core_state_file_path = "dummy"
         self.lifecycle_manager.read_only_mode = False
         ext_state_json = self.lifecycle_manager.read_arc_core_sequence()
-        self.assertEquals(ext_state_json['completed'], 'True')
+        self.assertEqual(ext_state_json['completed'], 'True')
 
         self.lifecycle_manager.arc_core_state_file_path = old_core_state_file_path
         self.lifecycle_manager.update_core_sequence(completed=True)
@@ -151,12 +151,12 @@ class TestLifecycleManagerArc(unittest.TestCase):
         self.lifecycle_manager.update_core_sequence(completed=True)
         # Completed True Case
         arc_core_state = self.lifecycle_manager.read_arc_core_sequence()
-        self.assertEquals(arc_core_state['completed'], 'True')
+        self.assertEqual(arc_core_state['completed'], 'True')
 
         # Completed False Case
         self.lifecycle_manager.update_core_sequence(completed=False)
         arc_core_state = self.lifecycle_manager.read_arc_core_sequence()
-        self.assertEquals(arc_core_state['completed'], 'False')
+        self.assertEqual(arc_core_state['completed'], 'False')
         os.remove(self.lifecycle_manager.core_state_file_path)
 
     def mock_file_open_throw_exception(self, file_path, mode):

--- a/src/core/tests/Test_LifecycleManagerAzure.py
+++ b/src/core/tests/Test_LifecycleManagerAzure.py
@@ -52,7 +52,7 @@ class TestLifecycleManagerAzure(unittest.TestCase):
         self.lifecycle_manager.ext_state_file_path = old_ext_state_file_path
         self.runtime.env_layer.file_system.open = self.mock_file_open_throw_exception
         ext_state_json = self.assertRaises(Exception, self.lifecycle_manager.read_extension_sequence)
-        self.assertEquals(ext_state_json, None)
+        self.assertEqual(ext_state_json, None)
 
     def test_read_extension_sequence_success(self):
         ext_state_json = self.lifecycle_manager.read_extension_sequence()
@@ -64,7 +64,7 @@ class TestLifecycleManagerAzure(unittest.TestCase):
         backup_open = self.runtime.env_layer.file_system.open
         self.runtime.env_layer.file_system.open = self.mock_file_open_throw_exception
         core_sequence_json = self.assertRaises(Exception, self.lifecycle_manager.read_core_sequence)
-        self.assertEquals(core_sequence_json, None)
+        self.assertEqual(core_sequence_json, None)
         # Unable to write to core state file (retries exhausted)
 
         # json throws exception, but in a different area to test retries exhausted
@@ -73,7 +73,7 @@ class TestLifecycleManagerAzure(unittest.TestCase):
         json.load = None
         self.runtime.env_layer.file_system.open = backup_open
         core_sequence_json = self.assertRaises(Exception, self.lifecycle_manager.read_core_sequence)
-        self.assertEquals(core_sequence_json, None)
+        self.assertEqual(core_sequence_json, None)
         json.load = backup_json_load
         # Unable to read core state file (retries exhausted).
 
@@ -104,7 +104,7 @@ class TestLifecycleManagerAzure(unittest.TestCase):
         # file open throws exception
         self.runtime.env_layer.file_system.open = self.mock_file_open_throw_exception
         core_sequence_json = self.lifecycle_manager.update_core_sequence()
-        self.assertEquals(core_sequence_json, None)
+        self.assertEqual(core_sequence_json, None)
 
     def test_update_core_sequence_success(self):
         old_core_state_file_path = self.lifecycle_manager.core_state_file_path

--- a/src/core/tests/Test_TelemetryWriter.py
+++ b/src/core/tests/Test_TelemetryWriter.py
@@ -53,7 +53,7 @@ class TestTelemetryWriter(unittest.TestCase):
         with open(os.path.join(self.runtime.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:
             events = json.load(f)
             self.assertTrue(events is not None)
-            self.assertEquals(events[-1]["TaskName"], "Test Task")
+            self.assertEqual(events[-1]["TaskName"], "Test Task")
             text_found = re.search('TC=([0-9]+)', events[-1]['Message'])
             telemetry_event_counter_in_first_test_event = text_found.group(1) if text_found else None
             f.close()
@@ -64,7 +64,7 @@ class TestTelemetryWriter(unittest.TestCase):
         with open(os.path.join(self.runtime.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:
             events = json.load(f)
             self.assertTrue(events is not None)
-            self.assertEquals(events[-1]["TaskName"], "Test Task2")
+            self.assertEqual(events[-1]["TaskName"], "Test Task2")
             text_found = re.search('TC=([0-9]+)', events[-1]['Message'])
             telemetry_event_counter_in_second_test_event = text_found.group(1) if text_found else None
             f.close()
@@ -82,8 +82,8 @@ class TestTelemetryWriter(unittest.TestCase):
         with open(os.path.join(self.runtime.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:
             events = json.load(f)
             self.assertTrue(events is not None)
-            self.assertEquals(events[-2]["TaskName"], "Test Task")
-            self.assertEquals(events[-1]["TaskName"], "Test Task2")
+            self.assertEqual(events[-2]["TaskName"], "Test Task")
+            self.assertEqual(events[-1]["TaskName"], "Test Task2")
             f.close()
         time.time = time_backup
 
@@ -95,7 +95,7 @@ class TestTelemetryWriter(unittest.TestCase):
         with open(os.path.join(self.runtime.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:
             events = json.load(f)
             self.assertTrue(events is not None)
-            self.assertEquals(events[-1]["TaskName"], "Test Task")
+            self.assertEqual(events[-1]["TaskName"], "Test Task")
             self.assertTrue(len(events[-1]["Message"]) < len(message.encode('utf-8')))
             chars_dropped = len(message.encode('utf-8')) - Constants.TELEMETRY_MSG_SIZE_LIMIT_IN_CHARS + Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_CHARS + Constants.TELEMETRY_EVENT_COUNTER_MSG_SIZE_LIMIT_IN_CHARS
             self.assertTrue("a"*(len(message.encode('utf-8')) - chars_dropped) + ". [{0} chars dropped]".format(chars_dropped) in events[-1]["Message"])
@@ -110,7 +110,7 @@ class TestTelemetryWriter(unittest.TestCase):
     #     task_name = "b" * 5000
     #     self.runtime.telemetry_writer.write_event(message, Constants.TelemetryEventLevel.Error, task_name)
     #     new_events = os.listdir(self.runtime.telemetry_writer.events_folder_path)
-    #     self.assertEquals(old_events, new_events)
+    #     self.assertEqual(old_events, new_events)
     #     latest_event_file = [pos_json for pos_json in os.listdir(self.runtime.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)][-1]
     #     with open(os.path.join(self.runtime.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:
     #         events = json.load(f)
@@ -150,7 +150,7 @@ class TestTelemetryWriter(unittest.TestCase):
     #
     #     self.runtime.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task4")
     #     new_event_files = [pos_json for pos_json in os.listdir(self.runtime.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)]
-    #     self.assertEquals(len(new_event_files), 1)
+    #     self.assertEqual(len(new_event_files), 1)
     #     self.assertTrue(old_event_files[0] not in new_event_files and old_event_files[1] not in new_event_files and old_event_files[2] not in new_event_files)
     #     Constants.TELEMETRY_DIR_SIZE_LIMIT_IN_CHARS = telemetry_dir_size_backup
     #     Constants.TELEMETRY_EVENT_FILE_SIZE_LIMIT_IN_CHARS = telemetry_event_size_backup

--- a/src/core/tests/Test_YumPackageManager.py
+++ b/src/core/tests/Test_YumPackageManager.py
@@ -180,7 +180,7 @@ class TestYumPackageManager(unittest.TestCase):
         self.assertIsNotNone(package_filter)
 
         # test for successfully installing a package
-        self.assertEquals(package_manager.install_update_and_dependencies('selinux-policy.noarch', '3.13.1-102.el7_3.16', simulate=True), Constants.INSTALLED)
+        self.assertEqual(package_manager.install_update_and_dependencies('selinux-policy.noarch', '3.13.1-102.el7_3.16', simulate=True), Constants.INSTALLED)
 
     def test_install_package_failure(self):
         """Unit test for install package failure"""
@@ -192,7 +192,7 @@ class TestYumPackageManager(unittest.TestCase):
         self.assertIsNotNone(package_filter)
 
         # test for unsuccessfully installing a package
-        self.assertEquals(package_manager.install_update_and_dependencies('selinux-policy', '3.13.1-102.el7_3.16', simulate=True), Constants.FAILED)
+        self.assertEqual(package_manager.install_update_and_dependencies('selinux-policy', '3.13.1-102.el7_3.16', simulate=True), Constants.FAILED)
 
     def test_install_package_obsoleted(self):
         """Unit test for install package failure"""
@@ -204,7 +204,7 @@ class TestYumPackageManager(unittest.TestCase):
         self.assertIsNotNone(package_filter)
 
         # test for unsuccessfully installing a package
-        self.assertEquals(package_manager.install_update_and_dependencies('rdma.noarch', '7.3_4.7_rc2-6.el7_3', simulate=True), Constants.INSTALLED)
+        self.assertEqual(package_manager.install_update_and_dependencies('rdma.noarch', '7.3_4.7_rc2-6.el7_3', simulate=True), Constants.INSTALLED)
 
     def test_install_package_replaced(self):
         """Unit test for install package failure"""
@@ -216,7 +216,7 @@ class TestYumPackageManager(unittest.TestCase):
         self.assertIsNotNone(package_filter)
 
         # test for unsuccessfully installing a package
-        self.assertEquals(package_manager.install_update_and_dependencies('python-rhsm.x86_64', '1.19.10-1.el7_4', simulate=True), Constants.INSTALLED)
+        self.assertEqual(package_manager.install_update_and_dependencies('python-rhsm.x86_64', '1.19.10-1.el7_4', simulate=True), Constants.INSTALLED)
 
     def test_get_product_name(self):
         """Unit test for retrieving product Name"""
@@ -474,24 +474,24 @@ class TestYumPackageManager(unittest.TestCase):
 
         # validating backup for yum-cron
         self.assertTrue(Constants.YumAutoOSUpdateServices.YUM_CRON in image_default_patch_configuration_backup)
-        self.assertEquals(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.YUM_CRON][package_manager.yum_cron_download_updates_identifier_text], "")
-        self.assertEquals(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.YUM_CRON][package_manager.yum_cron_apply_updates_identifier_text], "")
-        self.assertEquals(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.YUM_CRON][package_manager.yum_cron_enable_on_reboot_identifier_text], False)
-        self.assertEquals(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.YUM_CRON][package_manager.yum_cron_installation_state_identifier_text], False)
+        self.assertEqual(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.YUM_CRON][package_manager.yum_cron_download_updates_identifier_text], "")
+        self.assertEqual(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.YUM_CRON][package_manager.yum_cron_apply_updates_identifier_text], "")
+        self.assertEqual(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.YUM_CRON][package_manager.yum_cron_enable_on_reboot_identifier_text], False)
+        self.assertEqual(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.YUM_CRON][package_manager.yum_cron_installation_state_identifier_text], False)
 
         # validating backup for dnf-automatic
         self.assertTrue(Constants.YumAutoOSUpdateServices.DNF_AUTOMATIC in image_default_patch_configuration_backup)
-        self.assertEquals(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.DNF_AUTOMATIC][package_manager.dnf_automatic_download_updates_identifier_text], "")
-        self.assertEquals(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.DNF_AUTOMATIC][package_manager.dnf_automatic_apply_updates_identifier_text], "")
-        self.assertEquals(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.DNF_AUTOMATIC][package_manager.dnf_automatic_enable_on_reboot_identifier_text], False)
-        self.assertEquals(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.DNF_AUTOMATIC][package_manager.dnf_automatic_installation_state_identifier_text], False)
+        self.assertEqual(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.DNF_AUTOMATIC][package_manager.dnf_automatic_download_updates_identifier_text], "")
+        self.assertEqual(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.DNF_AUTOMATIC][package_manager.dnf_automatic_apply_updates_identifier_text], "")
+        self.assertEqual(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.DNF_AUTOMATIC][package_manager.dnf_automatic_enable_on_reboot_identifier_text], False)
+        self.assertEqual(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.DNF_AUTOMATIC][package_manager.dnf_automatic_installation_state_identifier_text], False)
 
         # validating backup for packagekit
         self.assertTrue(Constants.YumAutoOSUpdateServices.PACKAGEKIT in image_default_patch_configuration_backup)
-        self.assertEquals(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.PACKAGEKIT][package_manager.packagekit_download_updates_identifier_text], "")
-        self.assertEquals(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.PACKAGEKIT][package_manager.packagekit_apply_updates_identifier_text], "")
-        self.assertEquals(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.PACKAGEKIT][package_manager.packagekit_enable_on_reboot_identifier_text], False)
-        self.assertEquals(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.PACKAGEKIT][package_manager.packagekit_installation_state_identifier_text], False)
+        self.assertEqual(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.PACKAGEKIT][package_manager.packagekit_download_updates_identifier_text], "")
+        self.assertEqual(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.PACKAGEKIT][package_manager.packagekit_apply_updates_identifier_text], "")
+        self.assertEqual(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.PACKAGEKIT][package_manager.packagekit_enable_on_reboot_identifier_text], False)
+        self.assertEqual(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.PACKAGEKIT][package_manager.packagekit_installation_state_identifier_text], False)
 
     def test_disable_auto_os_updates_with_installed_services(self):
         # all services are installed and contain valid configurations. expected o/p All services will be disabled and backup file should reflect default settings for all
@@ -517,24 +517,24 @@ class TestYumPackageManager(unittest.TestCase):
 
         # validating backup for yum-cron
         self.assertTrue(Constants.YumAutoOSUpdateServices.YUM_CRON in image_default_patch_configuration_backup)
-        self.assertEquals(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.YUM_CRON][package_manager.yum_cron_download_updates_identifier_text], "yes")
-        self.assertEquals(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.YUM_CRON][package_manager.yum_cron_apply_updates_identifier_text], "yes")
-        self.assertEquals(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.YUM_CRON][package_manager.yum_cron_enable_on_reboot_identifier_text], True)
-        self.assertEquals(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.YUM_CRON][package_manager.yum_cron_installation_state_identifier_text], True)
+        self.assertEqual(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.YUM_CRON][package_manager.yum_cron_download_updates_identifier_text], "yes")
+        self.assertEqual(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.YUM_CRON][package_manager.yum_cron_apply_updates_identifier_text], "yes")
+        self.assertEqual(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.YUM_CRON][package_manager.yum_cron_enable_on_reboot_identifier_text], True)
+        self.assertEqual(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.YUM_CRON][package_manager.yum_cron_installation_state_identifier_text], True)
 
         # validating backup for dnf-automatic
         self.assertTrue(Constants.YumAutoOSUpdateServices.DNF_AUTOMATIC in image_default_patch_configuration_backup)
-        self.assertEquals(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.DNF_AUTOMATIC][package_manager.dnf_automatic_download_updates_identifier_text], "yes")
-        self.assertEquals(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.DNF_AUTOMATIC][package_manager.dnf_automatic_apply_updates_identifier_text], "yes")
-        self.assertEquals(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.DNF_AUTOMATIC][package_manager.dnf_automatic_enable_on_reboot_identifier_text], True)
-        self.assertEquals(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.DNF_AUTOMATIC][package_manager.dnf_automatic_installation_state_identifier_text], True)
+        self.assertEqual(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.DNF_AUTOMATIC][package_manager.dnf_automatic_download_updates_identifier_text], "yes")
+        self.assertEqual(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.DNF_AUTOMATIC][package_manager.dnf_automatic_apply_updates_identifier_text], "yes")
+        self.assertEqual(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.DNF_AUTOMATIC][package_manager.dnf_automatic_enable_on_reboot_identifier_text], True)
+        self.assertEqual(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.DNF_AUTOMATIC][package_manager.dnf_automatic_installation_state_identifier_text], True)
 
         # validating backup for packagekit
         self.assertTrue(Constants.YumAutoOSUpdateServices.PACKAGEKIT in image_default_patch_configuration_backup)
-        self.assertEquals(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.PACKAGEKIT][package_manager.packagekit_download_updates_identifier_text], "true")
-        self.assertEquals(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.PACKAGEKIT][package_manager.packagekit_apply_updates_identifier_text], "true")
-        self.assertEquals(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.PACKAGEKIT][package_manager.packagekit_enable_on_reboot_identifier_text], True)
-        self.assertEquals(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.PACKAGEKIT][package_manager.packagekit_installation_state_identifier_text], True)
+        self.assertEqual(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.PACKAGEKIT][package_manager.packagekit_download_updates_identifier_text], "true")
+        self.assertEqual(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.PACKAGEKIT][package_manager.packagekit_apply_updates_identifier_text], "true")
+        self.assertEqual(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.PACKAGEKIT][package_manager.packagekit_enable_on_reboot_identifier_text], True)
+        self.assertEqual(image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.PACKAGEKIT][package_manager.packagekit_installation_state_identifier_text], True)
 
     def test_disable_auto_os_update_failure(self):
         # disable with non existing log file

--- a/src/core/tests/Test_ZypperPackageManager.py
+++ b/src/core/tests/Test_ZypperPackageManager.py
@@ -211,7 +211,7 @@ class TestZypperPackageManager(unittest.TestCase):
         self.assertIsNotNone(package_manager)
 
         # test for successfully installing a package
-        self.assertEquals(package_manager.install_update_and_dependencies('selinux-policy', '3.13.1-102.el7_3.16', simulate=True), Constants.INSTALLED)
+        self.assertEqual(package_manager.install_update_and_dependencies('selinux-policy', '3.13.1-102.el7_3.16', simulate=True), Constants.INSTALLED)
 
     def test_install_package_failure(self):
         self.runtime.set_legacy_test_type('FailInstallPath')
@@ -220,7 +220,7 @@ class TestZypperPackageManager(unittest.TestCase):
         self.assertIsNotNone(package_manager)
 
         # test for unsuccessfully installing a package
-        self.assertEquals(package_manager.install_update_and_dependencies('selinux-policy.noarch', '3.13.1-102.el7_3.16', simulate=True), Constants.FAILED)
+        self.assertEqual(package_manager.install_update_and_dependencies('selinux-policy.noarch', '3.13.1-102.el7_3.16', simulate=True), Constants.FAILED)
 
     def test_get_process_tree_from_package_manager_output_success(self):
         self.runtime.set_legacy_test_type('HappyPath')
@@ -368,8 +368,8 @@ class TestZypperPackageManager(unittest.TestCase):
 
         # validating backup for yast2-online-update-configuration
         self.assertTrue(package_manager.ZypperAutoOSUpdateServices.YAST2_ONLINE_UPDATE_CONFIGURATION in image_default_patch_configuration_backup)
-        self.assertEquals(image_default_patch_configuration_backup[package_manager.ZypperAutoOSUpdateServices.YAST2_ONLINE_UPDATE_CONFIGURATION][package_manager.YastOnlineUpdateConfigurationConstants.APPLY_UPDATES_IDENTIFIER_TEXT], "")
-        self.assertEquals(image_default_patch_configuration_backup[package_manager.ZypperAutoOSUpdateServices.YAST2_ONLINE_UPDATE_CONFIGURATION][package_manager.YastOnlineUpdateConfigurationConstants.INSTALLATION_STATE_IDENTIFIER_TEXT], False)
+        self.assertEqual(image_default_patch_configuration_backup[package_manager.ZypperAutoOSUpdateServices.YAST2_ONLINE_UPDATE_CONFIGURATION][package_manager.YastOnlineUpdateConfigurationConstants.APPLY_UPDATES_IDENTIFIER_TEXT], "")
+        self.assertEqual(image_default_patch_configuration_backup[package_manager.ZypperAutoOSUpdateServices.YAST2_ONLINE_UPDATE_CONFIGURATION][package_manager.YastOnlineUpdateConfigurationConstants.INSTALLATION_STATE_IDENTIFIER_TEXT], False)
 
     def test_disable_auto_os_updates_with_installed_services(self):
         # all services are installed and contain valid configurations. expected o/p All services will be disabled and backup file should reflect default settings for all
@@ -387,8 +387,8 @@ class TestZypperPackageManager(unittest.TestCase):
 
         # validating backup for yast2-online-update-configuration
         self.assertTrue(package_manager.ZypperAutoOSUpdateServices.YAST2_ONLINE_UPDATE_CONFIGURATION in image_default_patch_configuration_backup)
-        self.assertEquals(image_default_patch_configuration_backup[package_manager.ZypperAutoOSUpdateServices.YAST2_ONLINE_UPDATE_CONFIGURATION][package_manager.YastOnlineUpdateConfigurationConstants.APPLY_UPDATES_IDENTIFIER_TEXT], "true")
-        self.assertEquals(image_default_patch_configuration_backup[package_manager.ZypperAutoOSUpdateServices.YAST2_ONLINE_UPDATE_CONFIGURATION][package_manager.YastOnlineUpdateConfigurationConstants.INSTALLATION_STATE_IDENTIFIER_TEXT], True)
+        self.assertEqual(image_default_patch_configuration_backup[package_manager.ZypperAutoOSUpdateServices.YAST2_ONLINE_UPDATE_CONFIGURATION][package_manager.YastOnlineUpdateConfigurationConstants.APPLY_UPDATES_IDENTIFIER_TEXT], "true")
+        self.assertEqual(image_default_patch_configuration_backup[package_manager.ZypperAutoOSUpdateServices.YAST2_ONLINE_UPDATE_CONFIGURATION][package_manager.YastOnlineUpdateConfigurationConstants.INSTALLATION_STATE_IDENTIFIER_TEXT], True)
 
     def test_update_image_default_patch_mode(self):
         package_manager = self.container.get('package_manager')

--- a/src/extension/tests/Test_ActionHandler.py
+++ b/src/extension/tests/Test_ActionHandler.py
@@ -336,7 +336,7 @@ class TestActionHandler(unittest.TestCase):
         for event_file in event_files:
             with open(os.path.join(self.action_handler.telemetry_writer.events_folder_path, event_file), 'r+') as f:
                 events = json.load(f)
-                self.assertEquals(events[0]["OperationId"], self.action_handler.operation_id_substitute_for_all_actions_in_telemetry)
+                self.assertEqual(events[0]["OperationId"], self.action_handler.operation_id_substitute_for_all_actions_in_telemetry)
 
     def test_write_basic_status_uninstall(self):
         """ Check that a basic status file is NOT written during uninstall handler command setup """

--- a/src/extension/tests/Test_ProcessHandler.py
+++ b/src/extension/tests/Test_ProcessHandler.py
@@ -130,15 +130,15 @@ class TestProcessHandler(unittest.TestCase):
 
         # testing for 'python' command
         EnvLayer.run_command_output = self.mock_run_command_output_for_python
-        self.assertEquals(process_handler.get_python_cmd(), "python")
+        self.assertEqual(process_handler.get_python_cmd(), "python")
 
         # testing for 'python3' command
         EnvLayer.run_command_output = self.mock_run_command_output_for_python3
-        self.assertEquals(process_handler.get_python_cmd(), "python3")
+        self.assertEqual(process_handler.get_python_cmd(), "python3")
 
         # testing when python is not found on machine
         EnvLayer.run_command_output = self.mock_run_command_output_for_python_not_found
-        self.assertEquals(process_handler.get_python_cmd(), Constants.PYTHON_NOT_FOUND)
+        self.assertEqual(process_handler.get_python_cmd(), Constants.PYTHON_NOT_FOUND)
 
         # resetting mocks
         EnvLayer.run_command_output = run_command_output_backup

--- a/src/extension/tests/Test_TelemetryWriter.py
+++ b/src/extension/tests/Test_TelemetryWriter.py
@@ -44,7 +44,7 @@ class TestTelemetryWriter(unittest.TestCase):
         with open(os.path.join(self.telemetry_writer.events_folder_path, os.listdir(self.telemetry_writer.events_folder_path)[0]), 'r+') as f:
             events = json.load(f)
             self.assertTrue(events is not None)
-            self.assertEquals(events[0]["TaskName"], "Test Task")
+            self.assertEqual(events[0]["TaskName"], "Test Task")
             f.close()
 
         self.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task2")
@@ -52,14 +52,14 @@ class TestTelemetryWriter(unittest.TestCase):
             with open(os.path.join(self.telemetry_writer.events_folder_path, os.listdir(self.telemetry_writer.events_folder_path)[1]), 'r+') as f:
                 events = json.load(f)
                 self.assertTrue(events is not None)
-                self.assertEquals(events[0]["TaskName"], "Test Task2")
+                self.assertEqual(events[0]["TaskName"], "Test Task2")
                 f.close()
         else:
             with open(os.path.join(self.telemetry_writer.events_folder_path, os.listdir(self.telemetry_writer.events_folder_path)[0]), 'r+') as f:
                 events = json.load(f)
                 self.assertTrue(events is not None)
-                self.assertEquals(len(events), 2)
-                self.assertEquals(events[1]["TaskName"], "Test Task2")
+                self.assertEqual(len(events), 2)
+                self.assertEqual(events[1]["TaskName"], "Test Task2")
                 f.close()
 
     def test_write_multiple_events_in_same_file(self):
@@ -70,9 +70,9 @@ class TestTelemetryWriter(unittest.TestCase):
         with open(os.path.join(self.telemetry_writer.events_folder_path, os.listdir(self.telemetry_writer.events_folder_path)[0]), 'r+') as f:
             events = json.load(f)
             self.assertTrue(events is not None)
-            self.assertEquals(len(events), 2)
-            self.assertEquals(events[0]["TaskName"], "Test Task")
-            self.assertEquals(events[1]["TaskName"], "Test Task2")
+            self.assertEqual(len(events), 2)
+            self.assertEqual(events[0]["TaskName"], "Test Task")
+            self.assertEqual(events[1]["TaskName"], "Test Task2")
             f.close()
         time.time = time_backup
 
@@ -83,10 +83,10 @@ class TestTelemetryWriter(unittest.TestCase):
         with open(os.path.join(self.telemetry_writer.events_folder_path, os.listdir(self.telemetry_writer.events_folder_path)[0]), 'r+') as f:
             events = json.load(f)
             self.assertTrue(events is not None)
-            self.assertEquals(events[0]["TaskName"], "Test Task")
+            self.assertEqual(events[0]["TaskName"], "Test Task")
             self.assertTrue(len(events[0]["Message"]) < len(message.encode('utf-8')))
             chars_dropped = len(message.encode('utf-8')) - Constants.TELEMETRY_MSG_SIZE_LIMIT_IN_CHARS + Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_CHARS
-            self.assertEquals(events[0]["Message"], "a"*(len(message.encode('utf-8')) - chars_dropped) + ". [{0} chars dropped]".format(chars_dropped))
+            self.assertEqual(events[0]["Message"], "a"*(len(message.encode('utf-8')) - chars_dropped) + ". [{0} chars dropped]".format(chars_dropped))
             f.close()
 
     def test_write_event_size_limit(self):
@@ -106,7 +106,7 @@ class TestTelemetryWriter(unittest.TestCase):
     #
     #     self.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task2")
     #     events = os.listdir(self.telemetry_writer.events_folder_path)
-    #     self.assertEquals(len(events), 2)
+    #     self.assertEqual(len(events), 2)
     #     os.path.exists = os_path_exists_backup
     #     self.telemetry_writer.get_file_size = telemetry_get_event_file_size_backup
 
@@ -124,7 +124,7 @@ class TestTelemetryWriter(unittest.TestCase):
 
         self.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task4")
         new_events = os.listdir(self.telemetry_writer.events_folder_path)
-        self.assertEquals(len(new_events), 1)
+        self.assertEqual(len(new_events), 1)
         self.assertTrue(old_events[0] not in new_events)
         Constants.TELEMETRY_DIR_SIZE_LIMIT_IN_CHARS = telemetry_dir_size_backup
         Constants.TELEMETRY_EVENT_FILE_SIZE_LIMIT_IN_CHARS = telemetry_event_size_backup


### PR DESCRIPTION
Fixes all AssertEquals deprecations warnings from the tests by replacing them with AssertEqual. Tests work fine on both Python 2.7 and 3.9.