### PR TITLE
raise exception if min py version is < 2.7

### DIFF
--- a/src/core/src/bootstrap/Bootstrapper.py
+++ b/src/core/src/bootstrap/Bootstrapper.py
@@ -174,3 +174,4 @@ class Bootstrapper(object):
                                             "Exception details: " + str(exception))
             if raise_if_not_sudo:
                 raise
+

--- a/src/core/src/bootstrap/Bootstrapper.py
+++ b/src/core/src/bootstrap/Bootstrapper.py
@@ -180,5 +180,5 @@ class Bootstrapper(object):
 
     def check_min_python_version(self):
         if sys.version_info < (2, 7):
-            self.composite_logger.log_debug("Python version is below 2.7")
+            self.composite_logger.log_error("Python version is below 2.7")
             raise Exception("Error: minimum python version is not met - Python version is below 2.7")

--- a/src/core/src/bootstrap/Bootstrapper.py
+++ b/src/core/src/bootstrap/Bootstrapper.py
@@ -141,6 +141,9 @@ class Bootstrapper(object):
         self.composite_logger.log("Linux distribution: " + str(self.env_layer.platform.linux_distribution()) + "\n")
         self.composite_logger.log("Process id: " + str(os.getpid()))
 
+        # check machine min python version is met
+        self.check_min_python_version()
+
         # Ensure sudo works in the environment
         sudo_check_result = self.check_sudo_status()
         self.composite_logger.log_debug("Sudo status check: " + str(sudo_check_result) + "\n")
@@ -175,3 +178,7 @@ class Bootstrapper(object):
             if raise_if_not_sudo:
                 raise
 
+    def check_min_python_version(self):
+        if sys.version_info < (2, 7):
+            self.composite_logger.log_debug("Python version is below 2.7")
+            raise Exception("Error: minimum python version is not met - Python version is below 2.7")

--- a/src/core/src/bootstrap/Bootstrapper.py
+++ b/src/core/src/bootstrap/Bootstrapper.py
@@ -141,9 +141,6 @@ class Bootstrapper(object):
         self.composite_logger.log("Linux distribution: " + str(self.env_layer.platform.linux_distribution()) + "\n")
         self.composite_logger.log("Process id: " + str(os.getpid()))
 
-        # check machine min python version is met
-        self.check_min_python_version()
-
         # Ensure sudo works in the environment
         sudo_check_result = self.check_sudo_status()
         self.composite_logger.log_debug("Sudo status check: " + str(sudo_check_result) + "\n")
@@ -177,8 +174,3 @@ class Bootstrapper(object):
                                             "Exception details: " + str(exception))
             if raise_if_not_sudo:
                 raise
-
-    def check_min_python_version(self):
-        if sys.version_info < (2, 7):
-            self.composite_logger.log_error("Python version is below 2.7")
-            raise Exception("Error: minimum python version is not met - Python version is below 2.7")

--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -300,7 +300,7 @@ class Constants(object):
 
     TELEMETRY_NOT_COMPATIBLE_ERROR_MSG = "Unsupported older Azure Linux Agent version. To resolve: http://aka.ms/UpdateLinuxAgent"
     TELEMETRY_COMPATIBLE_MSG = "Minimum Azure Linux Agent version prerequisite met"
-
+    PYTHON_NOT_COMPATIBLE_ERROR_MSG = "Unsupported older Python version. Minimum Python version required is 2.7. [DetectedPythonVersion={0}]"
     UTC_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
     # EnvLayer Constants
@@ -335,6 +335,3 @@ class Constants(object):
         MAX_OS_MAJOR_VERSION_SUPPORTED = 18
         MINIMUM_CLIENT_VERSION = "27.14.4"
 
-    class PythonVersionMsg(EnumBackport):
-        PYTHON_NOT_COMPATIBLE_ERROR_MSG = "Unsupported older Python version. Python version is below 2.7. To resolve: https://www.pythoncentral.io/how-to-update-python/"
-        PYTHON_COMPATIBLE_MSG = "Minimum Python version (2.7) prerequisite met"

--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -335,3 +335,6 @@ class Constants(object):
         MAX_OS_MAJOR_VERSION_SUPPORTED = 18
         MINIMUM_CLIENT_VERSION = "27.14.4"
 
+    class PythonVersionMsg(EnumBackport):
+        PYTHON_NOT_COMPATIBLE_ERROR_MSG = "Unsupported older Python version. Python version is below 2.7. To resolve: https://www.pythoncentral.io/how-to-update-python/"
+        PYTHON_COMPATIBLE_MSG = "Minimum Python version (2.7) prerequisite met"

--- a/src/core/src/core_logic/PatchAssessor.py
+++ b/src/core/src/core_logic/PatchAssessor.py
@@ -19,6 +19,7 @@ import datetime
 import json
 import os
 import shutil
+import sys
 import time
 from core.src.bootstrap.Constants import Constants
 from core.src.core_logic.Stopwatch import Stopwatch
@@ -43,6 +44,7 @@ class PatchAssessor(object):
         """ Start a patch assessment """
         self.status_handler.set_current_operation(Constants.ASSESSMENT)
         self.raise_if_telemetry_unsupported()
+        self.raise_if_min_python_version_not_met()
 
         if self.execution_config.exec_auto_assess_only and not self.should_auto_assessment_run():
             self.composite_logger.log("\nSkipping automatic patch assessment... [ShouldAutoAssessmentRun=False]\n")
@@ -128,6 +130,14 @@ class PatchAssessor(object):
             raise Exception(error_msg)
 
         self.composite_logger.log("{0}".format(Constants.TELEMETRY_COMPATIBLE_MSG))
+
+    def raise_if_min_python_version_not_met(self):
+        if sys.version_info < (2, 7):
+            error_msg = "{0}".format(Constants.PythonVersionMsg.PYTHON_NOT_COMPATIBLE_ERROR_MSG)
+            self.composite_logger.log_error(error_msg)
+            self.status_handler.set_assessment_substatus_json(status=Constants.STATUS_ERROR)
+            raise Exception(error_msg)
+        self.composite_logger.log("{0}".format(Constants.PythonVersionMsg.PYTHON_COMPATIBLE_MSG))
 
     # region - Auto-assessment extensions
     def should_auto_assessment_run(self):

--- a/src/core/src/core_logic/PatchAssessor.py
+++ b/src/core/src/core_logic/PatchAssessor.py
@@ -133,11 +133,10 @@ class PatchAssessor(object):
 
     def raise_if_min_python_version_not_met(self):
         if sys.version_info < (2, 7):
-            error_msg = "{0}".format(Constants.PythonVersionMsg.PYTHON_NOT_COMPATIBLE_ERROR_MSG)
+            error_msg = Constants.PYTHON_NOT_COMPATIBLE_ERROR_MSG.format(sys.version_info)
             self.composite_logger.log_error(error_msg)
             self.status_handler.set_assessment_substatus_json(status=Constants.STATUS_ERROR)
             raise Exception(error_msg)
-        self.composite_logger.log("{0}".format(Constants.PythonVersionMsg.PYTHON_COMPATIBLE_MSG))
 
     # region - Auto-assessment extensions
     def should_auto_assessment_run(self):

--- a/src/core/src/core_logic/PatchInstaller.py
+++ b/src/core/src/core_logic/PatchInstaller.py
@@ -17,7 +17,7 @@
 """ The patch install orchestrator """
 import datetime
 import math
-import os
+import sys
 import time
 from core.src.bootstrap.Constants import Constants
 from core.src.core_logic.Stopwatch import Stopwatch
@@ -56,6 +56,7 @@ class PatchInstaller(object):
         """ Kick off a patch installation run """
         self.status_handler.set_current_operation(Constants.INSTALLATION)
         self.raise_if_telemetry_unsupported()
+        self.raise_if_min_python_version_not_met()
 
         self.composite_logger.log('\nStarting patch installation...')
 
@@ -139,6 +140,13 @@ class PatchInstaller(object):
             raise Exception(error_msg)
 
         self.composite_logger.log("{0}".format(Constants.TELEMETRY_COMPATIBLE_MSG))
+
+    def raise_if_min_python_version_not_met(self):
+        if sys.version_info < (2, 7):
+            error_msg = Constants.PYTHON_NOT_COMPATIBLE_ERROR_MSG.format(sys.version_info)
+            self.composite_logger.log_error(error_msg)
+            self.status_handler.set_installation_substatus_json(status=Constants.STATUS_ERROR)
+            raise Exception(error_msg)
 
     def install_updates(self, maintenance_window, package_manager, simulate=False):
         """wrapper function of installing updates"""

--- a/src/core/tests/Test_CoreMain.py
+++ b/src/core/tests/Test_CoreMain.py
@@ -19,8 +19,6 @@ import json
 import os
 import re
 import shutil
-import sys
-import time
 import unittest
 import uuid
 

--- a/src/core/tests/Test_CoreMain.py
+++ b/src/core/tests/Test_CoreMain.py
@@ -1136,26 +1136,6 @@ class TestCoreMain(unittest.TestCase):
             self.assertTrue('Core' in events[0]['TaskName'])
             f.close()
 
-    # def test_python_version_below_2_7(self):
-    #     sys.version_info = (2, 6)
-    #     argument_composer = ArgumentComposer()
-    #     argument_composer.operation = Constants.ASSESSMENT
-    #     runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.ZYPPER)
-    #     runtime.set_legacy_test_type('HappyPath')
-    #     CoreMain(argument_composer.get_composed_arguments())
-    #
-    #     # check telemetry events
-    #     self.__check_telemetry_events(runtime)
-    #
-    #     # check status file
-    #     with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
-    #         substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
-    #     self.assertEqual(len(substatus_file_data), 2)
-    #     self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
-    #     self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
-    #     self.assertTrue(substatus_file_data[1]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
-    #     self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_SUCCESS.lower())
-    #     runtime.stop()
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/core/tests/Test_CoreMain.py
+++ b/src/core/tests/Test_CoreMain.py
@@ -1134,6 +1134,5 @@ class TestCoreMain(unittest.TestCase):
             self.assertTrue('Core' in events[0]['TaskName'])
             f.close()
 
-
 if __name__ == '__main__':
     unittest.main()

--- a/src/core/tests/Test_CoreMain.py
+++ b/src/core/tests/Test_CoreMain.py
@@ -1134,5 +1134,6 @@ class TestCoreMain(unittest.TestCase):
             self.assertTrue('Core' in events[0]['TaskName'])
             f.close()
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/core/tests/Test_CoreMain.py
+++ b/src/core/tests/Test_CoreMain.py
@@ -19,6 +19,7 @@ import json
 import os
 import re
 import shutil
+import sys
 import time
 import unittest
 import uuid
@@ -1135,6 +1136,26 @@ class TestCoreMain(unittest.TestCase):
             self.assertTrue('Core' in events[0]['TaskName'])
             f.close()
 
+    # def test_python_version_below_2_7(self):
+    #     sys.version_info = (2, 6)
+    #     argument_composer = ArgumentComposer()
+    #     argument_composer.operation = Constants.ASSESSMENT
+    #     runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.ZYPPER)
+    #     runtime.set_legacy_test_type('HappyPath')
+    #     CoreMain(argument_composer.get_composed_arguments())
+    #
+    #     # check telemetry events
+    #     self.__check_telemetry_events(runtime)
+    #
+    #     # check status file
+    #     with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
+    #         substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
+    #     self.assertEqual(len(substatus_file_data), 2)
+    #     self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
+    #     self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
+    #     self.assertTrue(substatus_file_data[1]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
+    #     self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_SUCCESS.lower())
+    #     runtime.stop()
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/core/tests/Test_PatchAssessor.py
+++ b/src/core/tests/Test_PatchAssessor.py
@@ -179,7 +179,7 @@ class TestPatchAssessor(unittest.TestCase):
         # Assert that an exception is raised
         with self.assertRaises(Exception) as context:
             self.runtime.patch_assessor.start_assessment()
-        self.assertEqual(str(context.exception), "Unsupported older Python version. Python version is below 2.7. To resolve: https://www.pythoncentral.io/how-to-update-python/")
+        self.assertEqual(str(context.exception), Constants.PYTHON_NOT_COMPATIBLE_ERROR_MSG.format(sys.version_info))
 
     def raise_ex(self):
         raise Exception()

--- a/src/core/tests/Test_PatchAssessor.py
+++ b/src/core/tests/Test_PatchAssessor.py
@@ -29,8 +29,10 @@ class TestPatchAssessor(unittest.TestCase):
     def setUp(self):
         self.runtime = RuntimeCompositor(ArgumentComposer().get_composed_arguments(), legacy_mode=True)
         self.container = self.runtime.container
+        self.original_version_info = sys.version_info
 
     def tearDown(self):
+        sys.version_info = self.original_version_info
         self.runtime.stop()
 
     def test_assessment_success(self):

--- a/src/core/tests/Test_PatchAssessor.py
+++ b/src/core/tests/Test_PatchAssessor.py
@@ -16,6 +16,7 @@
 import datetime
 import json
 import os
+import sys
 import unittest
 
 from core.src.bootstrap.Constants import Constants
@@ -170,6 +171,13 @@ class TestPatchAssessor(unittest.TestCase):
         self.assertTrue(self.runtime.patch_assessor.stopwatch.end_time is not None)
         self.assertTrue(self.runtime.patch_assessor.stopwatch.time_taken_in_secs is not None)
         self.assertTrue(self.runtime.patch_assessor.stopwatch.task_details is not None)
+
+    def test_raise_if_min_python_version_not_met(self):
+        sys.version_info = (2, 6)
+        # Assert that an exception is raised
+        with self.assertRaises(Exception) as context:
+            self.runtime.patch_assessor.start_assessment()
+        self.assertEqual(str(context.exception), "Unsupported older Python version. Python version is below 2.7. To resolve: https://www.pythoncentral.io/how-to-update-python/")
 
     def raise_ex(self):
         raise Exception()

--- a/src/core/tests/Test_PatchInstaller.py
+++ b/src/core/tests/Test_PatchInstaller.py
@@ -16,6 +16,7 @@
 
 import datetime
 import json
+import sys
 import unittest
 from core.src.bootstrap.Constants import Constants
 from core.tests.Test_UbuntuProClient import MockUpdatesResult, MockVersionResult
@@ -651,6 +652,18 @@ class TestPatchInstaller(unittest.TestCase):
         self.assertTrue(runtime.patch_installer.write_installer_perf_logs(True, 1, 1, runtime.maintenance_window, False, Constants.TaskStatus.SUCCEEDED, ""))
         runtime.stop()
 
+    def test_raise_if_min_python_version_not_met(self):
+        runtime = RuntimeCompositor(ArgumentComposer().get_composed_arguments(), legacy_mode=True)
+        original_version = sys.version_info
+        sys.version_info = (2, 6)
+        # Assert that an exception is raised
+        with self.assertRaises(Exception) as context:
+            runtime.patch_installer.start_installation()
+        self.assertEqual(str(context.exception), Constants.PYTHON_NOT_COMPATIBLE_ERROR_MSG.format(sys.version_info))
+
+        # reset sys.version to original
+        sys.version_info = original_version
+        runtime.stop()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
[x] address the bug - Terminal exception AttributeError - 'datetime.timedelta' object has no attribute 'total_seconds'
[x]raise exception if min python version is < 2.7

apis call result
![image](https://github.com/Azure/LinuxPatchExtension/assets/127874208/ade0d3b0-6f9f-4c27-a1c3-abf0de6b44a9)

