### PR TITLE
Write to multiple statuses for ConfigurePatching on error

### DIFF
--- a/src/core/src/core_logic/ConfigurePatchingProcessor.py
+++ b/src/core/src/core_logic/ConfigurePatchingProcessor.py
@@ -54,6 +54,7 @@ class ConfigurePatchingProcessor(object):
             overall_status = Constants.STATUS_SUCCESS if self.configure_patching_successful else Constants.STATUS_ERROR
             self.__report_consolidated_configure_patch_status(overall_status)
         except Exception as error:
+            self.current_auto_assessment_state = Constants.AutoAssessmentStates.ERROR
             self.__report_consolidated_configure_patch_status(status=Constants.STATUS_ERROR, error=error)
             self.configure_patching_successful &= False
 
@@ -128,6 +129,7 @@ class ConfigurePatchingProcessor(object):
             error_msg = 'Error: ' + repr(error)
             self.composite_logger.log_error(error_msg)
             self.status_handler.add_error_to_status(error_msg, Constants.PatchOperationErrorCodes.DEFAULT_ERROR)
+            self.status_handler.add_error_to_status(error_msg, Constants.PatchOperationErrorCodes.DEFAULT_ERROR, current_operation_override_for_error=Constants.CONFIGURE_PATCHING_AUTO_ASSESSMENT)
 
         # write consolidated status
         self.status_handler.set_configure_patching_substatus_json(status=status,
@@ -140,7 +142,6 @@ class ConfigurePatchingProcessor(object):
             return
         if not self.telemetry_writer.is_agent_compatible():
             error_msg = "{0} [{1}]".format(Constants.TELEMETRY_AT_AGENT_NOT_COMPATIBLE_ERROR_MSG, self.telemetry_writer.get_telemetry_diagnostics())
-            self.composite_logger.log_error(error_msg)
             raise Exception(error_msg)
 
         self.composite_logger.log("{0} [{1}]".format(Constants.TELEMETRY_AT_AGENT_COMPATIBLE_MSG, self.telemetry_writer.get_telemetry_diagnostics()))

--- a/src/core/src/core_logic/PatchAssessor.py
+++ b/src/core/src/core_logic/PatchAssessor.py
@@ -86,6 +86,7 @@ class PatchAssessor(object):
         if not self.telemetry_writer.is_agent_compatible():
             error_msg = "{0} [{1}]".format(Constants.TELEMETRY_AT_AGENT_NOT_COMPATIBLE_ERROR_MSG, self.telemetry_writer.get_telemetry_diagnostics())
             self.composite_logger.log_error(error_msg)
+            self.status_handler.set_assessment_substatus_json(status=Constants.STATUS_ERROR)
             raise Exception(error_msg)
 
         self.composite_logger.log("{0} [{1}]".format(Constants.TELEMETRY_AT_AGENT_COMPATIBLE_MSG, self.telemetry_writer.get_telemetry_diagnostics()))

--- a/src/core/tests/Test_ConfigurePatchingProcessor.py
+++ b/src/core/tests/Test_ConfigurePatchingProcessor.py
@@ -147,6 +147,8 @@ class TestConfigurePatchingProcessor(unittest.TestCase):
             self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_ERROR.lower())
             self.assertTrue(len(json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"]), 1)
             self.assertTrue(Constants.TELEMETRY_AT_AGENT_NOT_COMPATIBLE_ERROR_MSG in json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"][0]["message"])
+            self.assertTrue(Constants.TELEMETRY_AT_AGENT_NOT_COMPATIBLE_ERROR_MSG in json.loads(substatus_file_data[0]["formattedMessage"]["message"])["autoAssessmentStatus"]["errors"]["details"][0]["message"])
+            self.assertTrue(Constants.STATUS_ERROR in json.loads(substatus_file_data[0]["formattedMessage"]["message"])["autoAssessmentStatus"]["autoAssessmentState"])
         else:
             self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         runtime.stop()

--- a/src/core/tests/Test_PatchAssessor.py
+++ b/src/core/tests/Test_PatchAssessor.py
@@ -17,7 +17,6 @@
 import json
 import unittest
 
-from core.src.bootstrap.Constants import Constants
 from core.src.service_interfaces.TelemetryWriter import TelemetryWriter
 from core.tests.library.ArgumentComposer import ArgumentComposer
 from core.tests.library.RuntimeCompositor import RuntimeCompositor

--- a/src/core/tests/Test_PatchAssessor.py
+++ b/src/core/tests/Test_PatchAssessor.py
@@ -16,6 +16,9 @@
 
 import json
 import unittest
+
+from core.src.bootstrap.Constants import Constants
+from core.src.service_interfaces.TelemetryWriter import TelemetryWriter
 from core.tests.library.ArgumentComposer import ArgumentComposer
 from core.tests.library.RuntimeCompositor import RuntimeCompositor
 
@@ -50,6 +53,13 @@ class TestPatchAssessor(unittest.TestCase):
         with open(self.runtime.execution_config.status_file_path, 'r') as file_handle:
             file_contents = json.loads(file_handle.read())
             self.assertTrue('Unexpected return code (100) from package manager on command: LANG=en_US.UTF8 sudo apt-get -s dist-upgrade' in str(file_contents))
+
+    def test_assessment_telemetry_fail(self):
+        backup_telemetry_writer = self.runtime.telemetry_writer
+        telemetry_writer = TelemetryWriter(self.runtime.env_layer, self.runtime.composite_logger, events_folder_path=None)
+        self.runtime.patch_assessor.telemetry_writer = telemetry_writer
+        self.assertRaises(Exception, self.runtime.patch_assessor.start_assessment)
+        self.runtime.patch_assessor.telemetry_writer = backup_telemetry_writer
 
     def mock_refresh_repo(self):
         pass


### PR DESCRIPTION
If ConfigurePatching fails with an error, the error is now also written to `autoAssessmentState` and `errors` sections in `autoAssessmentStatus`.