### PR TITLE
Differentiate logs from auto assessment and auto patching

### DIFF
--- a/src/core/src/CoreMain.py
+++ b/src/core/src/CoreMain.py
@@ -56,6 +56,7 @@ class CoreMain(object):
             composite_logger.log_debug("Obtaining execution configuration...")
             execution_config = container.get('execution_config')
             telemetry_writer.set_operation_id(execution_config.activity_id)
+            telemetry_writer.set_task_name(Constants.TelemetryTaskName.AUTO_ASSESSMENT if execution_config.exec_auto_assess_only else Constants.TelemetryTaskName.EXEC)
             patch_operation_requested = execution_config.operation.lower()
 
             patch_assessor = container.get('patch_assessor')

--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -126,6 +126,11 @@ class Constants(object):
         DISABLED = "Disabled"
         ENABLED = "Enabled"
 
+    # To separately preserve assessment + auto-assessment state information
+    ASSESSMENT_STATE_FILE = "AssessmentState.json"
+    AUTO_ASSESSMENT_MAXIMUM_DURATION = "PT1H"
+    MIN_AUTO_ASSESSMENT_INTERVAL = "PT6H"   # do not perform auto-assessment if the last assessment happened less than this time interval ago
+
     # wait time after status updates
     WAIT_TIME_AFTER_HEALTHSTORE_STATUS_UPDATE_IN_SECS = 20
     AUTO_ASSESSMENT_MAXIMUM_DURATION = "PT1H"
@@ -258,7 +263,12 @@ class Constants(object):
         Informational = "Informational"
         LogAlways = "LogAlways"
 
-    TELEMETRY_TASK_NAME = "ExtensionCoreLog"
+    # Telemetry Task Names for disambiguation
+    class TelemetryTaskName(EnumBackport):
+        UNKNOWN = "Core.Unknown"                     # function parameter default
+        STARTUP = "Core.Startup"                     # initial value until execution mode is determined
+        EXEC = "Core.Exec"                           # mainline execution triggered from handler
+        AUTO_ASSESSMENT = "Core.AutoAssessment"      # auto-assessment triggered from scheduler
 
     TELEMETRY_AT_AGENT_NOT_COMPATIBLE_ERROR_MSG = "Unsupported older Azure Linux Agent version. To resolve: http://aka.ms/UpdateLinuxAgent"
     TELEMETRY_AT_AGENT_COMPATIBLE_MSG = "Minimum Azure Linux Agent version prerequisite met"

--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -126,11 +126,6 @@ class Constants(object):
         DISABLED = "Disabled"
         ENABLED = "Enabled"
 
-    # To separately preserve assessment + auto-assessment state information
-    ASSESSMENT_STATE_FILE = "AssessmentState.json"
-    AUTO_ASSESSMENT_MAXIMUM_DURATION = "PT1H"
-    MIN_AUTO_ASSESSMENT_INTERVAL = "PT6H"   # do not perform auto-assessment if the last assessment happened less than this time interval ago
-
     # wait time after status updates
     WAIT_TIME_AFTER_HEALTHSTORE_STATUS_UPDATE_IN_SECS = 20
     AUTO_ASSESSMENT_MAXIMUM_DURATION = "PT1H"

--- a/src/core/src/service_interfaces/TelemetryWriter.py
+++ b/src/core/src/service_interfaces/TelemetryWriter.py
@@ -33,6 +33,8 @@ class TelemetryWriter(object):
         self.composite_logger = composite_logger
         self.__is_agent_compatible = False
         self.__operation_id = str(datetime.datetime.utcnow())
+        self.__task_name_watermark = "." + str(datetime.datetime.utcnow().hour) + "." + str(datetime.datetime.utcnow().minute) + "." + str(datetime.datetime.utcnow().second) + "." + str(os.getpid())
+        self.__task_name = Constants.TelemetryTaskName.STARTUP + self.__task_name_watermark
         self.events_folder_path = None
         self.__telemetry_event_counter = 1  # will be added at the end of each event sent to telemetry to assist in tracing and identifying event/message loss in telemetry
         self.start_time_for_event_count_throttle_check = datetime.datetime.utcnow()
@@ -259,7 +261,7 @@ class TelemetryWriter(object):
             self.composite_logger.log_telemetry_module_error("Error occurred while formatting message for a telemetry event. [Error={0}]".format(repr(e)))
             raise
 
-    def write_event(self, message, event_level=Constants.TelemetryEventLevel.Informational, task_name=Constants.TELEMETRY_TASK_NAME, is_event_file_throttling_needed=True):
+    def write_event(self, message, event_level=Constants.TelemetryEventLevel.Informational, task_name=Constants.TelemetryTaskName.UNKNOWN, is_event_file_throttling_needed=True):
         """ Creates and writes event to event file after validating none of the telemetry size restrictions are breached
         NOTE: is_event_file_throttling_needed is used to determine if event file throttling is required and as such should always be True.
         The only scenario where this is False is when throttling is taking place and we write to telemetry about it. i.e. only from within __throttle_telemetry_writes_if_required()"""
@@ -419,6 +421,10 @@ class TelemetryWriter(object):
 
     def set_operation_id(self, operation_id):
         self.__operation_id = operation_id
+
+    def set_task_name(self, task_name):
+        # sets a disambiguating task name and watermark (timestamp and process id)
+        self.__task_name = task_name + self.__task_name_watermark
 
     def is_agent_compatible(self):
         """ Verifies if telemetry is available. Stops execution if not available. """

--- a/src/core/tests/Test_ConfigurePatchingProcessor.py
+++ b/src/core/tests/Test_ConfigurePatchingProcessor.py
@@ -266,7 +266,7 @@ class TestConfigurePatchingProcessor(unittest.TestCase):
         with open(os.path.join(runtime.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:
             events = json.load(f)
             self.assertTrue(events is not None)
-            self.assertTrue('ExtensionCoreLog' in events[0]['TaskName'])
+            self.assertTrue('Core' in events[0]['TaskName'])
             f.close()
 
 

--- a/src/core/tests/Test_CoreMain.py
+++ b/src/core/tests/Test_CoreMain.py
@@ -895,7 +895,7 @@ class TestCoreMain(unittest.TestCase):
         with open(os.path.join(runtime.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:
             events = json.load(f)
             self.assertTrue(events is not None)
-            self.assertTrue('ExtensionCoreLog' in events[0]['TaskName'])
+            self.assertTrue('Core' in events[0]['TaskName'])
             f.close()
 
 

--- a/src/extension/src/Constants.py
+++ b/src/extension/src/Constants.py
@@ -83,7 +83,7 @@ class Constants(object):
         Informational = "Informational"
         LogAlways = "LogAlways"
 
-    TELEMETRY_TASK_NAME = "HandlerLog"
+    TELEMETRY_TASK_NAME = "Handler"
 
     UTC_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 

--- a/src/extension/src/TelemetryWriter.py
+++ b/src/extension/src/TelemetryWriter.py
@@ -35,6 +35,8 @@ class TelemetryWriter(object):
         self.agent_env_var_code = Constants.AgentEnvVarStatusCode.AGENT_ENABLED
         self.__operation_id = ""
         self.__agent_is_compatible = self.__get_agent_supports_telemetry_from_env_var()
+        self.__task_name_watermark = "." + str(datetime.datetime.utcnow().hour) + "." + str(datetime.datetime.utcnow().minute) + "." + str(datetime.datetime.utcnow().second) + "." + str(os.getpid())
+        self.__task_name = Constants.TELEMETRY_TASK_NAME + self.__task_name_watermark
 
     def __new_event_json(self, event_level, message, task_name):
         return {
@@ -96,6 +98,7 @@ class TelemetryWriter(object):
 
             self.__delete_older_events()
 
+            task_name = self.__task_name if task_name == Constants.TELEMETRY_TASK_NAME else task_name
             event = self.__new_event_json(event_level, message, task_name)
             if len(json.dumps(event)) > Constants.TELEMETRY_EVENT_SIZE_LIMIT_IN_CHARS:
                 self.logger.log_telemetry_module_error("Cannot send data to telemetry as it exceeded the acceptable data size. [Data not sent={0}]".format(json.dumps(message)))


### PR DESCRIPTION
We don't have any markers to differentiate between the extension telemetry events coming from an auto assessment operation and any of the non auto assessment operations. With auto assessment running in regular intervals, we should consider adding some marker to differentiate between these logs for easier investigation. This PR adds some markers to differentiate between logs.