### PR TITLE
fix TypeError in python3

### DIFF
--- a/src/core/src/bootstrap/Bootstrapper.py
+++ b/src/core/src/bootstrap/Bootstrapper.py
@@ -67,7 +67,9 @@ class Bootstrapper(object):
     def get_path_to_log_files_and_telemetry_dir(self, argv, auto_assessment_only):
         """ Performs the minimum steps required to determine where to start logging """
         sequence_number = self.get_value_from_argv(argv, Constants.ARG_SEQUENCE_NUMBER)
-        environment_settings = json.loads(base64.b64decode(self.get_value_from_argv(argv, Constants.ARG_ENVIRONMENT_SETTINGS).replace("b\'", "")))
+        decode_bytes = base64.b64decode(self.get_value_from_argv(argv, Constants.ARG_ENVIRONMENT_SETTINGS).replace("b\'", ""))
+        decode_value = decode_bytes.decode()
+        environment_settings = json.loads(decode_value)
         log_folder = environment_settings[Constants.EnvSettings.LOG_FOLDER]  # can throw exception and that's okay (since we can't recover from this)
         exec_demarcator = ".aa" if auto_assessment_only else ""
         log_file_path = os.path.join(log_folder, str(sequence_number) + exec_demarcator + ".core.log")

--- a/src/core/src/core_logic/ExecutionConfig.py
+++ b/src/core/src/core_logic/ExecutionConfig.py
@@ -114,7 +114,8 @@ class ExecutionConfig(object):
         value = self.__get_value_from_argv(argv, key)
 
         try:
-            decoded_value = base64.b64decode(value.replace("b\'", ""))
+            decoded_bytes = base64.b64decode(value.replace("b\'", ""))
+            decoded_value = decoded_bytes.decode()
             decoded_json = json.loads(decoded_value)
         except Exception as error:
             self.composite_logger.log_error('Unable to process JSON in core arguments for key: {0}. Details: {1}.'.format(str(key), repr(error)))


### PR DESCRIPTION
Bug: https://msazure.visualstudio.com/One/_workitems/edit/17037023

Issue:  In python3, b64encode return byte string. This needs to be decoded to a normal string before parsing with json. else it returns TypeError. Issue found as of now only in sles12 and ubuntu16 when python 3 versions are 3.4 and 3.5.2 respectively. The ubuntu 18 VM where it was working has python version 3.8.2.

Test done: 
* UT for python2 and python3
* Manually tested in ubuntu 18, rhel8, suse12.
* SLES15, ubuntu16 images not available in Azure. For ubuntu 16, repro-ed the issue locally and verified the fix.


