### PR TITLE
Updating extension version to 1.6.48 for a new release

### DIFF
--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -30,7 +30,7 @@ class Constants(object):
     UNKNOWN = "Unknown"
 
     # Extension version (todo: move to a different file)
-    EXT_VERSION = "1.6.47"
+    EXT_VERSION = "1.6.48"
 
     # Runtime environments
     TEST = 'Test'

--- a/src/extension/src/Constants.py
+++ b/src/extension/src/Constants.py
@@ -28,7 +28,7 @@ class Constants(object):
                         yield item
 
     # Extension version (todo: move to a different file)
-    EXT_VERSION = "1.6.47"
+    EXT_VERSION = "1.6.48"
 
     # Runtime environments
     TEST = 'Test'

--- a/src/extension/src/manifest.xml
+++ b/src/extension/src/manifest.xml
@@ -2,7 +2,7 @@
 <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure">
   <ProviderNameSpace>Microsoft.CPlat.Core</ProviderNameSpace>
   <Type>LinuxPatchExtension</Type>
-  <Version>1.6.47</Version>
+  <Version>1.6.48</Version>
   <Label>Microsoft Azure VM InGuest Patch Extension for Linux Virtual Machines</Label>
   <HostingResources>VmRole</HostingResources>
   <MediaLink></MediaLink>


### PR DESCRIPTION
This release will include following changes:

- Fixing python 2.7 issues with code coverage checks linked on repo: [197](https://github.com/Azure/LinuxPatchExtension/pull/197), [201](https://github.com/Azure/LinuxPatchExtension/pull/201), 
- Add ordered dictionary for quicker look up of Assessment packages in StatusHandler [193](https://github.com/Azure/LinuxPatchExtension/pull/193)
- Add ordered dictionary for quicker look up of Installation packages in StatusHandler [194](https://github.com/Azure/LinuxPatchExtension/pull/194)
- Setting auto assessment service to type: forking: [203](https://github.com/Azure/LinuxPatchExtension/pull/203)
- add complete status file logic: [195](https://github.com/Azure/LinuxPatchExtension/pull/195)
- Fix NameError: name 'OrderedDict' is not defined during runtime: [204](https://github.com/Azure/LinuxPatchExtension/pull/204)
- telemetry change to get esm packages selected count: [202](https://github.com/Azure/LinuxPatchExtension/pull/202)
- Adding more sources to security sources list: [208](https://github.com/Azure/LinuxPatchExtension/pull/208)
- raise exception if min py version is < 2.7: [207](https://github.com/Azure/LinuxPatchExtension/pull/207)
- For yum package manager only, sometimes VM gets rebooted in install updates job even though reboot is not required: [210](https://github.com/Azure/LinuxPatchExtension/pull/210)
- remove old complete status file: [205](https://github.com/Azure/LinuxPatchExtension/pull/205)
- APT: Patch Mode set to disabled in ConfigurePatching when os patch config file does not exist: [216](https://github.com/Azure/LinuxPatchExtension/pull/216)
- Adding EULA acceptance based on an inVM approval mechanism: [215](https://github.com/Azure/LinuxPatchExtension/pull/215)