### PR TITLE
change python version check order in shim and handler

### DIFF
--- a/src/extension/src/MsftLinuxPatchExtShim.sh
+++ b/src/extension/src/MsftLinuxPatchExtShim.sh
@@ -36,7 +36,7 @@ function find_python(){
     local python_exec_command=$1
 
     # Check if there is python defined.
-    for p in python python2 python3 /usr/libexec/platform-python; do
+    for p in python3 python python2 /usr/libexec/platform-python; do
         if command -v "${p}" ; then
             eval ${python_exec_command}=${p}
             return

--- a/src/extension/src/ProcessHandler.py
+++ b/src/extension/src/ProcessHandler.py
@@ -132,15 +132,15 @@ class ProcessHandler(object):
         command_to_use_for_python = "python"
         command_to_use_for_python3 = "python3"
 
-        # check if the machine contains python
-        code_returned_for_python_check, output_for_python_check = self.env_layer.run_command_output(command_to_check_for_python, False, False)
-        if code_returned_for_python_check == 0 and command_to_use_for_python in str(output_for_python_check) and command_to_use_for_python3 not in str(output_for_python_check):
-            return command_to_use_for_python
-
         # check if the machine contains python3
         code_returned_for_python3_check, output_for_python3_check = self.env_layer.run_command_output(command_to_check_for_python3, False, False)
         if code_returned_for_python3_check == 0 and command_to_use_for_python3 in str(output_for_python3_check):
             return command_to_use_for_python3
+
+        # check if the machine contains python
+        code_returned_for_python_check, output_for_python_check = self.env_layer.run_command_output(command_to_check_for_python, False, False)
+        if code_returned_for_python_check == 0 and command_to_use_for_python in str(output_for_python_check) and command_to_use_for_python3 not in str(output_for_python_check):
+            return command_to_use_for_python
 
         return Constants.PYTHON_NOT_FOUND
 


### PR DESCRIPTION
Pro client will work only when we use python3. In cases where VM has both python2 and python3 installed, we prefer python2. this will prevent us from using pro client. 
With this change, we will now prioritize using python3 over python2 when both versions are available in VM.

