### PR TITLE
APT: Patch Mode set to disabled in ConfigurePatching when os patch config file does not exist

### DIFF
--- a/src/core/src/package_managers/AptitudePackageManager.py
+++ b/src/core/src/package_managers/AptitudePackageManager.py
@@ -476,8 +476,9 @@ class AptitudePackageManager(PackageManager):
     def get_current_auto_os_patch_state(self):
         """ Gets the current auto OS update patch state on the machine """
         self.composite_logger.log("Fetching the current automatic OS patch state on the machine...")
-        self.__get_current_auto_os_updates_setting_on_machine()
-        if int(self.unattended_upgrade_value) == 0:
+        if os.path.exists(self.os_patch_configuration_settings_file_path):
+            self.__get_current_auto_os_updates_setting_on_machine()
+        if not os.path.exists(self.os_patch_configuration_settings_file_path) or int(self.unattended_upgrade_value) == 0:
             current_auto_os_patch_state = Constants.AutomaticOSPatchStates.DISABLED
         elif int(self.unattended_upgrade_value) == 1:
             current_auto_os_patch_state = Constants.AutomaticOSPatchStates.ENABLED

--- a/src/core/tests/Test_AptitudePackageManager.py
+++ b/src/core/tests/Test_AptitudePackageManager.py
@@ -214,6 +214,15 @@ class TestAptitudePackageManager(unittest.TestCase):
         self.assertTrue('APT::Periodic::Update-Package-Lists "0"' in os_patch_configuration_settings)
         self.assertTrue('APT::Periodic::Unattended-Upgrade "0"' in os_patch_configuration_settings)
 
+    def test_get_current_auto_os_updates_with_no_os_patch_configuration_settings_file(self):
+        # os_patch_configuration_settings_file does not exist, hence current os patch state is marked as Disabled
+        package_manager = self.container.get('package_manager')
+        package_manager.get_current_auto_os_patch_state = self.runtime.backup_get_current_auto_os_patch_state
+
+        self.assertTrue(package_manager.get_current_auto_os_patch_state() == Constants.AutomaticOSPatchStates.DISABLED)
+
+        package_manager.get_current_auto_os_patch_state = self.runtime.get_current_auto_os_patch_state
+
     def test_disable_auto_os_update_failure(self):
         # disable with non existing log file
         package_manager = self.container.get('package_manager')

--- a/src/core/tests/Test_ConfigurePatchingProcessor.py
+++ b/src/core/tests/Test_ConfigurePatchingProcessor.py
@@ -308,6 +308,34 @@ class TestConfigurePatchingProcessor(unittest.TestCase):
         # stop test runtime
         runtime.stop()
 
+    def test_patch_mode_disabled_for_configure_patching_with_no_os_patch_configuration_settings_file(self):
+        argument_composer = ArgumentComposer()
+        argument_composer.operation = Constants.CONFIGURE_PATCHING
+        argument_composer.patch_mode = Constants.PatchModes.AUTOMATIC_BY_PLATFORM
+        argument_composer.assessment_mode = "LetsThrowAnException"
+        runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.APT)
+        runtime.package_manager.get_current_auto_os_patch_state = runtime.backup_get_current_auto_os_patch_state
+        runtime.set_legacy_test_type('HappyPath')
+
+        # Execute main
+        CoreMain(argument_composer.get_composed_arguments())
+
+        # check telemetry events
+        self.__check_telemetry_events(runtime)
+
+        # check status file
+        with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
+            substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
+        self.assertEqual(len(substatus_file_data), 2)
+        self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)   # assessment is now part of the CP flow
+        self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[1]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
+        self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_ERROR.lower())
+        message = json.loads(substatus_file_data[1]["formattedMessage"]["message"])
+        self.assertEqual(message["automaticOSPatchState"], Constants.AutomaticOSPatchStates.DISABLED)
+
+        runtime.stop()
+
     def __check_telemetry_events(self, runtime):
         all_events = os.listdir(runtime.telemetry_writer.events_folder_path)
         self.assertTrue(len(all_events) > 0)

--- a/src/core/tests/Test_ConfigurePatchingProcessor.py
+++ b/src/core/tests/Test_ConfigurePatchingProcessor.py
@@ -35,7 +35,16 @@ class TestConfigurePatchingProcessor(unittest.TestCase):
         # self.runtime.stop()
         pass
 
-    def test_operation_success_for_configure_patching_request_for_apt(self):
+    #region Mocks
+    def mock_package_manager_get_current_auto_os_patch_state_returns_unknown(self):
+        if self.mock_package_manager_get_current_auto_os_patch_state_returns_unknown_call_count == 0:
+            self.mock_package_manager_get_current_auto_os_patch_state_returns_unknown_call_count = 1
+            return Constants.AutomaticOSPatchStates.DISABLED
+        else:
+            return Constants.AutomaticOSPatchStates.UNKNOWN
+    #endregion Mocks
+
+    def test_operation_success_for_configure_patching_request_for_apt_with_default_updates_config(self):
         # create and adjust arguments
         argument_composer = ArgumentComposer()
         argument_composer.operation = Constants.CONFIGURE_PATCHING
@@ -80,14 +89,28 @@ class TestConfigurePatchingProcessor(unittest.TestCase):
         # stop test runtime
         runtime.stop()
 
-    #region Mocks
-    def mock_package_manager_get_current_auto_os_patch_state_returns_unknown(self):
-        if self.mock_package_manager_get_current_auto_os_patch_state_returns_unknown_call_count == 0:
-            self.mock_package_manager_get_current_auto_os_patch_state_returns_unknown_call_count = 1
-            return Constants.AutomaticOSPatchStates.DISABLED
-        else:
-            return Constants.AutomaticOSPatchStates.UNKNOWN
-    #endregion Mocks
+    def test_operation_success_for_configure_patching_request_for_apt_without_default_updates_config(self):
+        # default auto OS updates config file not found on the machine
+        argument_composer = ArgumentComposer()
+        argument_composer.operation = Constants.CONFIGURE_PATCHING
+        argument_composer.patch_mode = Constants.PatchModes.AUTOMATIC_BY_PLATFORM
+        runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.APT)
+        runtime.package_manager.get_current_auto_os_patch_state = runtime.backup_get_current_auto_os_patch_state
+        runtime.set_legacy_test_type('HappyPath')
+        CoreMain(argument_composer.get_composed_arguments())
+
+        # check telemetry events
+        self.__check_telemetry_events(runtime)
+
+        # check status file
+        with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
+            substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
+        self.assertEqual(len(substatus_file_data), 2)
+        self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)   # assessment is now part of the CP flow
+        self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
+        self.assertTrue(substatus_file_data[1]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
+        self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_SUCCESS.lower())
+        runtime.stop()
 
     def test_operation_success_for_installation_request_with_configure_patching(self):
         argument_composer = ArgumentComposer()
@@ -161,29 +184,6 @@ class TestConfigurePatchingProcessor(unittest.TestCase):
             self.assertTrue(Constants.STATUS_ERROR in json.loads(substatus_file_data[0]["formattedMessage"]["message"])["autoAssessmentStatus"]["autoAssessmentState"])
         else:
             self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
-        runtime.stop()
-
-    def test_operation_success_for_configure_patching_request_for_apt(self):
-        # default auto OS updates config file not found on the machine
-        argument_composer = ArgumentComposer()
-        argument_composer.operation = Constants.CONFIGURE_PATCHING
-        argument_composer.patch_mode = Constants.PatchModes.AUTOMATIC_BY_PLATFORM
-        runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.APT)
-        runtime.package_manager.get_current_auto_os_patch_state = runtime.backup_get_current_auto_os_patch_state
-        runtime.set_legacy_test_type('HappyPath')
-        CoreMain(argument_composer.get_composed_arguments())
-
-        # check telemetry events
-        self.__check_telemetry_events(runtime)
-
-        # check status file
-        with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
-            substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
-        self.assertEqual(len(substatus_file_data), 2)
-        self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)   # assessment is now part of the CP flow
-        self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
-        self.assertTrue(substatus_file_data[1]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
-        self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         runtime.stop()
 
     def test_patch_mode_set_failure_for_configure_patching(self):

--- a/src/core/tests/Test_ConfigurePatchingProcessor.py
+++ b/src/core/tests/Test_ConfigurePatchingProcessor.py
@@ -163,7 +163,7 @@ class TestConfigurePatchingProcessor(unittest.TestCase):
             self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         runtime.stop()
 
-    def test_operation_fail_for_configure_patching_request_for_apt(self):
+    def test_operation_success_for_configure_patching_request_for_apt(self):
         # default auto OS updates config file not found on the machine
         argument_composer = ArgumentComposer()
         argument_composer.operation = Constants.CONFIGURE_PATCHING
@@ -183,7 +183,7 @@ class TestConfigurePatchingProcessor(unittest.TestCase):
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)   # assessment is now part of the CP flow
         self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         self.assertTrue(substatus_file_data[1]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
-        self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_ERROR.lower())
+        self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         runtime.stop()
 
     def test_patch_mode_set_failure_for_configure_patching(self):

--- a/src/core/tests/Test_ConfigurePatchingProcessor.py
+++ b/src/core/tests/Test_ConfigurePatchingProcessor.py
@@ -308,34 +308,6 @@ class TestConfigurePatchingProcessor(unittest.TestCase):
         # stop test runtime
         runtime.stop()
 
-    def test_patch_mode_disabled_for_configure_patching_with_no_os_patch_configuration_settings_file(self):
-        argument_composer = ArgumentComposer()
-        argument_composer.operation = Constants.CONFIGURE_PATCHING
-        argument_composer.patch_mode = Constants.PatchModes.AUTOMATIC_BY_PLATFORM
-        argument_composer.assessment_mode = "LetsThrowAnException"
-        runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.APT)
-        runtime.package_manager.get_current_auto_os_patch_state = runtime.backup_get_current_auto_os_patch_state
-        runtime.set_legacy_test_type('HappyPath')
-
-        # Execute main
-        CoreMain(argument_composer.get_composed_arguments())
-
-        # check telemetry events
-        self.__check_telemetry_events(runtime)
-
-        # check status file
-        with runtime.env_layer.file_system.open(runtime.execution_config.status_file_path, 'r') as file_handle:
-            substatus_file_data = json.load(file_handle)[0]["status"]["substatus"]
-        self.assertEqual(len(substatus_file_data), 2)
-        self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)   # assessment is now part of the CP flow
-        self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_SUCCESS.lower())
-        self.assertTrue(substatus_file_data[1]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
-        self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_ERROR.lower())
-        message = json.loads(substatus_file_data[1]["formattedMessage"]["message"])
-        self.assertEqual(message["automaticOSPatchState"], Constants.AutomaticOSPatchStates.DISABLED)
-
-        runtime.stop()
-
     def __check_telemetry_events(self, runtime):
         all_events = os.listdir(runtime.telemetry_writer.events_folder_path)
         self.assertTrue(len(all_events) > 0)


### PR DESCRIPTION
Issue:
- ConfigurePatching is marked as failed if '/etc/apt/apt.conf.d/20auto-upgrades' is not found. 

'/etc/apt/apt.conf.d/20auto-upgrades' not existing on a VM has been observed to be an indication that default auto updates are not configured. The config file is only created the very first time auto updates are configured on the machine.  Hence, non existence of the file can be safely considered as default auto updates are disabled. This also aligns with the implementation patterns used in YUM and Zypper package managers where a config not existing is considered as default updates disabled.

Desired behavior from this PR:
If '/etc/apt/apt.conf.d/20auto-upgrades' is not found:
- automaticOSPatchState in Configure Patching is marked as Disabled
- ConfigurePatching status does not fail due to this config not existing