### PR TITLE
Extend Composite Logger log functions to have built in buffer

### DIFF
--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -335,3 +335,16 @@ class Constants(object):
         MAX_OS_MAJOR_VERSION_SUPPORTED = 18
         MINIMUM_CLIENT_VERSION = "27.14.4"
 
+    BUFFER_LINE_SEPERATOR = "\n|\t"
+    BUFFER_LINE_SEPERATOR_LENGTH = len(BUFFER_LINE_SEPERATOR)
+
+    class BufferMessage(EnumBackport):
+        TRUE = 0
+        FALSE = 1
+        FLUSH = 2
+
+    class MessageLevel(EnumBackport):  
+        ERROR = 0
+        WARNING = 1
+        DEBUG = 2
+        VERBOSE = 3

--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -344,16 +344,8 @@ class Constants(object):
         MAX_OS_MAJOR_VERSION_SUPPORTED = 18
         MINIMUM_CLIENT_VERSION = "27.14.4"
 
-    BUFFER_LINE_SEPERATOR = "\n|\t"
-    BUFFER_LINE_SEPERATOR_LENGTH = len(BUFFER_LINE_SEPERATOR)
-
     class BufferMessage(EnumBackport):
         TRUE = 0
         FALSE = 1
         FLUSH = 2
 
-    class MessageLevel(EnumBackport):  
-        ERROR = 0
-        WARNING = 1
-        DEBUG = 2
-        VERBOSE = 3

--- a/src/core/src/local_loggers/CompositeLogger.py
+++ b/src/core/src/local_loggers/CompositeLogger.py
@@ -34,16 +34,13 @@ class CompositeLogger(object):
         self.TELEMETRY_LOG = "TELEMETRY_LOG:"
         self.current_env = current_env
         self.NEWLINE_REPLACE_CHAR = " "
-        self.MESSAGE_MAX_CHARS = Constants.TELEMETRY_MSG_SIZE_LIMIT_IN_CHARS - Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_CHARS - Constants.TELEMETRY_EVENT_COUNTER_MSG_SIZE_LIMIT_IN_CHARS
-        self.buffer_message = ""
 
-
-    def log(self, message, message_type=Constants.TelemetryEventLevel.Informational):
+    def log(self, message, message_type=Constants.TelemetryEventLevel.Informational, buffer_msg=Constants.BufferMessage.FALSE):
         """log output"""
         message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
         message = message.strip()
         if self.telemetry_writer is not None and self.telemetry_writer.events_folder_path is not None and self.current_env != Constants.DEV:  # turned off for dev environment as it severely slows down execution
-            self.telemetry_writer.write_event(message, message_type)
+            self.telemetry_writer.write_event_with_buffer(message, message_type, buffer_msg)
         if self.current_env in (Constants.DEV, Constants.TEST):
             for line in message.splitlines():  # allows the extended file logger to strip unnecessary white space
                 print(line)
@@ -51,74 +48,32 @@ class CompositeLogger(object):
             timestamp = self.env_layer.datetime.timestamp()
             self.file_logger.write("\n" + timestamp + "> " + message.strip(), fail_silently=False)
 
-    def flush(self, message, message_level):
-        if message_level == Constants.MessageLevel.ERROR:
-            self.flush_error(message)
-        elif message_level == Constants.MessageLevel.WARNING:
-            self.flush_warning(message)
-        elif message_level == Constants.MessageLevel.DEBUG:
-            self.flush_debug(message)
-        elif message_level == Constants.MessageLevel.VERBOSE:
-            self.flush_verbose(message)
-        self.buffer_message = ""
-
-    def buffer_or_flush_message(self, message, buffer, message_level):
-        message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
-
-        if buffer == Constants.BufferMessage.FALSE:
-            if len(self.buffer_message) > 0:
-                # If there is message already in buffer then first flush the buffer message.
-                self.flush(self.buffer_message, message_level)
-            self.flush(message, message_level)
-        else:
-            # This else part is for the case when buffer is either Constants.BufferMessage.TRUE or Constants.BufferMessage.FLUSH
-
-            # If the total sum of buffer message length, buffer line separator length and new message length is greater than max limit of chars then first flush the buffer message.
-            if len(self.buffer_message) > 0 and len(self.buffer_message) + Constants.BUFFER_LINE_SEPERATOR_LENGTH + len(message) > self.MESSAGE_MAX_CHARS:
-                self.flush(self.buffer_message, message_level)
-
-            if len(self.buffer_message) > 0:
-                self.buffer_message = self.buffer_message + Constants.BUFFER_LINE_SEPERATOR + message
-            else:
-                self.buffer_message = message
-
-            if buffer == Constants.BufferMessage.FLUSH:
-                self.flush(self.buffer_message, message_level)
-
-    def log_error(self, message, buffer=Constants.BufferMessage.FALSE):        
-        message = self.ERROR + (self.NEWLINE_REPLACE_CHAR.join(message.split(os.linesep))).strip()
-        self.buffer_or_flush_message(message, buffer, Constants.MessageLevel.ERROR)
-
-    def log_warning(self, message, buffer=Constants.BufferMessage.FALSE):
-        message = self.WARNING + (self.NEWLINE_REPLACE_CHAR.join(message.split(os.linesep))).strip()
-        self.buffer_or_flush_message(message, buffer, Constants.MessageLevel.WARNING)
-
-    def log_debug(self, message, buffer=Constants.BufferMessage.FALSE):
-        message = message.strip()
-        self.buffer_or_flush_message(message, buffer, Constants.MessageLevel.DEBUG)
-
-    def log_verbose(self, message, buffer=Constants.BufferMessage.FALSE):
-        self.buffer_or_flush_message(message, buffer, Constants.MessageLevel.VERBOSE)
-
-    def flush_error(self, message):
+    def log_error(self, message):
         """log errors"""
+        message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
+        message = self.ERROR + (self.NEWLINE_REPLACE_CHAR.join(message.split(os.linesep))).strip()
         self.log(message, message_type=Constants.TelemetryEventLevel.Error)
 
-    def flush_warning(self, message):
+    def log_warning(self, message):
         """log warning"""
+        message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
+        message = self.WARNING + (self.NEWLINE_REPLACE_CHAR.join(message.split(os.linesep))).strip()
         self.log(message, message_type=Constants.TelemetryEventLevel.Warning)
 
-    def flush_debug(self, message):
+    def log_debug(self, message, buffer_msg=Constants.BufferMessage.FALSE):
         """log debug"""
+        message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
+        message = message.strip()
         if self.telemetry_writer is not None and self.telemetry_writer.events_folder_path is not None and self.current_env not in (Constants.DEV, Constants.TEST):
-            self.telemetry_writer.write_event(message, Constants.TelemetryEventLevel.Verbose)
+            self.telemetry_writer.write_event_with_buffer(message, Constants.TelemetryEventLevel.Verbose, buffer_msg)
         if self.current_env in (Constants.DEV, Constants.TEST):
             self.log(self.current_env + ": " + str(self.env_layer.datetime.datetime_utcnow()) + ": " + message, Constants.TelemetryEventLevel.Verbose)  # send to standard output if dev or test env
         elif self.file_logger is not None:
             self.file_logger.write("\n\t" + self.DEBUG + " " + "\n\t".join(message.splitlines()).strip())
 
-    def flush_verbose(self, message):
+    def log_verbose(self, message):
         """log verbose"""
+        message = self.__remove_substring_from_message(message, Constants.ERROR_ADDED_TO_STATUS)
         # Only log verbose events to file, not to telemetry
         if self.file_logger is not None:
             self.file_logger.write("\n\t" + self.VERBOSE + " " + "\n\t".join(message.strip().splitlines()).strip())
@@ -147,4 +102,3 @@ class CompositeLogger(object):
         if substring in message:
             message = message.replace("[{0}]".format(Constants.ERROR_ADDED_TO_STATUS), "")
         return message
-

--- a/src/core/src/service_interfaces/TelemetryWriter.py
+++ b/src/core/src/service_interfaces/TelemetryWriter.py
@@ -179,13 +179,8 @@ class TelemetryWriter(object):
 
         elif buffer_msg == Constants.BufferMessage.FLUSH:
             if self.telemetry_buffer_store != "":
-                if event_level == self.last_telemetry_event_level:
-                    self.telemetry_buffer_store = self.telemetry_buffer_store + self.TELEMETRY_BUFFER_DELIMETER + message
-                    self.write_event(self.telemetry_buffer_store, self.last_telemetry_event_level)
-                else:
-                    self.write_event(self.telemetry_buffer_store, self.last_telemetry_event_level)
-                    self.write_event(message, event_level)
-
+                self.telemetry_buffer_store = self.telemetry_buffer_store + self.TELEMETRY_BUFFER_DELIMETER + message
+                self.write_event(self.telemetry_buffer_store, self.last_telemetry_event_level)
             else:
                 self.write_event(message, event_level)
 

--- a/src/core/tests/Test_TelemetryWriter.py
+++ b/src/core/tests/Test_TelemetryWriter.py
@@ -268,13 +268,20 @@ class TestTelemetryWriter(unittest.TestCase):
         # As the messages are with different TelemetryEventLevel, they will be written separately
         # even though flush is used.
         latest_event_file = [pos_json for pos_json in os.listdir(self.runtime.telemetry_writer.events_folder_path) if
-                             re.search('^[0-9]+.json$', pos_json)][-2]
+                             re.search('^[0-9]+.json$', pos_json)][-1]
         with open(os.path.join(self.runtime.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:
             events = json.load(f)
             self.assertTrue(events is not None)
             text_found = re.search('TC=([0-9]+)', events[-1]['Message'])
             f.close()
-            self.assertTrue(text_found.string.startswith("Message 1"))
+            self.assertTrue(text_found.string.startswith("Message 2"))
+
+    def test_write_event_with_buffer_true_and_empty_string_and_then_flush_with_non_empty_string(self):
+        self.runtime.telemetry_writer.write_event_with_buffer("", Constants.TelemetryEventLevel.Verbose,
+                                                              Constants.BufferMessage.TRUE)
+
+        self.runtime.telemetry_writer.write_event_with_buffer("Message 1", Constants.TelemetryEventLevel.Verbose,
+                                                              Constants.BufferMessage.FLUSH)
 
         latest_event_file = [pos_json for pos_json in os.listdir(self.runtime.telemetry_writer.events_folder_path) if
                              re.search('^[0-9]+.json$', pos_json)][-1]
@@ -283,7 +290,7 @@ class TestTelemetryWriter(unittest.TestCase):
             self.assertTrue(events is not None)
             text_found = re.search('TC=([0-9]+)', events[-1]['Message'])
             f.close()
-            self.assertTrue(text_found.string.startswith("Message 2"))
+            self.assertTrue(text_found.string.startswith("Message 1"))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Extend Composite Logger functions to have built in buffer. This will help in combining multiple messages in single log and hence decreasing number of logs and hence time loss due to telemetry throttling is decreased.

A new optional parameter is added in log functions. The data type of the parameter is enum whose values can be true, flush and false. The default value is false.

If the buffer is true, keep appending to built-in variable.
The buffer may be flushed to the log in the very last message meant to be part of the concatenation.
If it's false, write whatever is in memory, clear it out, and also separately write the new message that came in.

The buffer line separator is used to separate different messages in the same buffer - "\n|\t".

There is common buffer for different log levels i.e., error, warning, debug and verbose. This is simpler design than having separate buffers for each log level. The issue with having single buffer for all log levels is that if log function with warning level is called 3 times with different messages with buffer=true and then log function with error level is called with buffer=flush then all the 4 messages will be written with error level because there is single buffer for all log levels. The current use cases of decreasing number of logs by combining multiple messages to single log can be achievable with single buffer for all log levels.

If required later, the design can be expanded to have separate buffers each for error, warning, debug and verbose.

Manual testing done:
Tested the different sequences of logging messages with the buffer value true, false and flush. Tested following scenarios with all log levels i.e. error, warning, debug and verbose:
(a) When log function is called 2 times with buffer=true and third time with buffer=flush, then the three logs are combined to single log. 
(b) When log function is called with buffer=false then the message is logged.
(c) When log function is called with buffer=true followed by log function with buffer=false then the message with buffer=true is logged first and then the message with buffer=false is logged as a separate log.

Tested the scenarios with number of characters in message exceed the limit of maximum characters.
(a) If log function is called with buffer=true and then a new log function is called with buffer=flush and if sum of characters of both the messages exceeds the limit then both messages are logged separately.