### PR TITLE
add encoding propertity to resolve pro-client prerequist error

### DIFF
--- a/src/core/src/local_loggers/StdOutFileMirror.py
+++ b/src/core/src/local_loggers/StdOutFileMirror.py
@@ -26,6 +26,7 @@ class StdOutFileMirror(object):
         self.env_layer = env_layer
         self.terminal = sys.stdout  # preserve for recovery
         self.file_logger = file_logger
+        self.encoding = 'UTF-8'
         splash = "\n,---.                        ,---.     |         |        ,-.-.                                        |    \n|---|,---,.   .,---.,---.    |---',---.|--- ,---.|---.    | | |,---.,---.,---.,---.,---.,-.-.,---.,---.|--- \n|   | .-' |   ||    |---'    |    ,---||    |    |   |    | | |,---||   |,---||   ||---'| | ||---'|   ||    \n`   ''---'`---'`    `---'    `    `---^`---'`---'`   '    ` ' '`---^`   '`---^`---|`---'` ' '`---'`   '`---'\n                                                                              `---'                         "
 
         if self.file_logger.log_file_handle is not None:


### PR DESCRIPTION
* fixed ubuntu pro client pre-requisites error - StdOutFileMirror no attribute of encoding
* prior code change:
![image](https://github.com/Azure/LinuxPatchExtension/assets/127874208/dab0e698-5e11-4c97-8ee0-0017f64d34ea)
* post code change:
![image](https://github.com/Azure/LinuxPatchExtension/assets/127874208/64ef8231-2d38-4159-a345-aa7e77a5efdb)
