### PR TITLE
Update variable names and call different function to get package manager name

### DIFF
--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -107,7 +107,7 @@ class Constants(object):
         TASK = "task"
         TASK_STATUS = "task_status"
         PACKAGE_MANAGER = "package_manager"
-        NUMBER_OF_TRIALS = "number_of_trials"
+        RETRY_COUNT = "retry_count"
         ERROR_MSG = "error_msg"
         INSTALLED_PATCH_COUNT = "installed_patch_count"
         PATCH_OPERATION_SUCCESSFUL = "patch_operation_successful"

--- a/src/core/src/core_logic/PatchAssessor.py
+++ b/src/core/src/core_logic/PatchAssessor.py
@@ -35,7 +35,7 @@ class PatchAssessor(object):
         self.status_handler = status_handler
         self.lifecycle_manager = lifecycle_manager
         self.package_manager = package_manager
-        self.package_manager_name = self.package_manager.__class__.__name__
+        self.package_manager_name = self.package_manager.get_package_manager_setting(Constants.PKG_MGR_SETTING_IDENTITY)
         self.assessment_state_file_path = os.path.join(self.execution_config.config_folder, Constants.ASSESSMENT_STATE_FILE)
 
     def start_assessment(self):
@@ -62,13 +62,13 @@ class PatchAssessor(object):
         self.composite_logger.log("\n\nGetting available patches...")
         self.package_manager.refresh_repo()
         self.status_handler.reset_assessment_data()
-        number_of_tries = 0
+        retry_count = 0
 
         for i in range(0, Constants.MAX_ASSESSMENT_RETRY_COUNT):
             try:
                 if self.lifecycle_manager is not None:
                     self.lifecycle_manager.lifecycle_status_check()     # may terminate the code abruptly, as designed
-                number_of_tries = number_of_tries + 1
+                retry_count = retry_count + 1
                 packages, package_versions = self.package_manager.get_all_updates()
                 self.telemetry_writer.write_event("Full assessment: " + str(packages), Constants.TelemetryEventLevel.Verbose)
                 self.status_handler.set_package_assessment_status(packages, package_versions)
@@ -88,21 +88,21 @@ class PatchAssessor(object):
                 else:
                     error_msg = 'Error retrieving available patches: ' + repr(error)
                     self.composite_logger.log_error(error_msg)
-                    self.write_assessment_perf_logs(number_of_tries, Constants.TaskStatus.FAILED, error_msg)
+                    self.write_assessment_perf_logs(retry_count, Constants.TaskStatus.FAILED, error_msg)
                     self.status_handler.add_error_to_status(error_msg, Constants.PatchOperationErrorCodes.DEFAULT_ERROR)
                     if Constants.ERROR_ADDED_TO_STATUS not in repr(error):
                         error.args = (error.args, "[{0}]".format(Constants.ERROR_ADDED_TO_STATUS))
                     self.status_handler.set_assessment_substatus_json(status=Constants.STATUS_ERROR)
                     raise
 
-        self.write_assessment_perf_logs(number_of_tries, Constants.TaskStatus.SUCCEEDED, "")
+        self.write_assessment_perf_logs(retry_count, Constants.TaskStatus.SUCCEEDED, "")
         self.composite_logger.log("\nPatch assessment completed.\n")
         return True
 
-    def write_assessment_perf_logs(self, number_of_tries, task_status, error_msg):
+    def write_assessment_perf_logs(self, retry_count, task_status, error_msg):
         assessment_perf_log = {Constants.PerfLogTrackerParams.TASK: Constants.ASSESSMENT, Constants.PerfLogTrackerParams.TASK_STATUS: str(task_status),
                                Constants.PerfLogTrackerParams.ERROR_MSG: error_msg, Constants.PerfLogTrackerParams.PACKAGE_MANAGER: self.package_manager_name,
-                               Constants.PerfLogTrackerParams.NUMBER_OF_TRIALS: str(number_of_tries)}
+                               Constants.PerfLogTrackerParams.RETRY_COUNT: str(retry_count)}
         self.stopwatch.stop_and_write_telemetry(str(assessment_perf_log))
 
     def raise_if_telemetry_unsupported(self):

--- a/src/core/src/core_logic/PatchInstaller.py
+++ b/src/core/src/core_logic/PatchInstaller.py
@@ -33,7 +33,7 @@ class PatchInstaller(object):
         self.lifecycle_manager = lifecycle_manager
 
         self.package_manager = package_manager
-        self.package_manager_name = self.package_manager.__class__.__name__
+        self.package_manager_name = self.package_manager.get_package_manager_setting(Constants.PKG_MGR_SETTING_IDENTITY)
         self.package_filter = package_filter
         self.maintenance_window = maintenance_window
         self.reboot_manager = reboot_manager
@@ -106,7 +106,7 @@ class PatchInstaller(object):
 
         return overall_patch_installation_successful
 
-    def write_installer_perf_logs(self, patch_operation_successful, installed_patch_count, number_of_rounds, maintenance_window, maintenance_window_exceeded, task_status, error_msg):
+    def write_installer_perf_logs(self, patch_operation_successful, installed_patch_count, retry_count, maintenance_window, maintenance_window_exceeded, task_status, error_msg):
         perc_maintenance_window_used = -1
 
         try:
@@ -116,7 +116,7 @@ class PatchInstaller(object):
 
         patch_installation_perf_log = {Constants.PerfLogTrackerParams.TASK: Constants.INSTALLATION, Constants.PerfLogTrackerParams.TASK_STATUS: str(task_status), Constants.PerfLogTrackerParams.ERROR_MSG: error_msg,
                                        Constants.PerfLogTrackerParams.PACKAGE_MANAGER: self.package_manager_name, Constants.PerfLogTrackerParams.PATCH_OPERATION_SUCCESSFUL: str(patch_operation_successful),
-                                       Constants.PerfLogTrackerParams.INSTALLED_PATCH_COUNT: str(installed_patch_count), Constants.PerfLogTrackerParams.NUMBER_OF_TRIALS: str(number_of_rounds),
+                                       Constants.PerfLogTrackerParams.INSTALLED_PATCH_COUNT: str(installed_patch_count), Constants.PerfLogTrackerParams.RETRY_COUNT: str(retry_count),
                                        Constants.PerfLogTrackerParams.MAINTENANCE_WINDOW: str(maintenance_window.duration), Constants.PerfLogTrackerParams.PERC_MAINTENANCE_WINDOW_USED: str(perc_maintenance_window_used),
                                        Constants.PerfLogTrackerParams.MAINTENANCE_WINDOW_EXCEEDED: str(maintenance_window_exceeded)}
         self.stopwatch.stop_and_write_telemetry(str(patch_installation_perf_log))


### PR DESCRIPTION
There were some comments left on the pull request https://github.com/Azure/LinuxPatchExtension/pull/161 which were not addressed in that pull request as the comments were non-blocking for that pull request. We have merged that pull request and addressed the comments in this new pull request.

Changes done:
(a) Use package_manager.get_package_manager_setting(Constants.PKG_MGR_SETTING_IDENTITY) to get the package manager name which will return values like "apt", "yum" or "zypper" instead of using package_manager.__class__.__name__ which returns class name like AptitudePackageManager, etc.

(b) Update number_of_tries to retry_count

(c) Update number_of_rounds to retry_count

Manual testing completed:
Tested that one-time assessment and one-time install patches are working fine.
Tested that the log generated has expected package manager name and now retry_count is there in log instead of number_of_tries

Example of perf log for assessment:
Stopwatch details: {'start_time': '2023-02-24 07:27:47.045594', 'end_time': '2023-02-24 07:27:49.749904', 'time_taken': '0.04507183333333333', 'machine_info': {'platform_name': 'Ubuntu', 'platform_version': '18.04', 'machine_cpu': 'Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz', 'machine_arch': 'x86_64', 'disk_type': 'Hard drive'}, 'message': "{'task': 'Assessment', 'task_status': 'succeeded', 'error_msg': '', 'package_manager': 'apt', 'retry_count': '1'}"}

Example of perf log for installation:
Stopwatch details: {'start_time': '2023-02-24 07:30:20.425733', 'end_time': '2023-02-24 07:34:18.866651', 'time_taken': '3.9740153', 'machine_info': {'platform_name': 'Ubuntu', 'platform_version': '18.04', 'machine_cpu': 'Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz', 'machine_arch': 'x86_64', 'disk_type': 'Hard drive'}, 'message': "{'task': 'Installation', 'task_status': 'succeeded', 'error_msg': '', 'package_manager': 'apt', 'patch_operation_successful': 'True', 'installed_patch_count': '2', 'retry_count': '1', 'maintenance_window': '3:55:00', 'perc_maintenance_window_used': '2.147989744680851', 'maintenance_window_exceeded': 'False'}"}