### PR TITLE
Bugfix for error while updating top level message field in status file

### DIFF
--- a/src/extension/src/file_handlers/ExtOutputStatusHandler.py
+++ b/src/extension/src/file_handlers/ExtOutputStatusHandler.py
@@ -141,7 +141,7 @@ class ExtOutputStatusHandler(object):
             self.update_key_value_safely(status_json[0], self.file_keys.status_status, status, self.file_keys.status_status)
             self.update_key_value_safely(status_json[0], self.file_keys.status_code, code, self.file_keys.status_status)
             self.update_key_value_safely(status_json[0], self.file_keys.timestamp_utc, str(datetime.datetime.utcnow().strftime(Constants.UTC_DATETIME_FORMAT)))
-            self.update_key_value_safely(status_json[0][self.file_keys.status_status], self.file_keys.status_formatted_message_message, str(message), self.file_keys.status_formatted_message)
+            self.update_key_value_safely(status_json[0][self.file_keys.status], self.file_keys.status_formatted_message_message, str(message), self.file_keys.status_formatted_message)
             self.json_file_handler.write_to_json_file(self.__dir_path, file_name, status_json)
         except Exception as error:
             error_message = "Error in status file creation: " + repr(error)

--- a/src/extension/src/file_handlers/ExtOutputStatusHandler.py
+++ b/src/extension/src/file_handlers/ExtOutputStatusHandler.py
@@ -121,10 +121,10 @@ class ExtOutputStatusHandler(object):
     def update_key_value_safely(self, status_json, key, value_to_update, parent_key=None):
         if status_json is not None and len(status_json) != 0:
             if parent_key is None:
-                status_json[0].update({key: value_to_update})
+                status_json.update({key: value_to_update})
             else:
-                if parent_key in status_json[0]:
-                    status_json[0].get(parent_key).update({key: value_to_update})
+                if parent_key in status_json:
+                    status_json.get(parent_key).update({key: value_to_update})
                 else:
                     self.logger.log_error("Error updating config value in status file. [Config={0}]".format(key))
 
@@ -138,10 +138,10 @@ class ExtOutputStatusHandler(object):
             if status_json is None:
                 self.logger.log_error("Error processing file. [File={0}]".format(file_name))
                 return
-            self.update_key_value_safely(status_json, self.file_keys.status_status, status, self.file_keys.status_status)
-            self.update_key_value_safely(status_json, self.file_keys.status_code, code, self.file_keys.status_status)
-            self.update_key_value_safely(status_json, self.file_keys.timestamp_utc, str(datetime.datetime.utcnow().strftime(Constants.UTC_DATETIME_FORMAT)))
-            self.update_key_value_safely(status_json, self.file_keys.status_formatted_message_message, str(message), self.file_keys.status_formatted_message)
+            self.update_key_value_safely(status_json[0], self.file_keys.status_status, status, self.file_keys.status_status)
+            self.update_key_value_safely(status_json[0], self.file_keys.status_code, code, self.file_keys.status_status)
+            self.update_key_value_safely(status_json[0], self.file_keys.timestamp_utc, str(datetime.datetime.utcnow().strftime(Constants.UTC_DATETIME_FORMAT)))
+            self.update_key_value_safely(status_json[0][self.file_keys.status_status], self.file_keys.status_formatted_message_message, str(message), self.file_keys.status_formatted_message)
             self.json_file_handler.write_to_json_file(self.__dir_path, file_name, status_json)
         except Exception as error:
             error_message = "Error in status file creation: " + repr(error)

--- a/src/extension/tests/Test_ExtOutputStatusHandler.py
+++ b/src/extension/tests/Test_ExtOutputStatusHandler.py
@@ -92,6 +92,21 @@ class TestExtOutputStatusHandler(unittest.TestCase):
         self.assertNotEqual(prev_modified_time, modified_time)
         updated_status_json = ext_status_handler.read_file(file_name)
         self.assertEqual(updated_status_json[0][self.status_file_fields.status][self.status_file_fields.status_status], self.status.Transitioning.lower())
+        self.assertEqual(updated_status_json[0][self.status_file_fields.status][self.status_file_fields.status_name], "Azure Patch Management")
+        self.assertEqual(updated_status_json[0][self.status_file_fields.status][self.status_file_fields.status_operation], "Assessment")
+        self.assertEqual(updated_status_json[0][self.status_file_fields.status][self.status_file_fields.status_code], Constants.ExitCode.Okay)
+        self.assertEqual(updated_status_json[0][self.status_file_fields.status][self.status_file_fields.status_formatted_message][self.status_file_fields.status_formatted_message_message], "")
+
+        ext_status_handler.update_file(file_name, Constants.Status.Success.lower(), Constants.ExitCode.Okay, "Test message")
+        stat_file_name = os.stat(os.path.join(dir_path, file_name + ".status"))
+        modified_time = stat_file_name.st_mtime
+        self.assertNotEqual(prev_modified_time, modified_time)
+        updated_status_json = ext_status_handler.read_file(file_name)
+        self.assertEqual(updated_status_json[0][self.status_file_fields.status][self.status_file_fields.status_status], self.status.Success.lower())
+        self.assertEqual(updated_status_json[0][self.status_file_fields.status][self.status_file_fields.status_name], "Azure Patch Management")
+        self.assertEqual(updated_status_json[0][self.status_file_fields.status][self.status_file_fields.status_operation], "Assessment")
+        self.assertEqual(updated_status_json[0][self.status_file_fields.status][self.status_file_fields.status_code], Constants.ExitCode.Okay)
+        self.assertEqual(updated_status_json[0][self.status_file_fields.status][self.status_file_fields.status_formatted_message][self.status_file_fields.status_formatted_message_message], "Test message")
         shutil.rmtree(dir_path)
 
     def test_add_error_to_status(self):


### PR DESCRIPTION
Existing code was failing to write top level message in status file with the error reported as
![image](https://user-images.githubusercontent.com/56841542/175649970-7ff81731-f356-4ae5-8a0f-d8ad027e5b84.png)

This was not a blocker or terminal error but affected our reporting status accurately in status blob