### PR TITLE
Obsolete packages should not be attempted to install

### DIFF
--- a/src/core/src/package_managers/YumPackageManager.py
+++ b/src/core/src/package_managers/YumPackageManager.py
@@ -202,6 +202,10 @@ class YumPackageManager(PackageManager):
         lines = output.strip().split('\n')
 
         for line_index in range(0, len(lines)):
+            # Do not install Obsoleting Packages. The obsoleting packages list comes towards end in the output.
+            if lines[line_index].startswith("Obsoleting Packages"):
+                break
+
             line = re.split(r'\s+', lines[line_index].strip())
             next_line = []
 

--- a/src/core/src/package_managers/YumPackageManager.py
+++ b/src/core/src/package_managers/YumPackageManager.py
@@ -203,7 +203,7 @@ class YumPackageManager(PackageManager):
 
         for line_index in range(0, len(lines)):
             # Do not install Obsoleting Packages. The obsoleting packages list comes towards end in the output.
-            if lines[line_index].startswith("Obsoleting Packages"):
+            if lines[line_index].strip().startswith("Obsoleting Packages"):
                 break
 
             line = re.split(r'\s+', lines[line_index].strip())

--- a/src/core/tests/Test_YumPackageManager.py
+++ b/src/core/tests/Test_YumPackageManager.py
@@ -609,6 +609,15 @@ class TestYumPackageManager(unittest.TestCase):
 
         package_manager.do_processes_require_restart = backup_do_process_require_restart
 
+    def test_obsolete_packages_should_not_considered_in_available_updates(self):
+        self.runtime.set_legacy_test_type('ObsoletePackages')
+        package_manager = self.container.get('package_manager')
+        package_filter = self.container.get('package_filter')
+        available_updates, package_versions = package_manager.get_available_updates(package_filter)
+        self.assertEqual(len(available_updates), 1)
+        self.assertEqual(len(package_versions), 1)
+        self.assertTrue(available_updates[0] == "grub2-tools.x86_64")
+        self.assertTrue(package_versions[0] == "1:2.02-142.el8")
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/core/tests/library/LegacyEnvLayerExtensions.py
+++ b/src/core/tests/library/LegacyEnvLayerExtensions.py
@@ -1144,6 +1144,33 @@ class LegacyEnvLayerExtensions():
                             entry = template.replace('<PACKAGE>', package)
                             entry = entry.replace('<VERSION>', version)
                             output += entry
+            elif self.legacy_test_type == 'ObsoletePackages':
+                if self.legacy_package_manager_name is Constants.YUM:
+                    if cmd.find("check-update") > -1:
+                        code = 100
+                        output = "\n" + \
+                                 "grub2-tools.x86_64                                              " + \
+                                 "1:2.02-142.el8                                      " + \
+                                 "rhel-8-baseos-rhui-rpms\n" + \
+                                 "Obsoleting Packages\n" + \
+                                 "grub2-tools.x86_64                                     " + \
+                                 "1:2.02-123.el8_6.8                                      " + \
+                                 "rhel-8-baseos-rhui-rpms\n" + \
+                                 "    grub2-tools.x86_64                                      " + \
+                                 "1:2.02-123.el8                                      " + \
+                                 "@System\n"
+                    elif cmd.find("list installed") > -1:
+                        code = 0
+                        package = cmd.replace('sudo yum list installed ', '')
+                        whitelisted_versions = [
+                            '1:2.02-142.el8']  # any list of versions you want to work for *any* package
+                        output = "Loaded plugins: product-id, search-disabled-repos, subscription-manager\n" + \
+                                 "Installed Packages\n"
+                        template = "<PACKAGE>                                                                                     <VERSION>                                                                                      @anaconda/7.3\n"
+                        for version in whitelisted_versions:
+                            entry = template.replace('<PACKAGE>', package)
+                            entry = entry.replace('<VERSION>', version)
+                            output += entry
 
             major_version = self.get_python_major_version()
             if major_version == 2:

--- a/src/core/tests/library/LegacyEnvLayerExtensions.py
+++ b/src/core/tests/library/LegacyEnvLayerExtensions.py
@@ -1159,18 +1159,6 @@ class LegacyEnvLayerExtensions():
                                  "    grub2-tools.x86_64                                      " + \
                                  "1:2.02-123.el8                                      " + \
                                  "@System\n"
-                    elif cmd.find("list installed") > -1:
-                        code = 0
-                        package = cmd.replace('sudo yum list installed ', '')
-                        whitelisted_versions = [
-                            '1:2.02-142.el8']  # any list of versions you want to work for *any* package
-                        output = "Loaded plugins: product-id, search-disabled-repos, subscription-manager\n" + \
-                                 "Installed Packages\n"
-                        template = "<PACKAGE>                                                                                     <VERSION>                                                                                      @anaconda/7.3\n"
-                        for version in whitelisted_versions:
-                            entry = template.replace('<PACKAGE>', package)
-                            entry = entry.replace('<VERSION>', version)
-                            output += entry
 
             major_version = self.get_python_major_version()
             if major_version == 2:


### PR DESCRIPTION
**Issue:**
There are obsolete packages in the output of “yum check-update". While parsing the output of "yum check-update", the obsolete packages should be skipped but they are not skipped and included in list of packages to install and hence the obsolete packages are attempted for installation. 

The obsolete package is listed more than once in the output of "yum check-update". Once with the updated version and other with the obsolete version. Currently both versions of the package are attempted for installation. This is resulting in installing same package with updated version and then again downgrading the package to obsolete version.

Here is the example of "yum -q check-update" in which there are obsolete packages in the output:
![image](https://github.com/Azure/LinuxPatchExtension/assets/60310281/4e7f673c-eec3-458d-adda-83ca6fb5fe68)

**One more impacted scenario around package dependency is following:**
Suppose there are two packages p1 and p2 with versions v1 installed. p1 and p2 are dependent on each other. The version v1 is obsolete. The available updates for p1 is v2. The new update p1 v2 is not dependent on p2 and p2 is no longer supported. So, output of "yum check-update" is like following:
_p1 v2
Obsoleting Packages
p1 v1
p2 v1_

As we are not skipping obsolete packages currently, the list of updates to install is following:
p1 v2
p1 v1
p2 v1

When p1 v2 is processed, it is found that p1 is dependent on p2. The version of p2 is found to be v1. So, the command to install packages is:
_yum install -y p1-v2, p2-v1_

This command fails with error that there is a conflict. p1-v2 and p1-v1 cannot be installed together.
The reason for this error is that p2-v1 internally tries to install p1-v1 because p2-v1 is dependent on p1-v1.
So both versions v1 and v2 are attempted to be installed in a single command which fails and the job fails with error that package installation failed.

This issue is surfaced in our patch installation script in yum v3 and not yum v4 till now because in yum v4, the package dependency resolution was not working so packages are installed without mentioning dependency explicitly in the command. But with the fix in the PR https://github.com/Azure/LinuxPatchExtension/pull/209 i.e. (The output of command "yum install --assumeno" is different in yum 4 than that in yum 3 so adding parsing logic for yum 4), this issue will get surfaced for yum v4 also.

**Fix:**
Skip Obsolete packages when extracting packages from output of command to get available updates. The obsolete packages are towards the end of output of the command "yum check-update" and they are under the heading "Obsoleting Packages". So, skip extracting packages after the heading "Obsoleting Packages".

**Manual Test:**
Tested that only non-obsolete packages are attempted to install. The obsolete packages are skipped.

**Test Automation:**
Added test case for code coverage.
