### PR TITLE
prioritize critical patches first over others

### DIFF
--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -309,8 +309,8 @@ class Constants(object):
     # Package / Patch State Ordering Constants
     # This ordering ensures that the most important information is preserved in the case of patch object truncation
     PackageClassificationOrderInStatusReporting = {
-        PackageClassification.SECURITY: 1,
-        PackageClassification.CRITICAL: 2,
+        PackageClassification.CRITICAL: 1,
+        PackageClassification.SECURITY: 2,
         PackageClassification.OTHER: 3,
         PackageClassification.UNCLASSIFIED: 4
     }

--- a/src/core/tests/Test_StatusHandler.py
+++ b/src/core/tests/Test_StatusHandler.py
@@ -362,13 +362,14 @@ class TestStatusHandler(unittest.TestCase):
         with self.runtime.env_layer.file_system.open("../../extension/tests/helpers/PatchOrderAssessmentSummary.json", 'r') as file_handle:
             assessment_patches = json.load(file_handle)["patches"]
             assessment_patches_sorted = self.runtime.status_handler.sort_packages_by_classification_and_state(assessment_patches)
+            print('what is assessment_patches', assessment_patches_sorted)
             #                                                                           + Classifications    | Patch State +
             #                                                                           |--------------------|-------------|
-            self.assertEqual(assessment_patches_sorted[0]["name"], "test-package-3")  # | Other, Security    |             |
+            self.assertEqual(assessment_patches_sorted[0]["name"], "test-package-1")  # | Critical           |             |
             self.assertEqual(assessment_patches_sorted[1]["name"], "test-package-4")  # | Security, Critical |             |
-            self.assertEqual(assessment_patches_sorted[2]["name"], "test-package-7")  # | Security           |             |
-            self.assertEqual(assessment_patches_sorted[3]["name"], "test-package-1")  # | Critical           |             |
-            self.assertEqual(assessment_patches_sorted[4]["name"], "test-package-5")  # | Critical, Other    |             |
+            self.assertEqual(assessment_patches_sorted[2]["name"], "test-package-5")  # | Critical, Other    |             |
+            self.assertEqual(assessment_patches_sorted[3]["name"], "test-package-3")  # | Other, Security    |             |
+            self.assertEqual(assessment_patches_sorted[4]["name"], "test-package-7")  # | Security           |             |
             self.assertEqual(assessment_patches_sorted[5]["name"], "test-package-2")  # | Other              |             |
             self.assertEqual(assessment_patches_sorted[6]["name"], "test-package-6")  # | Unclassified       |             |
 
@@ -377,15 +378,18 @@ class TestStatusHandler(unittest.TestCase):
             installation_patches_sorted = self.runtime.status_handler.sort_packages_by_classification_and_state(installation_patches)
             #                                                                              + Classifications    | Patch State +
             #                                                                              |--------------------|-------------|
-            self.assertEqual(installation_patches_sorted[0]["name"], "test-package-6")  #  | Security           | Failed      |
-            self.assertEqual(installation_patches_sorted[1]["name"], "test-package-12")  # | Critical, Security | Failed      |
-            self.assertEqual(installation_patches_sorted[2]["name"], "test-package-11")  # | Security           | Installed   |
-            self.assertEqual(installation_patches_sorted[3]["name"], "test-package-10")  # | Security           | Available   |
-            self.assertEqual(installation_patches_sorted[4]["name"], "test-package-9")  #  | Security           | Pending     |
-            self.assertEqual(installation_patches_sorted[5]["name"], "test-package-8")  #  | Security, Critical | Excluded    |
-            self.assertEqual(installation_patches_sorted[6]["name"], "test-package-7")  #  | Security           | NotSelected |
-            self.assertEqual(installation_patches_sorted[7]["name"], "test-package-14")  # | Critical           | Installed   |
-            self.assertEqual(installation_patches_sorted[8]["name"], "test-package-13")  # | Critical           | Available   |
+            self.assertEqual(installation_patches_sorted[0]["name"], "test-package-12")  # | Critical, Security | Failed      |
+            self.assertEqual(installation_patches_sorted[1]["name"], "test-package-14")  # | Critical           | Installed   |
+            self.assertEqual(installation_patches_sorted[2]["name"], "test-package-13")  # | Critical           | Available   |
+            self.assertEqual(installation_patches_sorted[3]["name"], "test-package-8")  #  | Security, Critical | Excluded    |
+
+            self.assertEqual(installation_patches_sorted[4]["name"], "test-package-6")  #  | Security           | Failed      |
+            self.assertEqual(installation_patches_sorted[5]["name"], "test-package-11")  # | Security           | Installed   |
+            self.assertEqual(installation_patches_sorted[6]["name"], "test-package-10")  # | Security           | Available   |
+            self.assertEqual(installation_patches_sorted[7]["name"], "test-package-9")  #  | Security           | Pending     |
+            self.assertEqual(installation_patches_sorted[8]["name"], "test-package-7")  #  | Security           | NotSelected |
+
+
             self.assertEqual(installation_patches_sorted[9]["name"], "test-package-5")  #  | Other              | Installed   |
             self.assertEqual(installation_patches_sorted[10]["name"], "test-package-4")  # | Other              | Available   |
             self.assertEqual(installation_patches_sorted[11]["name"], "test-package-3")  # | Other              | Pending     |


### PR DESCRIPTION
- modified the Sort patches logic prioritized critical > security > other > unclassified.