### PR TITLE
Fix for ConfigurePatching getting stuck in transitioning

### DIFF
--- a/src/core/src/bootstrap/ConfigurationFactory.py
+++ b/src/core/src/bootstrap/ConfigurationFactory.py
@@ -171,17 +171,17 @@ class ConfigurationFactory(object):
         configuration = {
             'config_env': Constants.PROD,
             'package_manager_name': package_manager_name,
-            'lifecycle_manager': {
-                'component': self.lifecycle_manager_component,
-                'component_args': ['env_layer', 'execution_config', 'composite_logger', 'telemetry_writer'],
-                'component_kwargs': {}
-            },
             'status_handler': {
                 'component': StatusHandler,
                 'component_args': ['env_layer', 'execution_config', 'composite_logger', 'telemetry_writer'],
                 'component_kwargs': {
                     'vm_cloud_type': self.vm_cloud_type
                 }
+            },
+            'lifecycle_manager': {
+                'component': self.lifecycle_manager_component,
+                'component_args': ['env_layer', 'execution_config', 'composite_logger', 'telemetry_writer', 'status_handler'],
+                'component_kwargs': {}
             },
             'package_manager': {
                 'component': package_manager_component,

--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -227,10 +227,10 @@ class Constants(object):
         ERROR = 1
 
     class PatchOperationErrorCodes(EnumBackport):
-        # todo: finalize these error codes
-        PACKAGE_MANAGER_FAILURE = "PACKAGE_MANAGER_FAILURE"
-        OPERATION_FAILED = "OPERATION_FAILED"
         DEFAULT_ERROR = "ERROR"  # default error code
+        OPERATION_FAILED = "OPERATION_FAILED"
+        PACKAGE_MANAGER_FAILURE = "PACKAGE_MANAGER_FAILURE"
+        NEWER_OPERATION_SUPERSEDED = "NEWER_OPERATION_SUPERSEDED"
 
     ERROR_ADDED_TO_STATUS = "Error_added_to_status"
 

--- a/src/core/src/service_interfaces/LifecycleManager.py
+++ b/src/core/src/service_interfaces/LifecycleManager.py
@@ -24,11 +24,12 @@ from core.src.bootstrap.Constants import Constants
 class LifecycleManager(object):
     """ Parent class for LifecycleManagers of Azure and ARC ( auto assessment ), manages lifecycle within the extension wrapper ~ """
 
-    def __init__(self, env_layer, execution_config, composite_logger, telemetry_writer):
+    def __init__(self, env_layer, execution_config, composite_logger, telemetry_writer, status_handler):
         self.env_layer = env_layer
         self.execution_config = execution_config
         self.composite_logger = composite_logger
         self.telemetry_writer = telemetry_writer
+        self.status_handler = status_handler
 
         # Handshake file paths
         self.ext_state_file_path = os.path.join(self.execution_config.config_folder, Constants.EXT_STATE_FILE)

--- a/src/core/src/service_interfaces/LifecycleManagerArc.py
+++ b/src/core/src/service_interfaces/LifecycleManagerArc.py
@@ -24,8 +24,8 @@ from core.src.service_interfaces.LifecycleManager import LifecycleManager
 class LifecycleManagerArc(LifecycleManager):
     """Class for managing the core code's lifecycle within the extension wrapper"""
 
-    def __init__(self, env_layer, execution_config, composite_logger, telemetry_writer):
-        super(LifecycleManagerArc,self).__init__(env_layer,execution_config,composite_logger,telemetry_writer)
+    def __init__(self, env_layer, execution_config, composite_logger, telemetry_writer, status_handler):
+        super(LifecycleManagerArc,self).__init__(env_layer,execution_config,composite_logger,telemetry_writer, status_handler)
 
         # Handshake file paths
         self.ext_state_file_path = os.path.join(self.execution_config.config_folder, Constants.EXT_STATE_FILE)

--- a/src/core/src/service_interfaces/LifecycleManagerAzure.py
+++ b/src/core/src/service_interfaces/LifecycleManagerAzure.py
@@ -25,8 +25,8 @@ from core.src.service_interfaces.LifecycleManager import LifecycleManager
 class LifecycleManagerAzure(LifecycleManager):
     """Class for managing the core code's lifecycle within the extension wrapper"""
 
-    def __init__(self, env_layer, execution_config, composite_logger, telemetry_writer):
-        super(LifecycleManagerAzure, self).__init__(env_layer, execution_config, composite_logger, telemetry_writer)
+    def __init__(self, env_layer, execution_config, composite_logger, telemetry_writer, status_handler):
+        super(LifecycleManagerAzure, self).__init__(env_layer, execution_config, composite_logger, telemetry_writer, status_handler)
 
         # Handshake file paths
         self.ext_state_file_path = os.path.join(self.execution_config.config_folder, Constants.EXT_STATE_FILE)
@@ -127,7 +127,8 @@ class LifecycleManagerAzure(LifecycleManager):
             self.update_core_sequence(completed=False)
         else:
             self.composite_logger.log_error("Extension goal state has changed. Terminating current sequence: {0}".format(self.execution_config.sequence_number))
-            self.update_core_sequence(completed=True)   # forced-to-complete scenario | extension wrapper will be watching for this event
+            self.status_handler.report_sequence_number_changed_termination()        # fail everything in a sequence number change
+            self.update_core_sequence(completed=True)       # forced-to-complete scenario | extension wrapper will be watching for this event
             self.composite_logger.file_logger.close()
             self.env_layer.exit(0)
         self.composite_logger.log_debug("Completed lifecycle status check.")   

--- a/src/core/src/service_interfaces/StatusHandler.py
+++ b/src/core/src/service_interfaces/StatusHandler.py
@@ -247,7 +247,7 @@ class StatusHandler(object):
 
     # region - Terminal state management
     def report_sequence_number_changed_termination(self):
-        """ Based on the current operation (Assessment or Installation), adds an error status and sets the substatus to error """
+        """ Based on the current operation, adds an error status and sets the substatus to error """
         current_operation = self.execution_config.operation.lower()
         error_code = Constants.PatchOperationErrorCodes.NEWER_OPERATION_SUPERSEDED
         message = "Execution was stopped due to a newer operation taking precedence."
@@ -255,6 +255,10 @@ class StatusHandler(object):
         if current_operation == Constants.ASSESSMENT.lower() or self.execution_config.exec_auto_assess_only:
             self.add_error_to_status(message, error_code, current_operation_override_for_error=Constants.ASSESSMENT)
             self.set_assessment_substatus_json(status=Constants.STATUS_ERROR)
+        # elif current_operation == Constants.CONFIGURE_PATCHING.lower() or current_operation == Constants.CONFIGURE_PATCHING_AUTO_ASSESSMENT.lower():
+        #     self.add_error_to_status(message, error_code, current_operation_override_for_error=Constants.CONFIGURE_PATCHING)
+        #     self.add_error_to_status(message, error_code, current_operation_override_for_error=Constants.CONFIGURE_PATCHING_AUTO_ASSESSMENT)
+        #     self.set_configure_patching_substatus_json(status=Constants.STATUS_ERROR)
         elif current_operation == Constants.INSTALLATION.lower():
             self.add_error_to_status(message, error_code, current_operation_override_for_error=Constants.INSTALLATION)
             self.set_installation_substatus_json(status=Constants.STATUS_ERROR)

--- a/src/core/src/service_interfaces/StatusHandler.py
+++ b/src/core/src/service_interfaces/StatusHandler.py
@@ -380,7 +380,7 @@ class StatusHandler(object):
 
     def set_patch_metadata_for_healthstore_substatus_json(self, status=Constants.STATUS_SUCCESS, code=0, patch_version=Constants.PATCH_VERSION_UNKNOWN, report_to_healthstore=False, wait_after_update=False):
         """ Prepare the healthstore substatus json including message containing summary to be sent to healthstore """
-        if self.execution_config.exec_auto_assess_only:  # Previously included: status == Constants.STATUS_TRANSITIONING
+        if self.execution_config.exec_auto_assess_only:
             raise Exception("Auto-assessment mode. Unexpected attempt to update healthstore status.")
 
         self.composite_logger.log_debug("Setting patch metadata for healthstore substatus. [Substatus={0}] [Report to HealthStore={1}]".format(str(status), str(report_to_healthstore)))
@@ -413,7 +413,7 @@ class StatusHandler(object):
                                               automatic_os_patch_state=Constants.AutomaticOSPatchStates.UNKNOWN,
                                               auto_assessment_state=Constants.AutoAssessmentStates.UNKNOWN):
         """ Prepare the configure patching substatus json including the message containing configure patching summary """
-        if self.execution_config.exec_auto_assess_only:  # Previously included: status == Constants.STATUS_TRANSITIONING
+        if self.execution_config.exec_auto_assess_only:
             raise Exception("Auto-assessment mode. Unexpected attempt to update configure patching status.")
 
         self.composite_logger.log_debug("Setting configure patching substatus. [Substatus={0}]".format(str(status)))

--- a/src/core/src/service_interfaces/StatusHandler.py
+++ b/src/core/src/service_interfaces/StatusHandler.py
@@ -247,7 +247,7 @@ class StatusHandler(object):
 
     # region - Terminal state management
     def report_sequence_number_changed_termination(self):
-        """ Based on the current operation, sends """
+        """ Based on the current operation, adds an error status and sets the substatus to error """
         current_operation = self.execution_config.operation.lower()
         error_code = Constants.PatchOperationErrorCodes.NEWER_OPERATION_SUPERSEDED
         message = "Execution was stopped due to a newer operation taking precedence."

--- a/src/core/src/service_interfaces/StatusHandler.py
+++ b/src/core/src/service_interfaces/StatusHandler.py
@@ -255,10 +255,10 @@ class StatusHandler(object):
         if current_operation == Constants.ASSESSMENT.lower() or self.execution_config.exec_auto_assess_only:
             self.add_error_to_status(message, error_code, current_operation_override_for_error=Constants.ASSESSMENT)
             self.set_assessment_substatus_json(status=Constants.STATUS_ERROR)
-        # elif current_operation == Constants.CONFIGURE_PATCHING.lower() or current_operation == Constants.CONFIGURE_PATCHING_AUTO_ASSESSMENT.lower():
-        #     self.add_error_to_status(message, error_code, current_operation_override_for_error=Constants.CONFIGURE_PATCHING)
-        #     self.add_error_to_status(message, error_code, current_operation_override_for_error=Constants.CONFIGURE_PATCHING_AUTO_ASSESSMENT)
-        #     self.set_configure_patching_substatus_json(status=Constants.STATUS_ERROR)
+        elif current_operation == Constants.CONFIGURE_PATCHING.lower() or current_operation == Constants.CONFIGURE_PATCHING_AUTO_ASSESSMENT.lower():
+            self.add_error_to_status(message, error_code, current_operation_override_for_error=Constants.CONFIGURE_PATCHING)
+            self.add_error_to_status(message, error_code, current_operation_override_for_error=Constants.CONFIGURE_PATCHING_AUTO_ASSESSMENT)
+            self.set_configure_patching_substatus_json(status=Constants.STATUS_ERROR)
         elif current_operation == Constants.INSTALLATION.lower():
             self.add_error_to_status(message, error_code, current_operation_override_for_error=Constants.INSTALLATION)
             self.set_installation_substatus_json(status=Constants.STATUS_ERROR)

--- a/src/core/src/service_interfaces/StatusHandler.py
+++ b/src/core/src/service_interfaces/StatusHandler.py
@@ -499,6 +499,7 @@ class StatusHandler(object):
         :param initial_load: If no status file exists AND initial_load is true, a default initial status file is created.
         :return: None
         """
+        
         # Initializing records safely
         self.__installation_substatus_json = None
         self.__installation_summary_json = None

--- a/src/core/src/service_interfaces/StatusHandler.py
+++ b/src/core/src/service_interfaces/StatusHandler.py
@@ -247,7 +247,7 @@ class StatusHandler(object):
 
     # region - Terminal state management
     def report_sequence_number_changed_termination(self):
-        """ Based on the current operation, adds an error status and sets the substatus to error """
+        """ Based on the current operation (Assessment or Installation), adds an error status and sets the substatus to error """
         current_operation = self.execution_config.operation.lower()
         error_code = Constants.PatchOperationErrorCodes.NEWER_OPERATION_SUPERSEDED
         message = "Execution was stopped due to a newer operation taking precedence."
@@ -255,11 +255,6 @@ class StatusHandler(object):
         if current_operation == Constants.ASSESSMENT.lower() or self.execution_config.exec_auto_assess_only:
             self.add_error_to_status(message, error_code, current_operation_override_for_error=Constants.ASSESSMENT)
             self.set_assessment_substatus_json(status=Constants.STATUS_ERROR)
-        elif current_operation == Constants.CONFIGURE_PATCHING.lower() or current_operation == Constants.CONFIGURE_PATCHING_AUTO_ASSESSMENT.lower():
-            self.add_error_to_status(message, error_code, current_operation_override_for_error=Constants.CONFIGURE_PATCHING)
-            self.add_error_to_status(message, error_code, current_operation_override_for_error=Constants.CONFIGURE_PATCHING_AUTO_ASSESSMENT)
-            # TODO: pass in patch state / auto assessment state
-            self.set_configure_patching_substatus_json(status=Constants.STATUS_ERROR)
         elif current_operation == Constants.INSTALLATION.lower():
             self.add_error_to_status(message, error_code, current_operation_override_for_error=Constants.INSTALLATION)
             self.set_installation_substatus_json(status=Constants.STATUS_ERROR)

--- a/src/core/src/service_interfaces/StatusHandler.py
+++ b/src/core/src/service_interfaces/StatusHandler.py
@@ -499,7 +499,7 @@ class StatusHandler(object):
         :param initial_load: If no status file exists AND initial_load is true, a default initial status file is created.
         :return: None
         """
-        
+
         # Initializing records safely
         self.__installation_substatus_json = None
         self.__installation_summary_json = None

--- a/src/core/tests/Test_CoreMain.py
+++ b/src/core/tests/Test_CoreMain.py
@@ -824,6 +824,75 @@ class TestCoreMain(unittest.TestCase):
         self.assertTrue(substatus_file_data[2]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         runtime.stop()
 
+    def test_assessment_superseded(self):
+        """Unit test for an assessment request that gets superseded by a newer operation..
+        Result: Assessment should terminate with a superseded error message."""
+        # Step 1: Run assessment normally to generate 0.status and ExtState.json
+        argument_composer = ArgumentComposer()
+        argument_composer.operation = Constants.ASSESSMENT
+        runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.ZYPPER)
+        runtime.set_legacy_test_type('HappyPath')
+        CoreMain(argument_composer.get_composed_arguments())
+
+        # check telemetry events
+        self.__check_telemetry_events(runtime)
+
+        # check status file
+        with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
+            substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
+        self.assertEqual(len(substatus_file_data), 2)
+        self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
+        self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[1]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
+        self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_SUCCESS.lower())
+
+        # Step 2: Update 1.status to transitioning and ExtState.json to different sequence number
+        scratch_path = os.path.join(os.path.curdir, "scratch")
+
+        # Set 1.status to Transitioning
+        with open(os.path.join(scratch_path, "1.status"), 'r+') as f:
+            status = json.load(f)
+            status[0]["status"]["status"] = "transitioning"
+            status[0]["status"]["substatus"][0]["status"] = "transitioning"
+            f.seek(0)  # rewind
+            json.dump(status, f)
+            f.truncate()
+            f.close()
+
+        # Step 3: Run Assessment again with sequence number 1 to automatically terminate and report operation superseded
+        argument_composer = ArgumentComposer()
+        argument_composer.operation = Constants.ASSESSMENT
+        runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.ZYPPER)
+        runtime.set_legacy_test_type('HappyPath')
+        # Set ExtState.json sequence number to 2 so this operation will be superseded
+        runtime.write_ext_state_file(runtime.lifecycle_manager.ext_state_file_path, "2",
+                                  datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                                  runtime.execution_config.operation)
+
+        # Should raise a SystemExit exception
+        raised_exit_exception = False
+        try:
+            CoreMain(argument_composer.get_composed_arguments())
+        except SystemExit as error:
+            raised_exit_exception = True
+
+        self.assertTrue(raised_exit_exception)
+
+        # check telemetry events
+        self.__check_telemetry_events(runtime)
+
+        # check status file
+        with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
+            substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
+        self.assertEqual(len(substatus_file_data), 2)
+        self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
+        self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_ERROR.lower())
+        self.assertTrue(substatus_file_data[1]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
+        self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(Constants.PatchOperationErrorCodes.NEWER_OPERATION_SUPERSEDED in substatus_file_data[0]["formattedMessage"]["message"])
+
+        runtime.stop()
+
     def __check_telemetry_events(self, runtime):
         all_events = os.listdir(runtime.telemetry_writer.events_folder_path)
         self.assertTrue(len(all_events) > 0)

--- a/src/core/tests/Test_StatusHandler.py
+++ b/src/core/tests/Test_StatusHandler.py
@@ -362,17 +362,17 @@ class TestStatusHandler(unittest.TestCase):
     def test_set_patch_metadata_for_healthstore_substatus_json_auto_assess_transitioning(self):
         self.runtime.execution_config.exec_auto_assess_only = True
         self.assertRaises(Exception,
-                          lambda: self.runtime.status_handler.set_patch_metadata_for_healthstore_substatus_json(status=Constants.STATUS_TRANSITIONING))
+                          lambda: self.runtime.status_handler.set_patch_metadata_for_healthstore_substatus_json())
 
     def test_set_configure_patching_substatus_json_auto_assess_transitioning(self):
         self.runtime.execution_config.exec_auto_assess_only = True
         self.assertRaises(Exception,
-                          lambda: self.runtime.status_handler.set_patch_metadata_for_healthstore_substatus_json(status=Constants.STATUS_TRANSITIONING))
+                          lambda: self.runtime.status_handler.set_configure_patching_substatus_json())
 
     def test_set_current_operation_auto_assess_non_assessment(self):
         self.runtime.execution_config.exec_auto_assess_only = True
         self.assertRaises(Exception,
-                          lambda: self.runtime.status_handler.set_current_operation(status=Constants.INSTALLATION))
+                          lambda: self.runtime.status_handler.set_current_operation(Constants.INSTALLATION))
 
 
 if __name__ == '__main__':

--- a/src/core/tests/Test_StatusHandler.py
+++ b/src/core/tests/Test_StatusHandler.py
@@ -349,6 +349,30 @@ class TestStatusHandler(unittest.TestCase):
         self.runtime.status_handler.set_installation_substatus_json()
         self.assertEqual(expected_maintenance_run_id, self.get_status_handler_substatus_maintenance_run_id())
 
+    def test_sequence_number_changed_termination_auto_assess_only(self):
+        self.runtime.execution_config.exec_auto_assess_only = True
+        self.runtime.status_handler.report_sequence_number_changed_termination()
+        with self.runtime.env_layer.file_system.open(self.runtime.execution_config.status_file_path, 'r') as file_handle:
+            substatus_file_data = json.load(file_handle)[0]["status"]["substatus"][0]
+            self.assertTrue(substatus_file_data["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
+            formatted_message = json.loads(substatus_file_data['formattedMessage']['message'])
+            self.assertTrue(formatted_message["errors"]["details"][0]["code"] == Constants.PatchOperationErrorCodes.NEWER_OPERATION_SUPERSEDED)
+
+    def test_set_patch_metadata_for_healthstore_substatus_json_auto_assess_transitioning(self):
+        self.runtime.execution_config.exec_auto_assess_only = True
+        self.assertRaises(Exception,
+                          lambda: self.runtime.status_handler.set_patch_metadata_for_healthstore_substatus_json(status=Constants.STATUS_TRANSITIONING))
+
+    def test_set_configure_patching_substatus_json_auto_assess_transitioning(self):
+        self.runtime.execution_config.exec_auto_assess_only = True
+        self.assertRaises(Exception,
+                          lambda: self.runtime.status_handler.set_patch_metadata_for_healthstore_substatus_json(status=Constants.STATUS_TRANSITIONING))
+
+    def test_set_current_operation_auto_assess_non_assessment(self):
+        self.runtime.execution_config.exec_auto_assess_only = True
+        self.assertRaises(Exception,
+                          lambda: self.runtime.status_handler.set_current_operation(status=Constants.INSTALLATION))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/core/tests/Test_StatusHandler.py
+++ b/src/core/tests/Test_StatusHandler.py
@@ -357,6 +357,7 @@ class TestStatusHandler(unittest.TestCase):
             self.assertTrue(substatus_file_data["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
             formatted_message = json.loads(substatus_file_data['formattedMessage']['message'])
             self.assertTrue(formatted_message["errors"]["details"][0]["code"] == Constants.PatchOperationErrorCodes.NEWER_OPERATION_SUPERSEDED)
+            self.assertEqual(formatted_message["startedBy"], Constants.PatchAssessmentSummaryStartedBy.PLATFORM)
 
     def test_set_patch_metadata_for_healthstore_substatus_json_auto_assess_transitioning(self):
         self.runtime.execution_config.exec_auto_assess_only = True


### PR DESCRIPTION
Extracted from #139 

Notes:
 - On these lines of StatusHandler:
```py
def set_patch_metadata_for_healthstore_substatus_json(self, status=Constants.STATUS_SUCCESS, code=0, patch_version=Constants.PATCH_VERSION_UNKNOWN, report_to_healthstore=False, wait_after_update=False):
        """ Prepare the healthstore substatus json including message containing summary to be sent to healthstore """
        if self.execution_config.exec_auto_assess_only:
```
```py
    def set_configure_patching_substatus_json(self, status=Constants.STATUS_TRANSITIONING, code=0,
                                              automatic_os_patch_state=Constants.AutomaticOSPatchStates.UNKNOWN,
                                              auto_assessment_state=Constants.AutoAssessmentStates.UNKNOWN):
        """ Prepare the configure patching substatus json including the message containing configure patching summary """
        if self.execution_config.exec_auto_assess_only:
```
it may be necessary to add `and status == Constants.STATUS_TRANSITIONING` to it in the future.

 - On these lines of StatusHandler:
```py
def report_sequence_number_changed_termination(self):
...
        elif current_operation == Constants.CONFIGURE_PATCHING.lower() or current_operation == Constants.CONFIGURE_PATCHING_AUTO_ASSESSMENT.lower():
            self.add_error_to_status(message, error_code, current_operation_override_for_error=Constants.CONFIGURE_PATCHING)
            self.add_error_to_status(message, error_code, current_operation_override_for_error=Constants.CONFIGURE_PATCHING_AUTO_ASSESSMENT)
            self.set_configure_patching_substatus_json(status=Constants.STATUS_ERROR)
```
they are flagged as not covered because Configure Patching does not currently call LifecycleManager to check if the current operation has been preempted. Configure Patching can be preempted by an Installation operation. These checks will be added in a future PR, and once they are added, the lines above can be added back since they will be hit by code and can be covered by tests.