### PR TITLE
Fix telemetry not working

### DIFF
--- a/src/extension/src/ActionHandler.py
+++ b/src/extension/src/ActionHandler.py
@@ -151,6 +151,7 @@ class ActionHandler(object):
             # As this is a common function used by all handler actions, setting operation_id such that it will be the same timestamp for all handler actions, which can be used for identifying all events for an operation.
             # NOTE: Enable handler action will set operation_id to activity_id from config settings. And the same will be used in Core.
             self.telemetry_writer.set_operation_id(self.operation_id_substitute_for_all_actions_in_telemetry)
+            self.ext_env_handler.telemetry_supported = True
             self.__log_telemetry_info(telemetry_supported=True, events_folder_previously_existed=events_folder_previously_existed)
         else:
             # This line only logs to file since events_folder_path is not set in telemetry_writer

--- a/src/extension/src/Constants.py
+++ b/src/extension/src/Constants.py
@@ -215,6 +215,7 @@ class Constants(object):
         HandlerFailed = 88
         MissingConfig = 89
         OperationNotSupported = 90
+        AutoAssessmentFailure = 91
 
     class AgentEnvVarStatusCode(EnumBackport):
         AGENT_ENABLED = "AGENT_ENABLED"

--- a/src/extension/src/__main__.py
+++ b/src/extension/src/__main__.py
@@ -50,7 +50,6 @@ def main(argv):
         runtime_context_handler = RuntimeContextHandler(logger)
         json_file_handler = JsonFileHandler(logger)
         ext_env_handler = ExtEnvHandler(json_file_handler)
-        ext_env_handler.telemetry_supported = telemetry_writer.is_telemetry_supported()
         env_health_manager = EnvHealthManager(env_layer)
         if ext_env_handler.handler_environment_json is not None and ext_env_handler.config_folder is not None:
             config_folder = ext_env_handler.config_folder


### PR DESCRIPTION
Fix for #140 

The previous PR set whether or not telemetry was supported or not too early in the execution. It should be set in `setup_telemetry` since that is where the events folder for telemetry is also set, which the check uses.

Also includes extra exit code.