### PR TITLE
Update version to 1.6.42

### DIFF
--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -30,7 +30,7 @@ class Constants(object):
     UNKNOWN = "Unknown"
 
     # Extension version (todo: move to a different file)
-    EXT_VERSION = "1.6.41"
+    EXT_VERSION = "1.6.42"
 
     # Runtime environments
     TEST = 'Test'

--- a/src/extension/src/Constants.py
+++ b/src/extension/src/Constants.py
@@ -28,7 +28,7 @@ class Constants(object):
                         yield item
 
     # Extension version (todo: move to a different file)
-    EXT_VERSION = "1.6.41"
+    EXT_VERSION = "1.6.42"
 
     # Runtime environments
     TEST = 'Test'

--- a/src/extension/src/manifest.xml
+++ b/src/extension/src/manifest.xml
@@ -2,7 +2,7 @@
 <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure">
   <ProviderNameSpace>Microsoft.CPlat.Core</ProviderNameSpace>
   <Type>LinuxPatchExtension</Type>
-  <Version>1.6.41</Version>
+  <Version>1.6.42</Version>
   <Label>Microsoft Azure VM InGuest Patch Extension for Linux Virtual Machines</Label>
   <HostingResources>VmRole</HostingResources>
   <MediaLink></MediaLink>


### PR DESCRIPTION
This release contains:
- Fix telemetry writer extension tests: https://github.com/Azure/LinuxPatchExtension/pull/159
- Fix failing GitHub workflow tests: https://github.com/Azure/LinuxPatchExtension/pull/129
- Include extension coverage: https://github.com/Azure/LinuxPatchExtension/pull/160
- Add patch ordering to assessment and installation patch summaries: https://github.com/Azure/LinuxPatchExtension/pull/158
- Fix CoreState.json file being empty sometimes: https://github.com/Azure/LinuxPatchExtension/pull/156
- Fix logging for dpkg was interrupted (Exit code 100): https://github.com/Azure/LinuxPatchExtension/pull/155
- Add AssessmentState file and max auto assessment interval: https://github.com/Azure/LinuxPatchExtension/pull/150
- Quick fix for the extension security issue in Ubuntu: https://github.com/Azure/LinuxPatchExtension/pull/162