### PR TITLE
Fix for ConfigurePatching getting stuck in transitioning

### DIFF
--- a/src/core/src/service_interfaces/LifecycleManagerArc.py
+++ b/src/core/src/service_interfaces/LifecycleManagerArc.py
@@ -108,6 +108,8 @@ class LifecycleManagerArc(LifecycleManager):
 
             # Signalling take-over of core state by auto-assessment after safety checks for any competing process
             self.update_core_sequence(completed=False)
+            # Refresh status file in memory to be up-to-date
+            self.status_handler.load_status_file_components()
         else:
             # Logic for all non-Auto-assessment operations
             extension_sequence = self.read_extension_sequence()

--- a/src/core/src/service_interfaces/LifecycleManagerAzure.py
+++ b/src/core/src/service_interfaces/LifecycleManagerAzure.py
@@ -96,6 +96,8 @@ class LifecycleManagerAzure(LifecycleManager):
 
             # Signalling take-over of core state by auto-assessment after safety checks for any competing process
             self.update_core_sequence(completed=False)
+            # Refresh status file in memory to be up-to-date
+            self.status_handler.load_status_file_components()
         else:
             # Logic for all non-Auto-assessment operations
             extension_sequence = self.read_extension_sequence()

--- a/src/core/src/service_interfaces/StatusHandler.py
+++ b/src/core/src/service_interfaces/StatusHandler.py
@@ -69,7 +69,7 @@ class StatusHandler(object):
         self.__configure_patching_auto_assessment_error_count = 0  # All errors relating to auto-assessment configuration.
 
         # Load the currently persisted status file into memory
-        self.__load_status_file_components(initial_load=True)
+        self.load_status_file_components(initial_load=True)
 
         # Tracker for reboot pending status, the value is updated externally(PatchInstaller.py) whenever package is installed. As this var is directly written in status file, setting the default to False, instead of Empty/Unknown, to maintain a true bool field as per Agent team's architecture
         self.is_reboot_pending = False
@@ -490,7 +490,7 @@ class StatusHandler(object):
         except KeyError:
             return default_value
 
-    def __load_status_file_components(self, initial_load=False):
+    def load_status_file_components(self, initial_load=False):
         """ Loads currently persisted status data into memory.
         :param initial_load: If no status file exists AND initial_load is true, a default initial status file is created.
         :return: None


### PR DESCRIPTION
Fix for ConfigurePatching getting stuck in transitioning. ConfigurePatching would run, enable auto-assessment, and auto assessment would start but load the status file from disk. After ConfigurePatching completes, auto assessment would run but would not have updated status file information since it did not read it from disk again after ConfigurePatching updated if when it finished its operation.