### PR TITLE
Adding status file for non enable commands and catching early errors

### DIFF
--- a/src/extension/src/ActionHandler.py
+++ b/src/extension/src/ActionHandler.py
@@ -164,8 +164,9 @@ class ActionHandler(object):
         try:
             self.setup(action=Constants.INSTALL, log_message="Extension installation started")
             install_command_handler = InstallCommandHandler(self.logger, self.ext_env_handler)
+            exit_code_from_executing_install = install_command_handler.execute_handler_action()
             self.ext_output_status_handler.write_status_file("", self.seq_no, status=Constants.Status.Success.lower())
-            return install_command_handler.execute_handler_action()
+            return exit_code_from_executing_install
 
         except Exception as error:
             self.logger.log_error("Error occurred during extension install. [Error={0}]".format(repr(error)))

--- a/src/extension/src/ActionHandler.py
+++ b/src/extension/src/ActionHandler.py
@@ -94,7 +94,7 @@ class ActionHandler(object):
                 operation = config_settings.__getattribute__(Constants.ConfigPublicSettingsFields.operation)
 
             # create status file with basic status
-            self.ext_output_status_handler.write_status_file(operation, self.seq_no, message="Extension {0} in progress".format(str(action)))
+            self.ext_output_status_handler.write_status_file(operation, self.seq_no)
 
         except Exception as error:
             self.logger.log_error("Exception occurred while writing basic status. [Exception={0}]".format(repr(error)))
@@ -164,12 +164,12 @@ class ActionHandler(object):
         try:
             self.setup(action=Constants.INSTALL, log_message="Extension installation started")
             install_command_handler = InstallCommandHandler(self.logger, self.ext_env_handler)
+            self.ext_output_status_handler.write_status_file("", self.seq_no, status=Constants.Status.Success.lower())
             return install_command_handler.execute_handler_action()
 
         except Exception as error:
-            error_msg = "Error occurred during extension install. [Error={0}]".format(repr(error))
-            self.logger.log_error(error_msg)
-            self.ext_output_status_handler.add_error_to_message(self.seq_no, message=error_msg, error_code=Constants.PatchOperationErrorCodes.HANDLER_ACTION_FAILED)
+            self.logger.log_error("Error occurred during extension install. [Error={0}]".format(repr(error)))
+            self.ext_output_status_handler.write_status_file("", self.seq_no, status=Constants.Status.Error.lower(), message="Error occurred during extension install", code=Constants.ExitCode.HandlerFailed)
             return Constants.ExitCode.HandlerFailed
 
         finally:
@@ -200,7 +200,7 @@ class ActionHandler(object):
                 # b) after all artifacts from the preceding versions have been deleted
                 error_msg = "No earlier versions for the extension found on the machine. So, could not copy any references to the current version."
                 self.logger.log_error(error_msg)
-                self.ext_output_status_handler.add_error_to_message(self.seq_no, message=error_msg, error_code=Constants.PatchOperationErrorCodes.HANDLER_ACTION_FAILED)
+                self.ext_output_status_handler.write_status_file("", self.seq_no, status=Constants.Status.Error.lower(), message=error_msg, code=Constants.ExitCode.HandlerFailed)
                 return Constants.ExitCode.HandlerFailed
 
             # identify the version preceding current
@@ -211,7 +211,7 @@ class ActionHandler(object):
                 error_msg = "Could not find path where preceding extension version artifacts are stored. Hence, cannot copy the required artifacts to the latest version. "\
                             "[Preceding extension version path={0}]".format(str(preceding_version_path))
                 self.logger.log_error(error_msg)
-                self.ext_output_status_handler.add_error_to_message(self.seq_no, message=error_msg, error_code=Constants.PatchOperationErrorCodes.HANDLER_ACTION_FAILED)
+                self.ext_output_status_handler.write_status_file("", self.seq_no, status=Constants.Status.Error.lower(), message=error_msg, code=Constants.ExitCode.HandlerFailed)
                 return Constants.ExitCode.HandlerFailed
 
             self.logger.log("Preceding version path. [Path={0}]".format(str(preceding_version_path)))
@@ -220,12 +220,12 @@ class ActionHandler(object):
             self.copy_config_files(preceding_version_path, new_version_config_folder)
 
             self.logger.log("All update actions from extension handler completed.")
+            self.ext_output_status_handler.write_status_file("", self.seq_no, status=Constants.Status.Success.lower())
             return Constants.ExitCode.Okay
 
         except Exception as error:
-            error_msg = "Error occurred during extension update. [Error={0}]".format(repr(error))
-            self.logger.log_error(error_msg)
-            self.ext_output_status_handler.add_error_to_message(self.seq_no, message=error_msg, error_code=Constants.PatchOperationErrorCodes.HANDLER_ACTION_FAILED)
+            self.logger.log_error("Error occurred during extension update. [Error={0}]".format(repr(error)))
+            self.ext_output_status_handler.write_status_file("", self.seq_no, status=Constants.Status.Error.lower(), message="Error occurred during extension update", code=Constants.ExitCode.HandlerFailed)
             return Constants.ExitCode.HandlerFailed
 
         finally:
@@ -274,12 +274,12 @@ class ActionHandler(object):
     def uninstall(self):
         try:
             self.setup(action=Constants.UNINSTALL, log_message="Extension uninstalled")
+            self.ext_output_status_handler.write_status_file("", self.seq_no, status=Constants.Status.Success.lower())
             return Constants.ExitCode.Okay
 
         except Exception as error:
-            error_msg = "Error occurred during extension uninstall. [Error={0}]".format(repr(error))
-            self.logger.log_error(error_msg)
-            self.ext_output_status_handler.add_error_to_message(self.seq_no, message=error_msg, error_code=Constants.PatchOperationErrorCodes.HANDLER_ACTION_FAILED)
+            self.logger.log_error("Error occurred during extension uninstall. [Error={0}]".format(repr(error)))
+            self.ext_output_status_handler.write_status_file("", self.seq_no, status=Constants.Status.Error.lower(), message="Error occurred during extension uninstall", code=Constants.ExitCode.HandlerFailed)
             return Constants.ExitCode.HandlerFailed
 
         finally:
@@ -293,9 +293,8 @@ class ActionHandler(object):
             return Constants.ExitCode.Okay if exit_code_returned_from_executing_enable is None else exit_code_returned_from_executing_enable
 
         except Exception as error:
-            error_msg = "Error occurred during extension enable. [Error={0}]".format(repr(error))
-            self.logger.log_error(error_msg)
-            self.ext_output_status_handler.add_error_to_message(self.seq_no, message=error_msg, error_code=Constants.PatchOperationErrorCodes.HANDLER_ACTION_FAILED)
+            self.logger.log_error("Error occurred during extension enable. [Error={0}]".format(repr(error)))
+            self.ext_output_status_handler.write_status_file("", self.seq_no, status=Constants.Status.Error.lower(), message="Error occurred during extension enable", code=Constants.ExitCode.HandlerFailed)
             return Constants.ExitCode.HandlerFailed
         finally:
             self.tear_down()
@@ -325,12 +324,12 @@ class ActionHandler(object):
             # End of temporary auto-assessment disablement
 
             self.logger.log("Extension disabled successfully")
+            self.ext_output_status_handler.write_status_file("", self.seq_no, status=Constants.Status.Success.lower())
             return Constants.ExitCode.Okay
 
         except Exception as error:
-            error_msg = "Error occurred during extension disable. [Error={0}]".format(repr(error))
-            self.logger.log_error(error_msg)
-            self.ext_output_status_handler.add_error_to_message(self.seq_no, message=error_msg, error_code=Constants.PatchOperationErrorCodes.HANDLER_ACTION_FAILED)
+            self.logger.log_error("Error occurred during extension disable. [Error={0}]".format(repr(error)))
+            self.ext_output_status_handler.write_status_file("", self.seq_no, status=Constants.Status.Error.lower(), message="Error occurred during extension disable", code=Constants.ExitCode.HandlerFailed)
             return Constants.ExitCode.HandlerFailed
         finally:
             self.tear_down()
@@ -340,12 +339,12 @@ class ActionHandler(object):
             self.setup(action=Constants.RESET, log_message="Reset triggered on extension, deleting CoreState and ExtState files")
             self.utility.delete_file(self.core_state_handler.dir_path, self.core_state_handler.file, raise_if_not_found=False)
             self.utility.delete_file(self.ext_state_handler.dir_path, self.ext_state_handler.file, raise_if_not_found=False)
+            self.ext_output_status_handler.write_status_file("", self.seq_no, status=Constants.Status.Success.lower())
             return Constants.ExitCode.Okay
 
         except Exception as error:
-            error_msg = "Error occurred during extension reset. [Error={0}]".format(repr(error))
-            self.logger.log_error(error_msg)
-            self.ext_output_status_handler.add_error_to_message(self.seq_no, message=error_msg, error_code=Constants.PatchOperationErrorCodes.HANDLER_ACTION_FAILED)
+            self.logger.log_error("Error occurred during extension reset. [Error={0}]".format(repr(error)))
+            self.ext_output_status_handler.write_status_file("", self.seq_no, status=Constants.Status.Error.lower(), message="Error occurred during extension reset", code=Constants.ExitCode.HandlerFailed)
             return Constants.ExitCode.HandlerFailed
         finally:
             self.tear_down()

--- a/src/extension/src/ActionHandler.py
+++ b/src/extension/src/ActionHandler.py
@@ -65,10 +65,23 @@ class ActionHandler(object):
             raise e
 
     def setup(self, action, log_message):
-        self.setup_file_logger(action)
-        self.setup_telemetry()
-        self.logger.log(log_message)
-        self.write_basic_status(action)
+        try:
+            self.setup_file_logger(action)
+            self.validate_sudo()  # Validating sudo as early as possible and before it's use in setup_telemetry
+            self.setup_telemetry()
+            self.logger.log(log_message)
+        except Exception:
+            raise
+        finally:
+            self.write_basic_status(action)
+
+    def validate_sudo(self):
+        # Disable tty for sudo access, if required
+        self.env_health_manager.ensure_tty_not_required()
+
+        # Ensure sudo works in the environment
+        sudo_check_result = self.env_health_manager.check_sudo_status()
+        self.logger.log_debug("Sudo status check: " + str(sudo_check_result) + "\n")
 
     def write_basic_status(self, action):
         """ Writes a basic status file if one for the same sequence number does not exist """
@@ -165,7 +178,10 @@ class ActionHandler(object):
             self.setup(action=Constants.INSTALL, log_message="Extension installation started")
             install_command_handler = InstallCommandHandler(self.logger, self.ext_env_handler)
             exit_code_from_executing_install = install_command_handler.execute_handler_action()
-            self.ext_output_status_handler.write_status_file("", self.seq_no, status=Constants.Status.Success.lower())
+            if exit_code_from_executing_install == Constants.ExitCode.Okay or exit_code_from_executing_install is None:
+                self.ext_output_status_handler.write_status_file("", self.seq_no, status=Constants.Status.Success.lower())
+            else:
+                self.ext_output_status_handler.write_status_file("", self.seq_no, status=Constants.Status.Error.lower(), message="Error occurred during extension install", code=exit_code_from_executing_install)
             return exit_code_from_executing_install
 
         except Exception as error:
@@ -291,6 +307,8 @@ class ActionHandler(object):
             self.setup(action=Constants.ENABLE, log_message="Enable triggered on extension")
             enable_command_handler = EnableCommandHandler(self.logger, self.telemetry_writer, self.utility, self.env_health_manager, self.runtime_context_handler, self.ext_env_handler, self.ext_config_settings_handler, self.core_state_handler, self.ext_state_handler, self.ext_output_status_handler, self.process_handler, self.cmd_exec_start_time)
             exit_code_returned_from_executing_enable = enable_command_handler.execute_handler_action()
+            if exit_code_returned_from_executing_enable is not None and exit_code_returned_from_executing_enable != Constants.ExitCode.Okay:
+                self.ext_output_status_handler.write_status_file("", self.seq_no, status=Constants.Status.Error.lower(), message="Error occurred during extension enable", code=exit_code_returned_from_executing_enable)
             return Constants.ExitCode.Okay if exit_code_returned_from_executing_enable is None else exit_code_returned_from_executing_enable
 
         except Exception as error:

--- a/src/extension/src/Constants.py
+++ b/src/extension/src/Constants.py
@@ -204,16 +204,16 @@ class Constants(object):
         UnsupportedOperatingSystem = 51
         MissingDependency = 52
         ConfigurationError = 53
-        BadHandlerEnvironmentFile = 54
-        UnableToReadStatusFile = 55
-        CreateFileLoggerFailure = 56
-        ReadingAndDeserializingConfigFileFailure = 57
-        InvalidConfigSettingPropertyValue = 58
-        CreateLoggerFailure = 59
-        CreateStatusWriterFailure = 60
-        HandlerFailed = 61
-        MissingConfig = 62
-        OperationNotSupported = 64
+        BadHandlerEnvironmentFile = 81
+        UnableToReadStatusFile = 82
+        CreateFileLoggerFailure = 83
+        ReadingAndDeserializingConfigFileFailure = 84
+        InvalidConfigSettingPropertyValue = 85
+        CreateLoggerFailure = 86
+        CreateStatusWriterFailure = 87
+        HandlerFailed = 88
+        MissingConfig = 89
+        OperationNotSupported = 90
 
     class AgentEnvVarStatusCode(EnumBackport):
         AGENT_ENABLED = "AGENT_ENABLED"

--- a/src/extension/src/Constants.py
+++ b/src/extension/src/Constants.py
@@ -124,9 +124,6 @@ class Constants(object):
         PACKAGE_MANAGER_FAILURE = "PACKAGE_MANAGER_FAILURE"
         OPERATION_FAILED = "OPERATION_FAILED"
         DEFAULT_ERROR = "ERROR"  # default error code
-        SEQUENCE_NUMBER_NOT_FOUND = "SEQUENCE_NUMBER_NOT_FOUND"
-        OPERATION_NOT_SUPPORTED = "OPERATION_NOT_SUPPORTED"
-        HANDLER_ACTION_FAILED = "HANDLER_ACTION_FAILED"
 
     ERROR_ADDED_TO_STATUS = "Error_added_to_status"
     PYTHON_NOT_FOUND = "Python version could not be discovered for core invocation."
@@ -204,19 +201,20 @@ class Constants(object):
 
     class ExitCode(EnumBackport):
         Okay = 0
-        HandlerFailed = -1
-        MissingConfig = -2
-        BadConfig = -3
         UnsupportedOperatingSystem = 51
         MissingDependency = 52
         ConfigurationError = 53
-        BadHandlerEnvironmentFile = 3560
-        UnableToReadStatusFile = 3561
-        CreateFileLoggerFailure = 3562
-        ReadingAndDeserializingConfigFileFailure = 3563
-        InvalidConfigSettingPropertyValue = 3564
-        CreateLoggerFailure = 3565
-        CreateStatusWriterFailure = 3566
+        BadHandlerEnvironmentFile = 54
+        UnableToReadStatusFile = 55
+        CreateFileLoggerFailure = 56
+        ReadingAndDeserializingConfigFileFailure = 57
+        InvalidConfigSettingPropertyValue = 58
+        CreateLoggerFailure = 59
+        CreateStatusWriterFailure = 60
+        HandlerFailed = 61
+        MissingConfig = 62
+        BadConfig = 63
+        OperationNotSupported = 64
 
     class AgentEnvVarStatusCode(EnumBackport):
         AGENT_ENABLED = "AGENT_ENABLED"

--- a/src/extension/src/Constants.py
+++ b/src/extension/src/Constants.py
@@ -213,7 +213,6 @@ class Constants(object):
         CreateStatusWriterFailure = 60
         HandlerFailed = 61
         MissingConfig = 62
-        BadConfig = 63
         OperationNotSupported = 64
 
     class AgentEnvVarStatusCode(EnumBackport):

--- a/src/extension/src/Constants.py
+++ b/src/extension/src/Constants.py
@@ -124,6 +124,9 @@ class Constants(object):
         PACKAGE_MANAGER_FAILURE = "PACKAGE_MANAGER_FAILURE"
         OPERATION_FAILED = "OPERATION_FAILED"
         DEFAULT_ERROR = "ERROR"  # default error code
+        SEQUENCE_NUMBER_NOT_FOUND = "SEQUENCE_NUMBER_NOT_FOUND"
+        OPERATION_NOT_SUPPORTED = "OPERATION_NOT_SUPPORTED"
+        HANDLER_ACTION_FAILED = "HANDLER_ACTION_FAILED"
 
     ERROR_ADDED_TO_STATUS = "Error_added_to_status"
     PYTHON_NOT_FOUND = "Python version could not be discovered for core invocation."

--- a/src/extension/src/EnableCommandHandler.py
+++ b/src/extension/src/EnableCommandHandler.py
@@ -41,18 +41,11 @@ class EnableCommandHandler(object):
     def execute_handler_action(self):
         """ Responsible for taking appropriate action for enable command as per the request sent in Handler Configuration file by user """
         try:
-            # Disable tty for sudo access, if required
-            self.env_health_manager.ensure_tty_not_required()
-
-            # Ensure sudo works in the environment
-            sudo_check_result = self.env_health_manager.check_sudo_status()
-            self.logger.log_debug("Sudo status check: " + str(sudo_check_result) + "\n")
-
             # fetch seq_no
             self.seq_no = self.ext_config_settings_handler.get_seq_no(is_enable_request=True)
             if self.seq_no is None:
                 self.logger.log_error("Sequence number for current operation not found")
-                exit(Constants.ExitCode.MissingConfig)
+                return Constants.ExitCode.MissingConfig
 
             # read status file, to load any preserve existing context
             self.ext_output_status_handler.read_file(self.seq_no)

--- a/src/extension/src/EnableCommandHandler.py
+++ b/src/extension/src/EnableCommandHandler.py
@@ -68,8 +68,8 @@ class EnableCommandHandler(object):
             # Allow only certain operations
             if operation not in [Constants.NOOPERATION, Constants.ASSESSMENT, Constants.INSTALLATION, Constants.CONFIGURE_PATCHING]:
                 self.logger.log_error("Requested operation is not supported by the extension")
-                self.ext_output_status_handler.add_error_to_message(self.seq_no, message="Requested operation {0} is not supported by the extension".format(str(operation)), error_code=Constants.PatchOperationErrorCodes.OPERATION_NOT_SUPPORTED)
-                exit(Constants.ExitCode.InvalidConfigSettingPropertyValue)
+                self.ext_output_status_handler.write_status_file(operation, self.seq_no, status=Constants.Status.Error.lower(), message="Requested operation {0} is not supported by the extension".format(str(operation)), code=Constants.ExitCode.OperationNotSupported)
+                exit(Constants.ExitCode.OperationNotSupported)
 
             prev_patch_max_end_time = self.cmd_exec_start_time + datetime.timedelta(hours=0, minutes=Constants.ENABLE_MAX_RUNTIME)
             self.ext_state_handler.create_file(self.seq_no, operation, prev_patch_max_end_time)
@@ -124,11 +124,7 @@ class EnableCommandHandler(object):
         """ Creates <sequence number>.status to report the current request's status and launches core code to handle the requested operation """
         # create Status file
         if create_status_output_file:
-            self.ext_output_status_handler.write_status_file(
-                config_settings.__getattribute__(self.config_public_settings.operation),
-                self.seq_no,
-                status=self.status.Transitioning.lower(),
-                message="Extension enable in progress")
+            self.ext_output_status_handler.write_status_file(config_settings.__getattribute__(self.config_public_settings.operation), self.seq_no, status=self.status.Transitioning.lower())
         else:
             self.ext_output_status_handler.update_file(self.seq_no)
         # launch core code in a process and exit extension handler

--- a/src/extension/src/EnableCommandHandler.py
+++ b/src/extension/src/EnableCommandHandler.py
@@ -45,7 +45,7 @@ class EnableCommandHandler(object):
             self.seq_no = self.ext_config_settings_handler.get_seq_no(is_enable_request=True)
             if self.seq_no is None:
                 self.logger.log_error("Sequence number for current operation not found")
-                return Constants.ExitCode.MissingConfig
+                exit(Constants.ExitCode.MissingConfig)
 
             # read status file, to load any preserve existing context
             self.ext_output_status_handler.read_file(self.seq_no)

--- a/src/extension/src/EnableCommandHandler.py
+++ b/src/extension/src/EnableCommandHandler.py
@@ -68,6 +68,7 @@ class EnableCommandHandler(object):
             # Allow only certain operations
             if operation not in [Constants.NOOPERATION, Constants.ASSESSMENT, Constants.INSTALLATION, Constants.CONFIGURE_PATCHING]:
                 self.logger.log_error("Requested operation is not supported by the extension")
+                self.ext_output_status_handler.add_error_to_message(self.seq_no, message="Requested operation {0} is not supported by the extension".format(str(operation)), error_code=Constants.PatchOperationErrorCodes.OPERATION_NOT_SUPPORTED)
                 exit(Constants.ExitCode.InvalidConfigSettingPropertyValue)
 
             prev_patch_max_end_time = self.cmd_exec_start_time + datetime.timedelta(hours=0, minutes=Constants.ENABLE_MAX_RUNTIME)
@@ -123,9 +124,13 @@ class EnableCommandHandler(object):
         """ Creates <sequence number>.status to report the current request's status and launches core code to handle the requested operation """
         # create Status file
         if create_status_output_file:
-            self.ext_output_status_handler.write_status_file(config_settings.__getattribute__(self.config_public_settings.operation), self.seq_no, status=self.status.Transitioning.lower())
+            self.ext_output_status_handler.write_status_file(
+                config_settings.__getattribute__(self.config_public_settings.operation),
+                self.seq_no,
+                status=self.status.Transitioning.lower(),
+                message="Extension enable in progress")
         else:
-            self.ext_output_status_handler.update_file(self.seq_no, self.ext_env_handler.status_folder)
+            self.ext_output_status_handler.update_file(self.seq_no)
         # launch core code in a process and exit extension handler
         process = self.process_handler.start_daemon(self.seq_no, config_settings, self.ext_env_handler)
         self.logger.log("exiting extension handler")

--- a/src/extension/src/__main__.py
+++ b/src/extension/src/__main__.py
@@ -71,7 +71,6 @@ def main(argv):
             raise Exception(error_msg)
     except Exception as error:
         logger.log_error(repr(error))
-        # may come here
         exit_code = Constants.ExitCode.HandlerFailed
     finally:
         if stdout_file_mirror is not None:

--- a/src/extension/src/__main__.py
+++ b/src/extension/src/__main__.py
@@ -41,6 +41,7 @@ def main(argv):
     logger = Logger()
     telemetry_writer = TelemetryWriter(logger, env_layer)
     logger.telemetry_writer = telemetry_writer  # Need to set telemetry_writer within logger to enable sending all logs to telemetry
+    exit_code = None
     try:
         # initializing action handler
         # args will have values install, uninstall, etc, as given in MsftLinuxPatchExtShim.sh in the operation var
@@ -62,19 +63,22 @@ def main(argv):
             ext_output_status_handler = ExtOutputStatusHandler(logger, utility, json_file_handler, ext_env_handler.status_folder)
             process_handler = ProcessHandler(logger, env_layer, ext_output_status_handler)
             action_handler = ActionHandler(logger, env_layer, telemetry_writer, utility, runtime_context_handler, json_file_handler, env_health_manager, ext_env_handler, ext_config_settings_handler, core_state_handler, ext_state_handler, ext_output_status_handler, process_handler, cmd_exec_start_time)
-            action_handler.determine_operation(argv[1])
+            exit_code_from_handler_actions = action_handler.determine_operation(argv[1])
+            exit_code = Constants.ExitCode.Okay if exit_code_from_handler_actions is None else exit_code_from_handler_actions
         else:
             error_cause = "No configuration provided in HandlerEnvironment" if ext_env_handler.handler_environment_json is None else "Path to config folder not specified in HandlerEnvironment"
             error_msg = "Error processing file. [File={0}] [Error={1}]".format(Constants.HANDLER_ENVIRONMENT_FILE, error_cause)
             raise Exception(error_msg)
     except Exception as error:
         logger.log_error(repr(error))
-        return Constants.ExitCode.HandlerFailed
+        # may come here
+        exit_code = Constants.ExitCode.HandlerFailed
     finally:
         if stdout_file_mirror is not None:
             stdout_file_mirror.stop()
         if file_logger is not None:
             file_logger.close()
+    exit(exit_code)
 
 
 if __name__ == '__main__':

--- a/src/extension/src/file_handlers/ExtOutputStatusHandler.py
+++ b/src/extension/src/file_handlers/ExtOutputStatusHandler.py
@@ -62,17 +62,17 @@ class ExtOutputStatusHandler(object):
         #ToDo: move it to some other location, since seq no is not available at load
         # self.read_file()
 
-    def write_status_file(self, operation, seq_no, status=Constants.Status.Transitioning.lower(), message=""):
+    def write_status_file(self, operation, seq_no, status=Constants.Status.Transitioning.lower(), message="", code=0):
         self.logger.log("Writing status file to provide patch management data for [Sequence={0}]".format(str(seq_no)))
         file_name = self.__get_status_file_name(seq_no)
-        status_file_payload = self.__new_basic_status_json(operation, status, message)
+        status_file_payload = self.__new_basic_status_json(operation, status, message, code)
 
         if self.__nooperation_substatus_json is not None:
             status_file_payload['status']['substatus'].append(self.__nooperation_substatus_json)
 
         self.json_file_handler.write_to_json_file(self.__dir_path, file_name, [status_file_payload])
 
-    def __new_basic_status_json(self, operation, status, message=""):
+    def __new_basic_status_json(self, operation, status, message="", code=0):
         return {
             self.file_keys.version: 1.0,
             self.file_keys.timestamp_utc: str(self.utility.get_str_from_datetime(datetime.datetime.utcnow())),
@@ -80,10 +80,10 @@ class ExtOutputStatusHandler(object):
                 self.file_keys.status_name: "Azure Patch Management",
                 self.file_keys.status_operation: str(operation),
                 self.file_keys.status_status: status.lower(),
-                self.file_keys.status_code: 0,
+                self.file_keys.status_code: code,
                 self.file_keys.status_formatted_message: {
                     self.file_keys.status_formatted_message_lang: "en-US",
-                    self.file_keys.status_formatted_message_message: str(message)
+                    self.file_keys.status_formatted_message_message: str(self.__ensure_error_message_restriction_compliance(message))
                 },
                 self.file_keys.status_substatus: []
             }
@@ -210,30 +210,6 @@ class ExtOutputStatusHandler(object):
                 self.__nooperation_total_error_count += 1
         else:
             return
-
-    def add_error_to_message(self, seq_no, message, error_code=Constants.PatchOperationErrorCodes.DEFAULT_ERROR):
-        """ Add error to the top level status blob, outside of substatus list
-        i.e. [{
-            "version": 1.0,
-            "timestampUTC": "2019-07-20T12:12:14Z",
-            "status": {
-                "name": "Azure Patch Management",
-                "operation": "",
-                "status": "Error",
-                "code": <error_code>,
-                "formattedMessage": {
-                    "lang": "en-US",
-                    "message": "<message>"
-                }
-            }
-        }] """
-        try:
-            self.logger.log("Updating status file if it exists with values [seq_no={0}] [message={1}] [error_code={2}] [status={3}]".format(str(seq_no), str(message), str(error_code), str(Constants.Status.Error)))
-            formatted_message = self.__ensure_error_message_restriction_compliance(message)
-            self.update_file(seq_no, status=Constants.Status.Error, code=error_code, message=formatted_message)
-        except Exception as error:
-            error_msg = "Error occurred during updating status file. [Error={0}]".format(repr(error))
-            self.logger.log_error(error_msg)
 
     @staticmethod
     def __ensure_error_message_restriction_compliance(full_message):

--- a/src/extension/src/file_handlers/ExtOutputStatusHandler.py
+++ b/src/extension/src/file_handlers/ExtOutputStatusHandler.py
@@ -63,6 +63,10 @@ class ExtOutputStatusHandler(object):
         # self.read_file()
 
     def write_status_file(self, operation, seq_no, status=Constants.Status.Transitioning.lower(), message="", code=Constants.ExitCode.Okay):
+        if seq_no is None:
+            self.logger.log_error("Cannot write status file since sequence number is not available. [Sequence={0}]".format(str(seq_no)))
+            return
+
         self.logger.log("Writing status file to provide patch management data for [Sequence={0}]".format(str(seq_no)))
         file_name = self.__get_status_file_name(seq_no)
         status_file_payload = self.__new_basic_status_json(operation, status, message, code)

--- a/src/extension/src/file_handlers/ExtOutputStatusHandler.py
+++ b/src/extension/src/file_handlers/ExtOutputStatusHandler.py
@@ -62,7 +62,7 @@ class ExtOutputStatusHandler(object):
         #ToDo: move it to some other location, since seq no is not available at load
         # self.read_file()
 
-    def write_status_file(self, operation, seq_no, status=Constants.Status.Transitioning.lower(), message="", code=0):
+    def write_status_file(self, operation, seq_no, status=Constants.Status.Transitioning.lower(), message="", code=Constants.ExitCode.Okay):
         self.logger.log("Writing status file to provide patch management data for [Sequence={0}]".format(str(seq_no)))
         file_name = self.__get_status_file_name(seq_no)
         status_file_payload = self.__new_basic_status_json(operation, status, message, code)
@@ -72,7 +72,7 @@ class ExtOutputStatusHandler(object):
 
         self.json_file_handler.write_to_json_file(self.__dir_path, file_name, [status_file_payload])
 
-    def __new_basic_status_json(self, operation, status, message="", code=0):
+    def __new_basic_status_json(self, operation, status, message="", code=Constants.ExitCode.Okay):
         return {
             self.file_keys.version: 1.0,
             self.file_keys.timestamp_utc: str(self.utility.get_str_from_datetime(datetime.datetime.utcnow())),
@@ -124,7 +124,7 @@ class ExtOutputStatusHandler(object):
                 else:
                     self.logger.log_error("Error updating config value in status file. [Config={0}]".format(key))
 
-    def update_file(self, seq_no, status=Constants.Status.Transitioning.lower(), code=0, message=""):
+    def update_file(self, seq_no, status=Constants.Status.Transitioning.lower(), code=Constants.ExitCode.Okay, message=""):
         """ Reseting status, code and message with latest timestamp, while retaining all other values"""
         try:
             file_name = self.__get_status_file_name(seq_no)
@@ -147,7 +147,7 @@ class ExtOutputStatusHandler(object):
     def __get_status_file_name(self, seq_no):
         return str(seq_no) + self.file_ext
 
-    def set_nooperation_substatus_json(self, operation, activity_id, start_time, seq_no, status=Constants.Status.Transitioning, code=0):
+    def set_nooperation_substatus_json(self, operation, activity_id, start_time, seq_no, status=Constants.Status.Transitioning, code=Constants.ExitCode.Okay):
         """ Prepare the nooperation substatus json including the message containing nooperation summary """
         # Wrap patches into nooperation summary
         self.__nooperation_summary_json = self.new_nooperation_summary_json(activity_id, start_time)
@@ -169,7 +169,7 @@ class ExtOutputStatusHandler(object):
         }
 
     @staticmethod
-    def new_substatus_json_for_operation(operation_name, status="Transitioning", code=0, message=json.dumps("{}")):
+    def new_substatus_json_for_operation(operation_name, status="Transitioning", code=Constants.ExitCode.Okay, message=json.dumps("{}")):
         """ Generic substatus for nooperation """
         # NOTE: Todo Function is same for assessment and install, can be generalized later
         return {

--- a/src/extension/tests/Test_ActionHandler.py
+++ b/src/extension/tests/Test_ActionHandler.py
@@ -339,29 +339,66 @@ class TestActionHandler(unittest.TestCase):
                 self.assertEqual(events[0]["OperationId"], self.action_handler.operation_id_substitute_for_all_actions_in_telemetry)
 
     def test_write_basic_status_uninstall(self):
-        """ Check that a basic status file is NOT written during uninstall handler command setup """
+        """ Validate a basic status file is written if seq no exists in env var """
+        # no status file if seq no not found
         self.action_handler.uninstall()
         self.assertFalse(os.path.exists(os.path.join(self.ext_env_handler.status_folder, '1234.status')))
 
+        # status file will be written if seq no is found
+        self.action_handler.seq_no = 1234
+        self.action_handler.uninstall()
+        self.assertTrue(os.path.exists(os.path.join(self.ext_env_handler.status_folder, '1234.status')))
+        status_json = self.action_handler.ext_output_status_handler.read_file(self.action_handler.seq_no)
+        self.assertEquals(status_json[0]["status"]["name"], "Azure Patch Management")
+        self.assertEquals(status_json[0]["status"]["operation"], "")
+        self.assertEquals(status_json[0]["status"]["status"], Constants.Status.Transitioning.lower())
+        self.assertEquals(status_json[0]["status"]["code"], 0)
+        self.assertEquals(status_json[0]["status"]["formattedMessage"]["message"], "Extension {0} in progress".format(str(Constants.UNINSTALL)))
+        self.assertEquals(status_json[0]["status"]["substatus"], [])
+
     def test_write_basic_status_install(self):
-        """ Check that a basic status file is NOT written during install handler command setup """
+        """ Validate a basic status file is written if seq no exists in env var """
+        # no status file if seq no not found
         self.action_handler.install()
         self.assertFalse(os.path.exists(os.path.join(self.ext_env_handler.status_folder, '1234.status')))
 
+        # status file will be written if seq no is found
+        self.action_handler.seq_no = 1234
+        self.action_handler.install()
+        self.assertTrue(os.path.exists(os.path.join(self.ext_env_handler.status_folder, '1234.status')))
+
     def test_write_basic_status_update(self):
-        """ Check that a basic status file is NOT written during update handler command setup """
+        """ Validate a basic status file is written if seq no exists in env var """
+        # no status file if seq no not found
         self.action_handler.update()
         self.assertFalse(os.path.exists(os.path.join(self.ext_env_handler.status_folder, '1234.status')))
 
+        # status file will be written if seq no is found
+        self.action_handler.seq_no = 1234
+        self.action_handler.update()
+        self.assertTrue(os.path.exists(os.path.join(self.ext_env_handler.status_folder, '1234.status')))
+
     def test_write_basic_status_disable(self):
-        """ Check that a basic status file is NOT written during disable handler command setup """
+        """ Validate a basic status file is written if seq no exists in env var """
+        # no status file if seq no not found
         self.action_handler.disable()
         self.assertFalse(os.path.exists(os.path.join(self.ext_env_handler.status_folder, '1234.status')))
 
+        # status file will be written if seq no is found
+        self.action_handler.seq_no = 1234
+        self.action_handler.disable()
+        self.assertTrue(os.path.exists(os.path.join(self.ext_env_handler.status_folder, '1234.status')))
+
     def test_write_basic_status_reset(self):
-        """ Check that a basic status file is NOT written during reset handler command setup """
+        """ Validate a basic status file is written if seq no exists in env var """
+        # no status file if seq no not found
         self.action_handler.reset()
         self.assertFalse(os.path.exists(os.path.join(self.ext_env_handler.status_folder, '1234.status')))
+
+        # status file will be written if seq no is found
+        self.action_handler.seq_no = 1234
+        self.action_handler.reset()
+        self.assertTrue(os.path.exists(os.path.join(self.ext_env_handler.status_folder, '1234.status')))
 
     def test_write_basic_status_enable(self):
         """ Check that a basic status file is written during enable handler command setup """

--- a/src/extension/tests/Test_EnableCommandHandler.py
+++ b/src/extension/tests/Test_EnableCommandHandler.py
@@ -182,7 +182,7 @@ class TestEnableCommandHandler(unittest.TestCase):
         enable_command_handler = EnableCommandHandler(self.logger, self.telemetry_writer, self.utility, self.env_health_manager, self.runtime_context_handler, self.ext_env_handler, self.ext_config_settings_handler, self.core_state_handler, self.ext_state_handler, self.ext_output_status_handler, self.process_handler, datetime.utcnow())
         with self.assertRaises(SystemExit) as sys_exit:
             enable_command_handler.execute_handler_action()
-        self.assertEqual(sys_exit.exception.code, Constants.ExitCode.InvalidConfigSettingPropertyValue)
+        self.assertEqual(sys_exit.exception.code, Constants.ExitCode.OperationNotSupported)
 
     def test_enable_command_with_telemetry(self):
         # testing enable action's response with telemetry. Should writes .json events at the location specified in HandlerEnvironment.json

--- a/src/extension/tests/Test_ExtOutputStatusHandler.py
+++ b/src/extension/tests/Test_ExtOutputStatusHandler.py
@@ -81,12 +81,12 @@ class TestExtOutputStatusHandler(unittest.TestCase):
         stat_file_name = os.stat(os.path.join(dir_path, file_name + ".status"))
         prev_modified_time = stat_file_name.st_mtime
 
-        ext_status_handler.update_file("test1", dir_path)
+        ext_status_handler.update_file("test1")
         stat_file_name = os.stat(os.path.join(dir_path, file_name + ".status"))
         modified_time = stat_file_name.st_mtime
         self.assertEqual(prev_modified_time, modified_time)
 
-        ext_status_handler.update_file(file_name, dir_path)
+        ext_status_handler.update_file(file_name)
         stat_file_name = os.stat(os.path.join(dir_path, file_name + ".status"))
         modified_time = stat_file_name.st_mtime
         self.assertNotEqual(prev_modified_time, modified_time)


### PR DESCRIPTION
Changes included:

- Adds status file for non enable commands during their initial setup with basic details
- For any terminal errors, if the seq no is available, updates status file with error status as following:
   [{
            "version": 1.0,
            "timestampUTC": "2019-07-20T12:12:14Z",
            "status": {
                "name": "Azure Patch Management",
                "operation": "",
                "status": "Error",
                "code": <error_code>,
                "formattedMessage": {
                    "lang": "en-US",
                    "message": "<message>"
                }
            }
        }]