### PR TITLE
Update version to 1.6.37

### DIFF
--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -30,7 +30,7 @@ class Constants(object):
     UNKNOWN = "Unknown"
 
     # Extension version (todo: move to a different file)
-    EXT_VERSION = "1.6.36"
+    EXT_VERSION = "1.6.37"
 
     # Runtime environments
     TEST = 'Test'

--- a/src/extension/src/Constants.py
+++ b/src/extension/src/Constants.py
@@ -28,7 +28,7 @@ class Constants(object):
                         yield item
 
     # Extension version (todo: move to a different file)
-    EXT_VERSION = "1.6.36"
+    EXT_VERSION = "1.6.37"
 
     # Runtime environments
     TEST = 'Test'

--- a/src/extension/src/manifest.xml
+++ b/src/extension/src/manifest.xml
@@ -2,7 +2,7 @@
 <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure">
   <ProviderNameSpace>Microsoft.CPlat.Core</ProviderNameSpace>
   <Type>LinuxPatchExtension</Type>
-  <Version>1.6.36</Version>
+  <Version>1.6.37</Version>
   <Label>Microsoft Azure VM InGuest Patch Extension for Linux Virtual Machines</Label>
   <HostingResources>VmRole</HostingResources>
   <MediaLink></MediaLink>


### PR DESCRIPTION
This version includes:
 - [Fix AssertEquals deprecation warnings](https://github.com/Azure/LinuxPatchExtension/pull/128)
 - [Ignore repeat/reboot on dry run commands for Zypper](https://github.com/Azure/LinuxPatchExtension/pull/135)
 - [Do not error if OS backup settings do not exist](https://github.com/Azure/LinuxPatchExtension/pull/136)
 - [Write to multiple statuses for ConfigurePatching on error](https://github.com/Azure/LinuxPatchExtension/pull/137)