### PR TITLE
Only handle Zypper repeat exit code in one place

### DIFF
--- a/src/core/src/package_managers/ZypperPackageManager.py
+++ b/src/core/src/package_managers/ZypperPackageManager.py
@@ -176,7 +176,7 @@ class ZypperPackageManager(PackageManager):
 
         if code == self.zypper_exitcode_zypper_updated or self.zypper_out_zypper_updated_msg in out:
             self.composite_logger.log_debug(
-                "One of the installed patches affects the package manager itself. Patch installation run will be repeated.")
+                " - One of the installed patches affects the package manager itself. Patch installation run will be repeated.")
             self.set_package_manager_setting(Constants.PACKAGE_MGR_SETTING_REPEAT_PATCH_OPERATION, True)
         elif code == self.zypper_exitcode_reboot_required:
             self.composite_logger.log_warning(

--- a/src/core/src/package_managers/ZypperPackageManager.py
+++ b/src/core/src/package_managers/ZypperPackageManager.py
@@ -170,7 +170,7 @@ class ZypperPackageManager(PackageManager):
             Does not repeat installation or reboot if it is a dry run. """
         if "--dry-run" in command:
             self.composite_logger.log_debug(
-                "Exit code {0} detected from command \"{1}\", but it was a dry run. Continuing execution without performing additional actions.".format(
+                " - Exit code {0} detected from command \"{1}\", but it was a dry run. Continuing execution without performing additional actions.".format(
                 str(code), command))
             return
 
@@ -180,7 +180,7 @@ class ZypperPackageManager(PackageManager):
             self.set_package_manager_setting(Constants.PACKAGE_MGR_SETTING_REPEAT_PATCH_OPERATION, True)
         elif code == self.zypper_exitcode_reboot_required:
             self.composite_logger.log_warning(
-                "Machine requires reboot after patch installation. Setting force_reboot flag to True.")
+                " - Machine requires reboot after patch installation. Setting force_reboot flag to True.")
             self.force_reboot = True
 
     def modify_upgrade_or_patch_command_to_replacefiles(self, command):

--- a/src/core/src/package_managers/ZypperPackageManager.py
+++ b/src/core/src/package_managers/ZypperPackageManager.py
@@ -161,8 +161,7 @@ class ZypperPackageManager(PackageManager):
             else:  # verbose diagnostic log
                 self.log_success_on_invoke(code, out)
 
-            if code == self.zypper_exitcode_zypper_updated or code == self.zypper_exitcode_reboot_required:
-                self.__handle_zypper_updated_or_reboot_exit_codes(command, out, code)
+            self.__handle_zypper_updated_or_reboot_exit_codes(command, out, code)
 
             return out
 
@@ -171,13 +170,13 @@ class ZypperPackageManager(PackageManager):
             Does not repeat installation or reboot if it is a dry run. """
         if "--dry-run" in command:
             self.composite_logger.log_debug(
-                "Exit code {0} detected from command \"{1}\", but it was a dry run. Continuing execution without repeating installation or rebooting.".format(
+                "Exit code {0} detected from command \"{1}\", but it was a dry run. Continuing execution without performing additional actions.".format(
                 str(code), command))
             return
 
         if code == self.zypper_exitcode_zypper_updated or self.zypper_out_zypper_updated_msg in out:
             self.composite_logger.log_debug(
-                " - Package manager update detected. Patch installation run will be repeated.")
+                "One of the installed patches affects the package manager itself. Patch installation run will be repeated.")
             self.set_package_manager_setting(Constants.PACKAGE_MGR_SETTING_REPEAT_PATCH_OPERATION, True)
         elif code == self.zypper_exitcode_reboot_required:
             self.composite_logger.log_warning(

--- a/src/core/src/package_managers/ZypperPackageManager.py
+++ b/src/core/src/package_managers/ZypperPackageManager.py
@@ -65,6 +65,9 @@ class ZypperPackageManager(PackageManager):
         self.zypper_success_exit_codes = [self.zypper_exitcode_ok, self.zypper_exitcode_zypper_updated, self.zypper_exitcode_reboot_required]
         self.zypper_retriable_exit_codes = [self.zypper_exitcode_zypp_locked, self.zypper_exitcode_zypp_lib_exit_err, self.zypper_exitcode_repos_skipped]
 
+        # Additional output messages that corresponds with exit code 103
+        self.zypper_out_zypper_updated_msg = 'Warning: One of the installed patches affects the package manager itself. Run this command once more to install any other needed patches.'
+
         # Support to check for processes requiring restart
         self.zypper_ps = "sudo zypper ps -s"
 
@@ -159,11 +162,11 @@ class ZypperPackageManager(PackageManager):
                 self.log_success_on_invoke(code, out)
 
             if code == self.zypper_exitcode_zypper_updated or code == self.zypper_exitcode_reboot_required:
-                self.__handle_zypper_updated_or_reboot_exit_codes(command, code)
+                self.__handle_zypper_updated_or_reboot_exit_codes(command, out, code)
 
             return out
 
-    def __handle_zypper_updated_or_reboot_exit_codes(self, command, code):
+    def __handle_zypper_updated_or_reboot_exit_codes(self, command, out, code):
         """ Handles exit code 102 or 103 when returned from invoking package manager.
             Does not repeat installation or reboot if it is a dry run. """
         if "--dry-run" in command:
@@ -172,7 +175,7 @@ class ZypperPackageManager(PackageManager):
                 str(code), command))
             return
 
-        if code == self.zypper_exitcode_zypper_updated:
+        if code == self.zypper_exitcode_zypper_updated or self.zypper_out_zypper_updated_msg in out:
             self.composite_logger.log_debug(
                 " - Package manager update detected. Patch installation run will be repeated.")
             self.set_package_manager_setting(Constants.PACKAGE_MGR_SETTING_REPEAT_PATCH_OPERATION, True)
@@ -379,10 +382,6 @@ class ZypperPackageManager(PackageManager):
 
         lines = output.strip().split('\n')
         for line in lines:
-            if "Warning: One of the installed patches affects the package manager itself. Run this command once more to install any other needed patches." in line:
-                self.composite_logger.log_debug(" - Package manager requires restart. Patch installation run will be repeated.")
-                self.set_package_manager_setting(Constants.PACKAGE_MGR_SETTING_REPEAT_PATCH_OPERATION, True)
-
             if not parser_seeing_packages_flag:
                 if 'package is going to be installed' in line or 'package is going to be upgraded' in line or \
                         'packages are going to be installed:' in line or 'packages are going to be upgraded:' in line:


### PR DESCRIPTION
Addendum to #135. 

The fix for #135 did not work because there was one more location that was setting the package manager run to be repeated even on dry runs. This PR fixes it by removing that location and only having one location that handles any reboot/repeat exit codes (and now a message in the output as well)