### PR TITLE
Update version to 1.6.39

### DIFF
--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -30,7 +30,7 @@ class Constants(object):
     UNKNOWN = "Unknown"
 
     # Extension version (todo: move to a different file)
-    EXT_VERSION = "1.6.38"
+    EXT_VERSION = "1.6.39"
 
     # Runtime environments
     TEST = 'Test'

--- a/src/extension/src/Constants.py
+++ b/src/extension/src/Constants.py
@@ -28,7 +28,7 @@ class Constants(object):
                         yield item
 
     # Extension version (todo: move to a different file)
-    EXT_VERSION = "1.6.38"
+    EXT_VERSION = "1.6.39"
 
     # Runtime environments
     TEST = 'Test'

--- a/src/extension/src/manifest.xml
+++ b/src/extension/src/manifest.xml
@@ -2,7 +2,7 @@
 <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure">
   <ProviderNameSpace>Microsoft.CPlat.Core</ProviderNameSpace>
   <Type>LinuxPatchExtension</Type>
-  <Version>1.6.38</Version>
+  <Version>1.6.39</Version>
   <Label>Microsoft Azure VM InGuest Patch Extension for Linux Virtual Machines</Label>
   <HostingResources>VmRole</HostingResources>
   <MediaLink></MediaLink>


### PR DESCRIPTION
This version includes:
 - [Fix telemetry not working](https://github.com/Azure/LinuxPatchExtension/pull/148)
 - [Add telemetrySupported field to environmentSettings](https://github.com/Azure/LinuxPatchExtension/pull/140)
 - [Adding status file for non enable commands and catching early errors](https://github.com/Azure/LinuxPatchExtension/pull/144)
 - [Differentiate logs from auto assessment and auto patching](https://github.com/Azure/LinuxPatchExtension/pull/146)
 - [Only handle Zypper repeat exit code in one place](https://github.com/Azure/LinuxPatchExtension/pull/145)