### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           fail_ci_if_error: true
       - name: Read test output
         id: getoutput
-        run: echo "::set-output name=contents::$(cat err.txt)"
+        run: echo "contents=$(cat err.txt)" >> $GITHUB_OUTPUT
       - name: Check if all tests passed
         if: contains( steps.getoutput.outputs.contents, 'FAILED (failures=' )
         shell: cmd
@@ -114,7 +114,7 @@ jobs:
           fail_ci_if_error: true
       - name: Read test output
         id: getoutput
-        run: echo "::set-output name=contents::$(cat err2.txt)"
+        run: echo "contents=$(cat err2.txt)" >> $GITHUB_OUTPUT
       - name: Check if all tests passed
         if: contains( steps.getoutput.outputs.contents, 'FAILED (failures=' )
         run: |


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter`