### PR TITLE
Setting auto assessment service to type: forking

### DIFF
--- a/src/core/src/core_logic/ServiceManager.py
+++ b/src/core/src/core_logic/ServiceManager.py
@@ -89,6 +89,7 @@ class ServiceManager(SystemctlManager):
 
     # region - Service Unit Management
     def create_service_unit_file(self, exec_start, desc, after="network.target", service_type="forking", wanted_by="multi-user.target"):
+        """ Note: Service type defaults to forking because of sh to py process fork """
         service_unit_content_template = "\n[Unit]" + \
                                "\nDescription={0}" + \
                                "\nAfter={1}\n" + \

--- a/src/core/src/core_logic/ServiceManager.py
+++ b/src/core/src/core_logic/ServiceManager.py
@@ -88,7 +88,7 @@ class ServiceManager(SystemctlManager):
     # endregion
 
     # region - Service Unit Management
-    def create_service_unit_file(self, exec_start, desc, after="network.target", service_type="notify", wanted_by="multi-user.target"):
+    def create_service_unit_file(self, exec_start, desc, after="network.target", service_type="forking", wanted_by="multi-user.target"):
         service_unit_content_template = "\n[Unit]" + \
                                "\nDescription={0}" + \
                                "\nAfter={1}\n" + \


### PR DESCRIPTION
Internal tracker: 24467908

**Issue:**
Systemd was reporting the assessment service as failed (even though it hadn't), because of the way the process hierarchy is set up.
This was showing up as:
"Active: failed (result: protocol)" in reporting.

**Fix:**
Change the type to forking to reflect shell script invoking py code.