### PR TITLE
Fix telemetry writer extension tests

### DIFF
--- a/src/extension/tests/Test_TelemetryWriter.py
+++ b/src/extension/tests/Test_TelemetryWriter.py
@@ -5,9 +5,6 @@ import tempfile
 import time
 import unittest
 from extension.src.Constants import Constants
-from extension.src.EnvLayer import EnvLayer
-from extension.src.TelemetryWriter import TelemetryWriter
-from extension.src.local_loggers.Logger import Logger
 from extension.tests.helpers.VirtualTerminal import VirtualTerminal
 from extension.tests.helpers.RuntimeComposer import RuntimeComposer
 
@@ -17,8 +14,6 @@ class TestTelemetryWriter(unittest.TestCase):
     def setUp(self):
         VirtualTerminal().print_lowlight("\n----------------- setup test runner -----------------")
         self.runtime = RuntimeComposer()
-        self.logger = self.runtime.logger
-        self.env_layer = self.runtime.env_layer
         self.telemetry_writer = self.runtime.telemetry_writer
         self.telemetry_writer.events_folder_path = tempfile.mkdtemp()
 

--- a/src/extension/tests/Test_TelemetryWriter.py
+++ b/src/extension/tests/Test_TelemetryWriter.py
@@ -9,15 +9,17 @@ from extension.src.EnvLayer import EnvLayer
 from extension.src.TelemetryWriter import TelemetryWriter
 from extension.src.local_loggers.Logger import Logger
 from extension.tests.helpers.VirtualTerminal import VirtualTerminal
+from extension.tests.helpers.RuntimeComposer import RuntimeComposer
 
 
 class TestTelemetryWriter(unittest.TestCase):
 
     def setUp(self):
         VirtualTerminal().print_lowlight("\n----------------- setup test runner -----------------")
-        self.logger = Logger()
-        self.env_layer = EnvLayer()
-        self.telemetry_writer = TelemetryWriter(self.logger, self.env_layer)
+        self.runtime = RuntimeComposer()
+        self.logger = self.runtime.logger
+        self.env_layer = self.runtime.env_layer
+        self.telemetry_writer = self.runtime.telemetry_writer
         self.telemetry_writer.events_folder_path = tempfile.mkdtemp()
 
     def tearDown(self):


### PR DESCRIPTION
4/6 telemetry writer tests in the extension are currently failing 100% of the time. However, they only fail when run individually or only as a file (right click Test_TelemetryWriter -> Run Unittests...). If the tests are run as part of all the extension tests, they succeed.

Previously, the GitHub runner did not encounter issues with these tests. Within the last month, this issue has started to occur on GitHub and can also be reproduced locally.

The issue is that the telemetry writer tests do not use RuntimeComposer, which mocks the call to `os.getenv`, which is necessary for telemetry initialization through environment variables. This PR fixes the problem by adding RuntimeComposer to the telemetry writer tests.