### PR TITLE
Ignore repeat/reboot on dry run commands for Zypper

### DIFF
--- a/src/core/src/package_managers/ZypperPackageManager.py
+++ b/src/core/src/package_managers/ZypperPackageManager.py
@@ -158,13 +158,28 @@ class ZypperPackageManager(PackageManager):
             else:  # verbose diagnostic log
                 self.log_success_on_invoke(code, out)
 
-            if code == self.zypper_exitcode_zypper_updated:
-                self.composite_logger.log_debug(" - Package manager update detected. Patch installation run will be repeated.")
-                self.set_package_manager_setting(Constants.PACKAGE_MGR_SETTING_REPEAT_PATCH_OPERATION, True)
-            elif code == self.zypper_exitcode_reboot_required:
-                self.composite_logger.log_warning("Machine requires reboot after patch installation. Setting force_reboot flag to True.")
-                self.force_reboot = True
+            if code == self.zypper_exitcode_zypper_updated or code == self.zypper_exitcode_reboot_required:
+                self.__handle_repeat_or_reboot_exit_codes(command, code)
+                
             return out
+
+    def __handle_repeat_or_reboot_exit_codes(self, command, code):
+        """ Handles exit code 102 or 103 when returned from invoking package manager.
+            Does not repeat installation or reboot if it is a dry run. """
+        if "--dry-run" in command:
+            self.composite_logger.log_debug(
+                "Exit code {0} detected from command \"{1}\", but it was a dry run. Continuing execution without repeating installation or rebooting.".format(
+                str(code), command))
+            return
+
+        if code == self.zypper_exitcode_zypper_updated:
+            self.composite_logger.log_debug(
+                " - Package manager update detected. Patch installation run will be repeated.")
+            self.set_package_manager_setting(Constants.PACKAGE_MGR_SETTING_REPEAT_PATCH_OPERATION, True)
+        elif code == self.zypper_exitcode_reboot_required:
+            self.composite_logger.log_warning(
+                "Machine requires reboot after patch installation. Setting force_reboot flag to True.")
+            self.force_reboot = True
 
     def modify_upgrade_or_patch_command_to_replacefiles(self, command):
         """ Modifies a command to invoke_package_manager for update or patch to include a --replacefiles flag. 


### PR DESCRIPTION
If the package manager returns code 102 (`REBOOT_REQUIRED`) or 103 (`ZYPPER_UPDATED`, will need to repeat last patch installation) from a dry run command, it will get stuck in a loop. It gets stuck in a loop because although the dry run command returns a non-zero exit code indicating that a specific action needs to be taken, this action will only need to be taken once the command is actually run and does _not_ apply for the dry run command. The dry run command is a preview of what would happen when the command is run.

For code `REBOOT_REQUIRED`, it breaks out of the loop because the maintenance window is exceeded.

For code `ZYPPER_UPDATED`, it breaks out of the loop on the second attempt because of [this code](https://github.com/Azure/LinuxPatchExtension/blob/3e345736b7639df092e5d395fdf4f96cd75aa931/src/core/src/core_logic/PatchInstaller.py#L84):
```py
if package_manager.get_package_manager_setting(Constants.PACKAGE_MGR_SETTING_REPEAT_PATCH_OPERATION, False):  # We should not see this again
    error_msg = "Unexpected repeated package manager update occurred. Please re-run the update deployment."
    self.status_handler.add_error_to_status(error_msg, Constants.PatchOperationErrorCodes.PACKAGE_MANAGER_FAILURE)
    raise Exception(error_msg, "[{0}]".format(Constants.ERROR_ADDED_TO_STATUS))
```

This PR fixes this problem by _not_ taking any specific actions when these exit codes are returned. If one of these exit codes is returned on a dry run command, it's logged, and execution continues normally without repeating installation/rebooting.

