### PR TITLE
Include Assessment when ConfigurePatching -> AutoAssessmentMode is AutomaticByPlatform

### DIFF
--- a/src/core/src/CoreMain.py
+++ b/src/core/src/CoreMain.py
@@ -74,8 +74,6 @@ class CoreMain(object):
             if not execution_config.exec_auto_assess_only:
                 configure_patching_successful = configure_patching_processor.start_configure_patching()
 
-            # check if
-
             # Assessment happens for an Auto Assessment request or for all Non Auto Assessment operations, except for ConfigurePatching iff AssessmentMode is set to AutomaticByPlatform
             include_assessment_with_configure_patching = (patch_operation_requested == Constants.CONFIGURE_PATCHING.lower() and execution_config.assessment_mode == Constants.AssessmentModes.AUTOMATIC_BY_PLATFORM)
             if execution_config.exec_auto_assess_only or patch_operation_requested != Constants.CONFIGURE_PATCHING.lower() or include_assessment_with_configure_patching:

--- a/src/core/src/CoreMain.py
+++ b/src/core/src/CoreMain.py
@@ -74,8 +74,11 @@ class CoreMain(object):
             if not execution_config.exec_auto_assess_only:
                 configure_patching_successful = configure_patching_processor.start_configure_patching()
 
-            # Assessment happens for an Auto Assessment request or for Non Auto Assessment operations, if the operation requested is not Configure Patching
-            if execution_config.exec_auto_assess_only or patch_operation_requested != Constants.CONFIGURE_PATCHING.lower():
+            # check if
+
+            # Assessment happens for an Auto Assessment request or for all Non Auto Assessment operations, except for ConfigurePatching iff AssessmentMode is set to AutomaticByPlatform
+            include_assessment_with_configure_patching = (patch_operation_requested == Constants.CONFIGURE_PATCHING.lower() and execution_config.assessment_mode == Constants.AssessmentModes.AUTOMATIC_BY_PLATFORM)
+            if execution_config.exec_auto_assess_only or patch_operation_requested != Constants.CONFIGURE_PATCHING.lower() or include_assessment_with_configure_patching:
                 patch_assessment_successful = patch_assessor.start_assessment()
 
             # Patching + additional assessment occurs if the operation is 'Installation' and not Auto Assessment. Need to check both since operation_requested from prev run is preserved in Auto Assessment

--- a/src/core/src/service_interfaces/StatusHandler.py
+++ b/src/core/src/service_interfaces/StatusHandler.py
@@ -728,7 +728,7 @@ class StatusHandler(object):
                 if self.__try_add_error(self.__configure_patching_errors, error_detail):
                     self.__configure_patching_top_level_error_count += 1
 
-            # retain previously set status, code, patchMode and M for configure patching substatus
+            # retain previously set status, code, patchMode and assessmentMode for configure patching substatus
             if self.__configure_patching_substatus_json is not None:
                 automatic_os_patch_state = json.loads(self.__configure_patching_substatus_json["formattedMessage"]["message"])["automaticOSPatchState"]
                 auto_assessment_status = self.__json_try_get_key_value(self.__configure_patching_substatus_json["formattedMessage"]["message"],"autoAssessmentStatus","{}")

--- a/src/core/tests/Test_ConfigurePatchingProcessor.py
+++ b/src/core/tests/Test_ConfigurePatchingProcessor.py
@@ -203,14 +203,16 @@ class TestConfigurePatchingProcessor(unittest.TestCase):
             substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
 
         # check status file for configure patching patch state
-        self.assertEqual(len(substatus_file_data), 1)
-        self.assertTrue(substatus_file_data[0]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
-        self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
-        message = json.loads(substatus_file_data[0]["formattedMessage"]["message"])
+        self.assertEqual(len(substatus_file_data), 2)
+        self.assertTrue(substatus_file_data[1]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
+        self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_SUCCESS.lower())
+        message = json.loads(substatus_file_data[1]["formattedMessage"]["message"])
         self.assertEqual(message["automaticOSPatchState"], Constants.AutomaticOSPatchStates.ENABLED)  # no change is made on Auto OS updates for patch mode 'ImageDefault'
+        self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
+        self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
 
         # check status file for configure patching assessment state
-        message = json.loads(substatus_file_data[0]["formattedMessage"]["message"])
+        message = json.loads(substatus_file_data[1]["formattedMessage"]["message"])
         self.assertEqual(message["autoAssessmentStatus"]["autoAssessmentState"], Constants.AutoAssessmentStates.ENABLED)  # auto assessment is enabled
 
         # stop test runtime
@@ -246,14 +248,16 @@ class TestConfigurePatchingProcessor(unittest.TestCase):
 
         # check status file for configure patching patch state
         self.assertTrue(runtime.package_manager.image_default_patch_configuration_backup_exists())
-        self.assertEqual(len(substatus_file_data), 1)
-        self.assertTrue(substatus_file_data[0]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
-        self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
-        message = json.loads(substatus_file_data[0]["formattedMessage"]["message"])
+        self.assertEqual(len(substatus_file_data), 2)
+        self.assertTrue(substatus_file_data[1]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
+        self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_SUCCESS.lower())
+        message = json.loads(substatus_file_data[1]["formattedMessage"]["message"])
         self.assertEqual(message["automaticOSPatchState"], Constants.AutomaticOSPatchStates.DISABLED)  # auto OS updates are disabled on patch mode 'AutomaticByPlatform'
+        self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
+        self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
 
         # check status file for configure patching assessment state
-        message = json.loads(substatus_file_data[0]["formattedMessage"]["message"])
+        message = json.loads(substatus_file_data[1]["formattedMessage"]["message"])
         self.assertEqual(message["autoAssessmentStatus"]["autoAssessmentState"], Constants.AutoAssessmentStates.ENABLED)  # auto assessment is enabled
 
         # stop test runtime

--- a/src/core/tests/Test_CoreMain.py
+++ b/src/core/tests/Test_CoreMain.py
@@ -540,14 +540,14 @@ class TestCoreMain(unittest.TestCase):
             status_file_data = json.load(file_handle)[0]["status"]
         self.assertTrue(status_file_data["operation"] == Constants.CONFIGURE_PATCHING)
         substatus_file_data = status_file_data["substatus"]
-        self.assertEqual(len(substatus_file_data), 1)
-        self.assertTrue(substatus_file_data[0]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
-        self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
+        self.assertEqual(len(substatus_file_data), 2)
+        self.assertTrue(substatus_file_data[1]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
+        self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         # check status file for configure patching auto updates state
-        message = json.loads(substatus_file_data[0]["formattedMessage"]["message"])
+        message = json.loads(substatus_file_data[1]["formattedMessage"]["message"])
         self.assertEqual(message["automaticOSPatchState"], Constants.AutomaticOSPatchStates.DISABLED)  # auto OS updates are disabled in RuntimeCompositor
         # check status file for configure patching assessment state
-        message = json.loads(substatus_file_data[0]["formattedMessage"]["message"])
+        message = json.loads(substatus_file_data[1]["formattedMessage"]["message"])
         self.assertEqual(message["autoAssessmentStatus"]["autoAssessmentState"], Constants.AutoAssessmentStates.ENABLED)  # auto assessment is enabled
 
         # operation #2: Auto Assessment
@@ -577,8 +577,6 @@ class TestCoreMain(unittest.TestCase):
         self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         message = json.loads(substatus_file_data[1]["formattedMessage"]["message"])
         self.assertEqual(message["automaticOSPatchState"], Constants.AutomaticOSPatchStates.DISABLED)  # auto OS updates are disabled in RuntimeCompositor
-        # check status file for configure patching assessment state
-        message = json.loads(substatus_file_data[1]["formattedMessage"]["message"])
         self.assertEqual(message["autoAssessmentStatus"]["autoAssessmentState"], Constants.AutoAssessmentStates.ENABLED)  # auto assessment is enabled
 
         runtime.stop()
@@ -600,14 +598,14 @@ class TestCoreMain(unittest.TestCase):
             status_file_data = json.load(file_handle)[0]["status"]
         self.assertTrue(status_file_data["operation"] == Constants.CONFIGURE_PATCHING)
         substatus_file_data = status_file_data["substatus"]
-        self.assertEqual(len(substatus_file_data), 1)
-        self.assertTrue(substatus_file_data[0]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
-        self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
+        self.assertEqual(len(substatus_file_data), 2)
+        self.assertTrue(substatus_file_data[1]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
+        self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         # check status file for configure patching auto updates state
-        message = json.loads(substatus_file_data[0]["formattedMessage"]["message"])
+        message = json.loads(substatus_file_data[1]["formattedMessage"]["message"])
         self.assertEqual(message["automaticOSPatchState"], Constants.AutomaticOSPatchStates.DISABLED)  # auto OS updates are disabled in RuntimeCompositor
         # check status file for configure patching assessment state
-        message = json.loads(substatus_file_data[0]["formattedMessage"]["message"])
+        message = json.loads(substatus_file_data[1]["formattedMessage"]["message"])
         self.assertEqual(message["autoAssessmentStatus"]["autoAssessmentState"], Constants.AutoAssessmentStates.ENABLED)  # auto assessment is enabled
 
         # operation #2: Auto Assessment


### PR DESCRIPTION
This is a targeted AUM GA bugfix to have configurepatching consistently carry assessment results if the VM is expected to have auto-assessment set.

If the auto-assessment mode is anything other than AutomaticByPlatform, nothing changes in the behavior.