### PR TITLE
Refining auto-assessment timer & interval calculations and configuration

### DIFF
--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -155,8 +155,9 @@ class Constants(object):
 
     # To separately preserve assessment + auto-assessment state information
     ASSESSMENT_STATE_FILE = "AssessmentState.json"
-    AUTO_ASSESSMENT_MAXIMUM_DURATION = "PT1H"
-    MIN_AUTO_ASSESSMENT_INTERVAL = "PT6H"   # do not perform auto-assessment if the last assessment happened less than this time interval ago
+    AUTO_ASSESSMENT_MAXIMUM_DURATION = "PT1H"           # maximum time assessment is expected to take
+    AUTO_ASSESSMENT_CRON_INTERVAL = "PT1H"              # wake up to check for persistent assessment information this frequently
+    AUTO_ASSESSMENT_INTERVAL_BUFFER = "PT1H"            # allow for an hour's buffer from max interval passed down (PT6H) to keep within "max" SLA
 
     # wait time after status updates
     WAIT_TIME_AFTER_HEALTHSTORE_STATUS_UPDATE_IN_SECS = 20

--- a/src/core/src/core_logic/PatchAssessor.py
+++ b/src/core/src/core_logic/PatchAssessor.py
@@ -138,8 +138,10 @@ class PatchAssessor(object):
             self.composite_logger.log_warning("No valid last start information available for auto-assessment.")
             return True
 
-        # get minimum elapsed time required
-        min_elapsed_seconds_required = self.convert_iso8601_duration_to_total_seconds(Constants.MIN_AUTO_ASSESSMENT_INTERVAL)
+        # get minimum elapsed time required - difference between max allowed (passed down) and a safe buffer to prevent exceeding that
+        maximum_assessment_interval_in_seconds = self.convert_iso8601_duration_to_total_seconds(self.execution_config.maximum_assessment_interval)
+        maximum_assessment_interval_buffer_in_seconds = self.convert_iso8601_duration_to_total_seconds(Constants.AUTO_ASSESSMENT_INTERVAL_BUFFER)
+        minimum_elapsed_time_required_in_seconds = maximum_assessment_interval_in_seconds - maximum_assessment_interval_buffer_in_seconds
 
         # check if required duration has passed
         elapsed_time_in_seconds = self.__get_seconds_since_epoch() - last_start_in_seconds_since_epoch
@@ -147,7 +149,7 @@ class PatchAssessor(object):
             self.composite_logger.log_warning("Anomaly detected in system time now or during the last assessment run. Assessment will run anyway.")
             return True
         else:
-            return elapsed_time_in_seconds >= min_elapsed_seconds_required
+            return elapsed_time_in_seconds >= minimum_elapsed_time_required_in_seconds
 
     def read_assessment_state(self):
         """ Reads the assessment state file. """

--- a/src/core/src/core_logic/TimerManager.py
+++ b/src/core/src/core_logic/TimerManager.py
@@ -47,7 +47,7 @@ class TimerManager(SystemctlManager):
         """ Idempotent creation and setting of the timer associated with the service the class is instantiated with """
         self.get_timer_status()
         self.remove_timer()
-        interval_unix_timespan = self.__convert_iso8601_interval_to_unix_timespan(self.execution_config.maximum_assessment_interval)
+        interval_unix_timespan = self.__convert_iso8601_interval_to_unix_timespan(Constants.AUTO_ASSESSMENT_CRON_INTERVAL)
         self.create_timer_unit_file(Constants.AUTO_ASSESSMENT_SERVICE_DESC, interval_unix_timespan)
         self.systemctl_daemon_reload()
         self.enable_timer()

--- a/src/core/tests/Test_PatchAssessor.py
+++ b/src/core/tests/Test_PatchAssessor.py
@@ -123,13 +123,13 @@ class TestPatchAssessor(unittest.TestCase):
 
         # It has been minimum delay time since last run
         assessment_state = self.runtime.patch_assessor.read_assessment_state()
-        min_auto_assess_interval_in_seconds = self.runtime.patch_assessor.convert_iso8601_duration_to_total_seconds(Constants.MIN_AUTO_ASSESSMENT_INTERVAL)
+        min_auto_assess_interval_in_seconds = self.runtime.patch_assessor.convert_iso8601_duration_to_total_seconds(self.runtime.execution_config.maximum_assessment_interval)
         assessment_state["lastStartInSecondsSinceEpoch"] -= min_auto_assess_interval_in_seconds
         with open(self.runtime.patch_assessor.assessment_state_file_path, 'w+') as file_handle:
             file_handle.write(json.dumps({"assessmentState": assessment_state}))
         self.assertTrue(self.runtime.patch_assessor.should_auto_assessment_run())
 
-        # Time is in future, so run assessment and correct anomaly
+        # Time is in the future, so run assessment and correct anomaly
         self.runtime.patch_assessor.write_assessment_state()
         assessment_state["lastStartInSecondsSinceEpoch"] += 5000000
         with open(self.runtime.patch_assessor.assessment_state_file_path, 'w+') as file_handle:


### PR DESCRIPTION
Changes:

- Code will wake up every hour to check if auto-assessment data or regular assessment data is persisted correctly. No action if there is data from a 'fresh' successful assessment (either automatic or user initiated). Previously: Interval was the value passed down from the service.

- If successful assessment data is not found or if 'freshness' criteria doesn't match, auto-assessment will run.

- 'Freshness' previously was >= maximum allowable interval passed down. A buffer has been added to it to reduce the likelihood of exceeding the internal limit. This does not impact any customer-facing SLA. 