### PR TITLE
For yum package manager only, sometimes VM gets rebooted in install updates job even though reboot is not required

### DIFF
--- a/src/core/src/package_managers/YumPackageManager.py
+++ b/src/core/src/package_managers/YumPackageManager.py
@@ -932,6 +932,14 @@ class YumPackageManager(PackageManager):
                 self.composite_logger.log_debug(" - Inapplicable line: " + str(line))
                 continue
             else:
+                # The first string should be process ID and hence it should be integer.
+                # If first string is not process ID then the line is not for a process detail.
+                try:
+                    int(process_details[0])
+                except Exception:
+                    self.composite_logger.log_debug(" - Inapplicable line: " + str(line))
+                    continue
+
                 self.composite_logger.log_debug(" - Applicable line: " + str(line))
                 process_count += 1
                 process_list_verbose += process_details[1] + " (" + process_details[0] + "), "  # process name and id

--- a/src/core/tests/library/LegacyEnvLayerExtensions.py
+++ b/src/core/tests/library/LegacyEnvLayerExtensions.py
@@ -554,6 +554,15 @@ class LegacyEnvLayerExtensions():
                         output = "Loaded plugins: langpacks, product-id, search-disabled-repos" + \
                                  "No package microcode_ctl-2:2.1-29.16.el7_5 available." + \
                                  "Error: Nothing to do"
+                    elif cmd.find("sudo yum ps") > -1:
+                        code = 0
+                        output = "Loaded plugins: enabled_repos_upload, package_upload, product-id, ps, search-\n" + \
+                                 "              : disabled-repos, subscription-manager\n" + \
+                                 "This system is not registered with an entitlement server. You can use subscription-manager to register.\n" + \
+                                 "       pid proc                  CPU      RSS      State uptime\n" + \
+                                 "ps\n" + \
+                                 "Uploading Enabled Repositories Report\n" + \
+                                 "Cannot upload enabled repos report, is this client registered?"
                     else:
                         code = 0
                         output = ''


### PR DESCRIPTION
**Issue:**
As per the function do_processes_require_restart in YumPackageManager.py, the output of "sudo yum ps" is parsed to check if there are any processes and if there is any then True is returned in the function do_processes_require_restart
There is issue in parsing logic.

Example logs when true is returned when it should return false:

DEBUG: - Output from package manager:
| Loaded plugins: enabled_repos_upload, package_upload, product-id, ps, search-
| : disabled-repos, subscription-manager
|
| This system is not registered with an entitlement server. You can use subscription-manager to register.
|
| pid proc CPU RSS State uptime
| ps
| Uploading Enabled Repositories Report
| Cannot upload enabled repos report, is this client registered?
VERBOSE: ==========================================================================
DEBUG: - Inapplicable line: Loaded plugins: enabled_repos_upload, package_upload, product-id, ps, search-
DEBUG: - Inapplicable line: : disabled-repos, subscription-manager
DEBUG: - Inapplicable line:
DEBUG: - Inapplicable line: This system is not registered with an entitlement server. You can use subscription-manager to register.
DEBUG: - Inapplicable line:
DEBUG: - Process list started: pid proc CPU RSS State uptime
DEBUG: - Inapplicable line: ps
DEBUG: - Inapplicable line: Uploading Enabled Repositories Report
DEBUG: - Applicable line: Cannot upload enabled repos report, is this client registered?
2023-06-24T12:09:52Z> - Processes requiring restart (1): [upload (Cannot), <eol>]
DEBUG: - Reboot required debug flags (yum): False, True.
DEBUG: Setting reboot pending status. [RebootPendingStatus=True]

Following line is marked applicable but actually it is not for any process, it is error message line:
Cannot upload enabled repos report, is this client registered?

So, in this case reboot required is returned by the function but actually reboot is not required because above line is not for any process, it is error message.

**Root Cause:**
In parsing, it is checked if there are at least 7 strings in the line. If there are at least 7 strings then it is assumed as a process detail. But this line could be error line as per above example.

**Fix:**
Adding one more check that first string should be integer because first string should be Process ID and hence it should be integer.

**Testing**
(a) Testing done for case when first string of the line is integer because that is process detail.
(b) Testing done for scenario when there is no process line. Hence no reboot required.

Added sample output in the test type "SadPath" so that this scenario is covered in test case test_do_processes_require_restart in the file Test_YumPackageManager.py.