### PR TITLE
Fix/unicode in py27 utests

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -29,6 +29,4 @@ coverage:
         if_not_found: failure
     ignore:
       - "*/tests/*"
-      - "*_test.*"
-      - "*test_*"
-      - "Test_*"
+      - "*/tests/Test_"

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -27,5 +27,5 @@ coverage:
         threshold: 0%
         if_ci_failed: error
         if_not_found: failure
-    ignore:
-      - "**/tests/*"
+ignore:
+  - "src/core/tests/*"

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -27,6 +27,3 @@ coverage:
         threshold: 0%
         if_ci_failed: error
         if_not_found: failure
-    ignore:
-      - "*/tests/*"
-      - "*/tests/Test_"

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -27,3 +27,8 @@ coverage:
         threshold: 0%
         if_ci_failed: error
         if_not_found: failure
+    ignore:
+      - "*/tests/*"
+      - "*_test.*"
+      - "*test_*"
+      - "Test_*"

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -27,3 +27,5 @@ coverage:
         threshold: 0%
         if_ci_failed: error
         if_not_found: failure
+    ignore:
+      - "**/tests/*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
       PYTHONTRACEMALLOC: 1
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Install dependencies
@@ -41,14 +41,14 @@ jobs:
           cd ../../extension/tests
           coverage xml
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v3.1.5
         with:
           flags: python39
           name: python-39
           fail_ci_if_error: true
       - name: Read test output
         id: getoutput
-        run: echo "::set-output name=contents::$(cat err.txt)"
+        run: echo "contents=$(cat err.txt)" >> $GITHUB_OUTPUT
       - name: Check if all tests passed
         if: contains( steps.getoutput.outputs.contents, 'FAILED (failures=' )
         shell: cmd
@@ -60,9 +60,9 @@ jobs:
     needs: codecov-python-39
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Restore Python 2.7 cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: C:\Python27
           key: python27-cache
@@ -75,7 +75,7 @@ jobs:
             SETX PATH "%PATH%;C:\Python27"
           )
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: '%UserProfile%\.cache\pip'
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
@@ -107,14 +107,14 @@ jobs:
           cd ../../extension/tests
           coverage xml
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v3.1.5
         with:
           flags: python27
           name: python-27
           fail_ci_if_error: true
       - name: Read test output
         id: getoutput
-        run: echo "::set-output name=contents::$(cat err2.txt)"
+        run: echo "contents=$(cat err2.txt)" >> $GITHUB_OUTPUT
       - name: Check if all tests passed
         if: contains( steps.getoutput.outputs.contents, 'FAILED (failures=' )
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: pwd
       - name: Print test output
         if: always()
-        run: cat ..\..\..\err.txt
+        run: D:\a\LinuxPatchExtension\LinuxPatchExtension\err.txt
       - name: Collect coverage
         run: |
           cd ./src/core/tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: pwd
       - name: Print test output
         if: always()
-        run: cat ../../../err.txt
+        run: cat ..\..\..\err.txt
       - name: Collect coverage
         run: |
           cd ./src/core/tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,9 @@ jobs:
         run: D:\a\LinuxPatchExtension\LinuxPatchExtension\err.txt
       - name: Collect coverage
         run: |
-          cd ./src/core/tests
+          cd ./src/core
           coverage xml
-          cd ../../extension/tests
+          cd ../../extension
           coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3.1.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
           echo '===============START CORE TESTS...===============' >> ../../../err.txt
           coverage run -m unittest discover -s . -t ../../ 2>> ../../../err.txt
           echo '===============FINISH CORE TESTS...===============' >> ../../../err.txt
+      - name: Print current directory
+        run: pwd
       - name: Print test output
         if: always()
         run: cat ../../../err.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
           echo '===============START CORE TESTS...===============' >> ../../../err.txt
           coverage run -m unittest discover -s . -t ../../ 2>> ../../../err.txt
           echo '===============FINISH CORE TESTS...===============' >> ../../../err.txt
+      - name: Print test output
+        if: always()
+        run: cat ../../../err.txt
       - name: Collect coverage
         run: |
           cd ./src/core/tests

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ parts/
 sdist/
 var/
 wheels/
+scratch/
 pip-wheel-metadata/
 share/python-wheels/
 *.egg-info/

--- a/src/core/src/service_interfaces/TelemetryWriter.py
+++ b/src/core/src/service_interfaces/TelemetryWriter.py
@@ -22,7 +22,6 @@ import shutil
 import tempfile
 import time
 
-from six import text_type
 from core.src.bootstrap.Constants import Constants
 
 
@@ -145,19 +144,19 @@ class TelemetryWriter(object):
         Adds a telemetry event counter at the end of every event, irrespective of truncation, which can be used in debugging operation flow. """
 
         try:
-            print('full_message', full_message)
-            print('full_message type', type(full_message))
             message_size_limit_in_chars = Constants.TELEMETRY_MSG_SIZE_LIMIT_IN_CHARS
 
-            if isinstance(full_message, bytes):
-                full_message = full_message.decode('utf-8')
-
+            # if isinstance(full_message, str):
+            #     print('full_message type1', type(full_message))
+            #     full_message = full_message.decode('utf-8')
+            #     print('full_message type2', type(full_message))
+            print('full_message type1', type(full_message))
             formatted_message = re.sub(r"\s+", " ", full_message)
-            print('what is formatted_message', formatted_message)
 
             if len(formatted_message.encode('utf-8')) + Constants.TELEMETRY_EVENT_COUNTER_MSG_SIZE_LIMIT_IN_CHARS > message_size_limit_in_chars:
-                print('problem1')
-                self.composite_logger.log_telemetry_module("Data sent to telemetry will be truncated as it exceeds size limit. [Message={0}]".format(formatted_message if isinstance(formatted_message, str) else formatted_message.decode('utf-8')))
+                print('formatted_message type', type(formatted_message))
+                #self.composite_logger.log_telemetry_module("Data sent to telemetry will be truncated as it exceeds size limit. [Message={0}]".format(formatted_message if isinstance(formatted_message, six.text_type) else formatted_message))
+                self.composite_logger.log_telemetry_module("Data sent to telemetry will be truncated as it exceeds size limit. [Message={0}]".format(formatted_message.encode('utf-8')))
                 print('problem2')
                 formatted_message = formatted_message.encode('utf-8')
                 chars_dropped = len(formatted_message) - message_size_limit_in_chars + Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_CHARS + Constants.TELEMETRY_EVENT_COUNTER_MSG_SIZE_LIMIT_IN_CHARS

--- a/src/core/src/service_interfaces/TelemetryWriter.py
+++ b/src/core/src/service_interfaces/TelemetryWriter.py
@@ -151,6 +151,8 @@ class TelemetryWriter(object):
             #     full_message = full_message.decode('utf-8')
             #     print('full_message type2', type(full_message))
             print('full_message type1', type(full_message))
+            print('full_message ', full_message)
+
             formatted_message = re.sub(r"\s+", " ", full_message)
 
             if len(formatted_message.encode('utf-8')) + Constants.TELEMETRY_EVENT_COUNTER_MSG_SIZE_LIMIT_IN_CHARS > message_size_limit_in_chars:

--- a/src/core/src/service_interfaces/TelemetryWriter.py
+++ b/src/core/src/service_interfaces/TelemetryWriter.py
@@ -24,7 +24,6 @@ import time
 import traceback
 
 from six import text_type
-
 from core.src.bootstrap.Constants import Constants
 
 
@@ -215,7 +214,7 @@ class TelemetryWriter(object):
                 self.__write_event_using_temp_file(file_path, all_events)
 
         except Exception as e:
-            print(traceback.format_exc())
+            print(traceback.format_exc())  # great for analyze bug at specific point in the code, pushes exception down the stack
             self.composite_logger.log_telemetry_module_error("Error occurred while writing telemetry events. [Error={0}]".format(repr(e)))
             raise Exception("Internal reporting error. Execution could not complete.")
 

--- a/src/core/src/service_interfaces/TelemetryWriter.py
+++ b/src/core/src/service_interfaces/TelemetryWriter.py
@@ -21,7 +21,6 @@ import re
 import shutil
 import tempfile
 import time
-import traceback
 
 from six import text_type
 from core.src.bootstrap.Constants import Constants
@@ -214,7 +213,6 @@ class TelemetryWriter(object):
                 self.__write_event_using_temp_file(file_path, all_events)
 
         except Exception as e:
-            print(traceback.format_exc())  # great for analyze bug at specific point in the code, pushes exception down the stack
             self.composite_logger.log_telemetry_module_error("Error occurred while writing telemetry events. [Error={0}]".format(repr(e)))
             raise Exception("Internal reporting error. Execution could not complete.")
 

--- a/src/core/src/service_interfaces/TelemetryWriter.py
+++ b/src/core/src/service_interfaces/TelemetryWriter.py
@@ -146,13 +146,12 @@ class TelemetryWriter(object):
 
         try:
             message_size_limit_in_chars = Constants.TELEMETRY_MSG_SIZE_LIMIT_IN_CHARS
-            #formatted_message = re.sub(r"\s+", " ", text_type(full_message))  # text_type provides compatibility in py27 for unicode str input as str
-            formatted_message = re.sub(r"\s+", " ", str(full_message))  # text_type provides compatibility in py27 for unicode str input as str
+            formatted_message = re.sub(r"\s+", " ", text_type(full_message))  # text_type provides compatibility in py27 for unicode str input as str
 
             if len(formatted_message.encode('utf-8')) + Constants.TELEMETRY_EVENT_COUNTER_MSG_SIZE_LIMIT_IN_CHARS > message_size_limit_in_chars:
-                # formatted_message = formatted_message.encode('utf-8')
-                self.composite_logger.log_telemetry_module("Data sent to telemetry will be truncated as it exceeds size limit. [Message={0}]".format(str(formatted_message)))
                 formatted_message = formatted_message.encode('utf-8')
+                self.composite_logger.log_telemetry_module("Data sent to telemetry will be truncated as it exceeds size limit. [Message={0}]".format(str(formatted_message)))
+                # formatted_message = formatted_message.encode('utf-8')
                 chars_dropped = len(formatted_message) - message_size_limit_in_chars + Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_CHARS + Constants.TELEMETRY_EVENT_COUNTER_MSG_SIZE_LIMIT_IN_CHARS
                 formatted_message = formatted_message[:message_size_limit_in_chars - Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_CHARS - Constants.TELEMETRY_EVENT_COUNTER_MSG_SIZE_LIMIT_IN_CHARS].decode('utf-8', errors='replace') + '. [{0} chars dropped]'.format(chars_dropped)
 

--- a/src/core/src/service_interfaces/TelemetryWriter.py
+++ b/src/core/src/service_interfaces/TelemetryWriter.py
@@ -22,6 +22,7 @@ import shutil
 import tempfile
 import time
 
+from six import text_type
 from core.src.bootstrap.Constants import Constants
 
 
@@ -144,11 +145,20 @@ class TelemetryWriter(object):
         Adds a telemetry event counter at the end of every event, irrespective of truncation, which can be used in debugging operation flow. """
 
         try:
+            print('full_message', full_message)
+            print('full_message type', type(full_message))
             message_size_limit_in_chars = Constants.TELEMETRY_MSG_SIZE_LIMIT_IN_CHARS
-            formatted_message = re.sub(r"\s+", " ", str(full_message))
+
+            if isinstance(full_message, bytes):
+                full_message = full_message.decode('utf-8')
+
+            formatted_message = re.sub(r"\s+", " ", full_message)
+            print('what is formatted_message', formatted_message)
 
             if len(formatted_message.encode('utf-8')) + Constants.TELEMETRY_EVENT_COUNTER_MSG_SIZE_LIMIT_IN_CHARS > message_size_limit_in_chars:
-                self.composite_logger.log_telemetry_module("Data sent to telemetry will be truncated as it exceeds size limit. [Message={0}]".format(str(formatted_message)))
+                print('problem1')
+                self.composite_logger.log_telemetry_module("Data sent to telemetry will be truncated as it exceeds size limit. [Message={0}]".format(formatted_message if isinstance(formatted_message, str) else formatted_message.decode('utf-8')))
+                print('problem2')
                 formatted_message = formatted_message.encode('utf-8')
                 chars_dropped = len(formatted_message) - message_size_limit_in_chars + Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_CHARS + Constants.TELEMETRY_EVENT_COUNTER_MSG_SIZE_LIMIT_IN_CHARS
                 formatted_message = formatted_message[:message_size_limit_in_chars - Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_CHARS - Constants.TELEMETRY_EVENT_COUNTER_MSG_SIZE_LIMIT_IN_CHARS].decode('utf-8', errors='replace') + '. [{0} chars dropped]'.format(chars_dropped)

--- a/src/core/src/service_interfaces/TelemetryWriter.py
+++ b/src/core/src/service_interfaces/TelemetryWriter.py
@@ -146,11 +146,13 @@ class TelemetryWriter(object):
 
         try:
             message_size_limit_in_chars = Constants.TELEMETRY_MSG_SIZE_LIMIT_IN_CHARS
-            formatted_message = re.sub(r"\s+", " ", text_type(full_message))  # text_type provides compatibility in py27 for unicode str input as str
+            #formatted_message = re.sub(r"\s+", " ", text_type(full_message))  # text_type provides compatibility in py27 for unicode str input as str
+            formatted_message = re.sub(r"\s+", " ", str(full_message))  # text_type provides compatibility in py27 for unicode str input as str
 
             if len(formatted_message.encode('utf-8')) + Constants.TELEMETRY_EVENT_COUNTER_MSG_SIZE_LIMIT_IN_CHARS > message_size_limit_in_chars:
+                # formatted_message = formatted_message.encode('utf-8')
+                self.composite_logger.log_telemetry_module("Data sent to telemetry will be truncated as it exceeds size limit. [Message={0}]".format(str(formatted_message)))
                 formatted_message = formatted_message.encode('utf-8')
-                self.composite_logger.log_telemetry_module("Data sent to telemetry will be truncated as it exceeds size limit. [Message={0}]".format(formatted_message))
                 chars_dropped = len(formatted_message) - message_size_limit_in_chars + Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_CHARS + Constants.TELEMETRY_EVENT_COUNTER_MSG_SIZE_LIMIT_IN_CHARS
                 formatted_message = formatted_message[:message_size_limit_in_chars - Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_CHARS - Constants.TELEMETRY_EVENT_COUNTER_MSG_SIZE_LIMIT_IN_CHARS].decode('utf-8', errors='replace') + '. [{0} chars dropped]'.format(chars_dropped)
 

--- a/src/core/tests/Test_TelemetryWriter.py
+++ b/src/core/tests/Test_TelemetryWriter.py
@@ -103,15 +103,15 @@ class TestTelemetryWriter(unittest.TestCase):
             self.assertTrue("a"*(len(message.encode('utf-8')) - chars_dropped) + ". [{0} chars dropped]".format(chars_dropped) in events[-1]["Message"])
             f.close()
 
-    def test_write_event_msg_size_limit_char_with_actual_unicode_str(self):
-        """ Perform 1 byte truncation on unicode str that is more than 1 byte, use decode('utf-8', errors='replace') to replace bad unicode with a good 1 byte char (�) """
-        message = u"a€bc"*3074  # €(\xe2\x82\xac) is 3 bytes char can be written in windows console w/o encoding
-        self.__assert_write_event_msg_size_limit_char(message)
+    # def test_write_event_msg_size_limit_char_with_actual_unicode_str(self):
+    #     """ Perform 1 byte truncation on unicode str that is more than 1 byte, use decode('utf-8', errors='replace') to replace bad unicode with a good 1 byte char (�) """
+    #     message = u"a€bc"*3074  # €(\xe2\x82\xac) is 3 bytes char can be written in windows console w/o encoding
+    #     self.__assert_write_event_msg_size_limit_char(message)
 
-    def test_write_event_msg_size_limit_char_with_unicode_point(self):
-        """ Perform 1 byte truncation on unicode code point str that is more than 1 byte, use decode('utf-8', errors='replace') to replace bad unicode with a good 1 byte char (�) """
-        message = u"a\u20acbc"*3074  # unicode code point €(\xe2\x82\xac) is 3 bytes char can be written in windows console w/o encoding
-        self.__assert_write_event_msg_size_limit_char(message)
+    # def test_write_event_msg_size_limit_char_with_unicode_point(self):
+    #     """ Perform 1 byte truncation on unicode code point str that is more than 1 byte, use decode('utf-8', errors='replace') to replace bad unicode with a good 1 byte char (�) """
+    #     message = u"a\u20acbc"*3074  # unicode code point €(\xe2\x82\xac) is 3 bytes char can be written in windows console w/o encoding
+    #     self.__assert_write_event_msg_size_limit_char(message)
 
     # TODO: The following 3 tests cause widespread test suite failures (on master), so leaving it out. And tracking in: Task 10912099: [Bug] Bug in telemetry writer - overwriting prior events in fast execution
     # def test_write_event_size_limit(self):

--- a/src/core/tests/Test_TelemetryWriter.py
+++ b/src/core/tests/Test_TelemetryWriter.py
@@ -103,15 +103,15 @@ class TestTelemetryWriter(unittest.TestCase):
             self.assertTrue("a"*(len(message.encode('utf-8')) - chars_dropped) + ". [{0} chars dropped]".format(chars_dropped) in events[-1]["Message"])
             f.close()
 
-    # def test_write_event_msg_size_limit_char_with_actual_unicode_str(self):
-    #     """ Perform 1 byte truncation on unicode str that is more than 1 byte, use decode('utf-8', errors='replace') to replace bad unicode with a good 1 byte char (�) """
-    #     message = u"a€bc"*3074  # €(\xe2\x82\xac) is 3 bytes char can be written in windows console w/o encoding
-    #     self.__assert_write_event_msg_size_limit_char(message)
+    def test_write_event_msg_size_limit_char_with_actual_unicode_str(self):
+        """ Perform 1 byte truncation on unicode str that is more than 1 byte, use decode('utf-8', errors='replace') to replace bad unicode with a good 1 byte char (�) """
+        message = u"a€bc"*3074  # €(\xe2\x82\xac) is 3 bytes char can be written in windows console w/o encoding
+        self.__assert_write_event_msg_size_limit_char(message)
 
-    # def test_write_event_msg_size_limit_char_with_unicode_point(self):
-    #     """ Perform 1 byte truncation on unicode code point str that is more than 1 byte, use decode('utf-8', errors='replace') to replace bad unicode with a good 1 byte char (�) """
-    #     message = u"a\u20acbc"*3074  # unicode code point €(\xe2\x82\xac) is 3 bytes char can be written in windows console w/o encoding
-    #     self.__assert_write_event_msg_size_limit_char(message)
+    def test_write_event_msg_size_limit_char_with_unicode_point(self):
+        """ Perform 1 byte truncation on unicode code point str that is more than 1 byte, use decode('utf-8', errors='replace') to replace bad unicode with a good 1 byte char (�) """
+        message = u"a\u20acbc"*3074  # unicode code point €(\xe2\x82\xac) is 3 bytes char can be written in windows console w/o encoding
+        self.__assert_write_event_msg_size_limit_char(message)
 
     # TODO: The following 3 tests cause widespread test suite failures (on master), so leaving it out. And tracking in: Task 10912099: [Bug] Bug in telemetry writer - overwriting prior events in fast execution
     # def test_write_event_size_limit(self):
@@ -304,18 +304,18 @@ class TestTelemetryWriter(unittest.TestCase):
             f.close()
             self.assertTrue(text_found.string.startswith("Message 1"))
 
-    # def __assert_write_event_msg_size_limit_char(self, message):
-    #     self.runtime.telemetry_writer.write_event(message, Constants.TelemetryEventLevel.Error, "Test Task")
-    #     latest_event_file = [pos_json for pos_json in os.listdir(self.runtime.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)][-1]
-    #     with open(os.path.join(self.runtime.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:
-    #         events = json.load(f)
-    #         self.assertTrue(events is not None)
-    #         self.assertEqual(events[-1]["TaskName"], "Test Task")
-    #         self.assertTrue(len(events[-1]["Message"]) < len(message.encode('utf-8')))
-    #         chars_dropped = len(message.encode('utf-8')) - Constants.TELEMETRY_MSG_SIZE_LIMIT_IN_CHARS + Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_CHARS + Constants.TELEMETRY_EVENT_COUNTER_MSG_SIZE_LIMIT_IN_CHARS
-    #         self.assertTrue(u"a\u20acbc" in events[-1]["Message"])
-    #         self.assertTrue(u"a\u20acb c" * (len(message) + 1 - chars_dropped) + ". [{0} chars dropped]".format(chars_dropped) in events[-1]["Message"])  # len(message) + 1 due to bad unicode will be replaced by �
-    #         f.close()
+    def __assert_write_event_msg_size_limit_char(self, message):
+        self.runtime.telemetry_writer.write_event(message, Constants.TelemetryEventLevel.Error, "Test Task")
+        latest_event_file = [pos_json for pos_json in os.listdir(self.runtime.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)][-1]
+        with open(os.path.join(self.runtime.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:
+            events = json.load(f)
+            self.assertTrue(events is not None)
+            self.assertEqual(events[-1]["TaskName"], "Test Task")
+            self.assertTrue(len(events[-1]["Message"]) < len(message.encode('utf-8')))
+            chars_dropped = len(message.encode('utf-8')) - Constants.TELEMETRY_MSG_SIZE_LIMIT_IN_CHARS + Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_CHARS + Constants.TELEMETRY_EVENT_COUNTER_MSG_SIZE_LIMIT_IN_CHARS
+            self.assertTrue(u"a\u20acbc" in events[-1]["Message"])
+            self.assertTrue(u"a\u20acb c" * (len(message) + 1 - chars_dropped) + ". [{0} chars dropped]".format(chars_dropped) in events[-1]["Message"])  # len(message) + 1 due to bad unicode will be replaced by �
+            f.close()
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/core/tests/Test_TelemetryWriter.py
+++ b/src/core/tests/Test_TelemetryWriter.py
@@ -103,15 +103,15 @@ class TestTelemetryWriter(unittest.TestCase):
             self.assertTrue("a"*(len(message.encode('utf-8')) - chars_dropped) + ". [{0} chars dropped]".format(chars_dropped) in events[-1]["Message"])
             f.close()
 
-    def test_write_event_msg_size_limit_char_with_actual_unicode_str(self):
-        """ Perform 1 byte truncation on unicode str that is more than 1 byte, use decode('utf-8', errors='replace') to replace bad unicode with a good 1 byte char (�) """
-        message = u"a€bc"*3074  # €(\xe2\x82\xac) is 3 bytes char can be written in windows console w/o encoding
-        self.__assert_write_event_msg_size_limit_char(message)
-
-    def test_write_event_msg_size_limit_char_with_unicode_point(self):
-        """ Perform 1 byte truncation on unicode code point str that is more than 1 byte, use decode('utf-8', errors='replace') to replace bad unicode with a good 1 byte char (�) """
-        message = u"a\u20acbc"*3074  # unicode code point €(\xe2\x82\xac) is 3 bytes char can be written in windows console w/o encoding
-        self.__assert_write_event_msg_size_limit_char(message)
+    # def test_write_event_msg_size_limit_char_with_actual_unicode_str(self):
+    #     """ Perform 1 byte truncation on unicode str that is more than 1 byte, use decode('utf-8', errors='replace') to replace bad unicode with a good 1 byte char (�) """
+    #     message = u"a€bc"*3074  # €(\xe2\x82\xac) is 3 bytes char can be written in windows console w/o encoding
+    #     self.__assert_write_event_msg_size_limit_char(message)
+    #
+    # def test_write_event_msg_size_limit_char_with_unicode_point(self):
+    #     """ Perform 1 byte truncation on unicode code point str that is more than 1 byte, use decode('utf-8', errors='replace') to replace bad unicode with a good 1 byte char (�) """
+    #     message = u"a\u20acbc"*3074  # unicode code point €(\xe2\x82\xac) is 3 bytes char can be written in windows console w/o encoding
+    #     self.__assert_write_event_msg_size_limit_char(message)
 
     # TODO: The following 3 tests cause widespread test suite failures (on master), so leaving it out. And tracking in: Task 10912099: [Bug] Bug in telemetry writer - overwriting prior events in fast execution
     # def test_write_event_size_limit(self):
@@ -304,18 +304,18 @@ class TestTelemetryWriter(unittest.TestCase):
             f.close()
             self.assertTrue(text_found.string.startswith("Message 1"))
 
-    def __assert_write_event_msg_size_limit_char(self, message):
-        self.runtime.telemetry_writer.write_event(message, Constants.TelemetryEventLevel.Error, "Test Task")
-        latest_event_file = [pos_json for pos_json in os.listdir(self.runtime.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)][-1]
-        with open(os.path.join(self.runtime.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:
-            events = json.load(f)
-            self.assertTrue(events is not None)
-            self.assertEqual(events[-1]["TaskName"], "Test Task")
-            self.assertTrue(len(events[-1]["Message"]) < len(message.encode('utf-8')))
-            chars_dropped = len(message.encode('utf-8')) - Constants.TELEMETRY_MSG_SIZE_LIMIT_IN_CHARS + Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_CHARS + Constants.TELEMETRY_EVENT_COUNTER_MSG_SIZE_LIMIT_IN_CHARS
-            self.assertTrue(u"a\u20acbc" in events[-1]["Message"])
-            self.assertTrue(u"a\u20acb c" * (len(message) + 1 - chars_dropped) + ". [{0} chars dropped]".format(chars_dropped) in events[-1]["Message"])  # len(message) + 1 due to bad unicode will be replaced by �
-            f.close()
+    # def __assert_write_event_msg_size_limit_char(self, message):
+    #     self.runtime.telemetry_writer.write_event(message, Constants.TelemetryEventLevel.Error, "Test Task")
+    #     latest_event_file = [pos_json for pos_json in os.listdir(self.runtime.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)][-1]
+    #     with open(os.path.join(self.runtime.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:
+    #         events = json.load(f)
+    #         self.assertTrue(events is not None)
+    #         self.assertEqual(events[-1]["TaskName"], "Test Task")
+    #         self.assertTrue(len(events[-1]["Message"]) < len(message.encode('utf-8')))
+    #         chars_dropped = len(message.encode('utf-8')) - Constants.TELEMETRY_MSG_SIZE_LIMIT_IN_CHARS + Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_CHARS + Constants.TELEMETRY_EVENT_COUNTER_MSG_SIZE_LIMIT_IN_CHARS
+    #         self.assertTrue(u"a\u20acbc" in events[-1]["Message"])
+    #         self.assertTrue(u"a\u20acb c" * (len(message) + 1 - chars_dropped) + ". [{0} chars dropped]".format(chars_dropped) in events[-1]["Message"])  # len(message) + 1 due to bad unicode will be replaced by �
+    #         f.close()
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/core/tests/Test_TelemetryWriter.py
+++ b/src/core/tests/Test_TelemetryWriter.py
@@ -103,15 +103,15 @@ class TestTelemetryWriter(unittest.TestCase):
             self.assertTrue("a"*(len(message.encode('utf-8')) - chars_dropped) + ". [{0} chars dropped]".format(chars_dropped) in events[-1]["Message"])
             f.close()
 
-    # def test_write_event_msg_size_limit_char_with_actual_unicode_str(self):
-    #     """ Perform 1 byte truncation on unicode str that is more than 1 byte, use decode('utf-8', errors='replace') to replace bad unicode with a good 1 byte char (�) """
-    #     message = u"a€bc"*3074  # €(\xe2\x82\xac) is 3 bytes char can be written in windows console w/o encoding
-    #     self.__assert_write_event_msg_size_limit_char(message)
-    #
-    # def test_write_event_msg_size_limit_char_with_unicode_point(self):
-    #     """ Perform 1 byte truncation on unicode code point str that is more than 1 byte, use decode('utf-8', errors='replace') to replace bad unicode with a good 1 byte char (�) """
-    #     message = u"a\u20acbc"*3074  # unicode code point €(\xe2\x82\xac) is 3 bytes char can be written in windows console w/o encoding
-    #     self.__assert_write_event_msg_size_limit_char(message)
+    def test_write_event_msg_size_limit_char_with_actual_unicode_str(self):
+        """ Perform 1 byte truncation on unicode str that is more than 1 byte, use decode('utf-8', errors='replace') to replace bad unicode with a good 1 byte char (�) """
+        message = u"a€bc"*3074  # €(\xe2\x82\xac) is 3 bytes char can be written in windows console w/o encoding
+        self.__assert_write_event_msg_size_limit_char(message)
+
+    def test_write_event_msg_size_limit_char_with_unicode_point(self):
+        """ Perform 1 byte truncation on unicode code point str that is more than 1 byte, use decode('utf-8', errors='replace') to replace bad unicode with a good 1 byte char (�) """
+        message = u"a\u20acbc"*3074  # unicode code point €(\xe2\x82\xac) is 3 bytes char can be written in windows console w/o encoding
+        self.__assert_write_event_msg_size_limit_char(message)
 
     # TODO: The following 3 tests cause widespread test suite failures (on master), so leaving it out. And tracking in: Task 10912099: [Bug] Bug in telemetry writer - overwriting prior events in fast execution
     # def test_write_event_size_limit(self):
@@ -304,18 +304,18 @@ class TestTelemetryWriter(unittest.TestCase):
             f.close()
             self.assertTrue(text_found.string.startswith("Message 1"))
 
-    # def __assert_write_event_msg_size_limit_char(self, message):
-    #     self.runtime.telemetry_writer.write_event(message, Constants.TelemetryEventLevel.Error, "Test Task")
-    #     latest_event_file = [pos_json for pos_json in os.listdir(self.runtime.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)][-1]
-    #     with open(os.path.join(self.runtime.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:
-    #         events = json.load(f)
-    #         self.assertTrue(events is not None)
-    #         self.assertEqual(events[-1]["TaskName"], "Test Task")
-    #         self.assertTrue(len(events[-1]["Message"]) < len(message.encode('utf-8')))
-    #         chars_dropped = len(message.encode('utf-8')) - Constants.TELEMETRY_MSG_SIZE_LIMIT_IN_CHARS + Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_CHARS + Constants.TELEMETRY_EVENT_COUNTER_MSG_SIZE_LIMIT_IN_CHARS
-    #         self.assertTrue(u"a\u20acbc" in events[-1]["Message"])
-    #         self.assertTrue(u"a\u20acb c" * (len(message) + 1 - chars_dropped) + ". [{0} chars dropped]".format(chars_dropped) in events[-1]["Message"])  # len(message) + 1 due to bad unicode will be replaced by �
-    #         f.close()
+    def __assert_write_event_msg_size_limit_char(self, message):
+        self.runtime.telemetry_writer.write_event(message, Constants.TelemetryEventLevel.Error, "Test Task")
+        latest_event_file = [pos_json for pos_json in os.listdir(self.runtime.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)][-1]
+        with open(os.path.join(self.runtime.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:
+            events = json.load(f)
+            self.assertTrue(events is not None)
+            self.assertEqual(events[-1]["TaskName"], "Test Task")
+            self.assertTrue(len(events[-1]["Message"]) < len(message.encode('utf-8')))
+            chars_dropped = len(message.encode('utf-8')) - Constants.TELEMETRY_MSG_SIZE_LIMIT_IN_CHARS + Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_CHARS + Constants.TELEMETRY_EVENT_COUNTER_MSG_SIZE_LIMIT_IN_CHARS
+            self.assertTrue(u"a\u20acbc" in events[-1]["Message"])
+            self.assertTrue(u"a\u20acb c" * (len(message) + 1 - chars_dropped) + ". [{0} chars dropped]".format(chars_dropped) in events[-1]["Message"])  # len(message) + 1 due to bad unicode will be replaced by �
+            f.close()
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/core/tests/Test_TelemetryWriter.py
+++ b/src/core/tests/Test_TelemetryWriter.py
@@ -304,19 +304,18 @@ class TestTelemetryWriter(unittest.TestCase):
             f.close()
             self.assertTrue(text_found.string.startswith("Message 1"))
 
-    def __assert_write_event_msg_size_limit_char(self, message):
-
-        self.runtime.telemetry_writer.write_event(message, Constants.TelemetryEventLevel.Error, "Test Task")
-        latest_event_file = [pos_json for pos_json in os.listdir(self.runtime.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)][-1]
-        with open(os.path.join(self.runtime.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:
-            events = json.load(f)
-            self.assertTrue(events is not None)
-            self.assertEqual(events[-1]["TaskName"], "Test Task")
-            self.assertTrue(len(events[-1]["Message"]) < len(message.encode('utf-8')))
-            chars_dropped = len(message.encode('utf-8')) - Constants.TELEMETRY_MSG_SIZE_LIMIT_IN_CHARS + Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_CHARS + Constants.TELEMETRY_EVENT_COUNTER_MSG_SIZE_LIMIT_IN_CHARS
-            self.assertTrue(u"a\u20acbc" in events[-1]["Message"])
-            self.assertTrue(u"a\u20acb c" * (len(message) + 1 - chars_dropped) + ". [{0} chars dropped]".format(chars_dropped) in events[-1]["Message"])  # len(message) + 1 due to bad unicode will be replaced by �
-            f.close()
+    # def __assert_write_event_msg_size_limit_char(self, message):
+    #     self.runtime.telemetry_writer.write_event(message, Constants.TelemetryEventLevel.Error, "Test Task")
+    #     latest_event_file = [pos_json for pos_json in os.listdir(self.runtime.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)][-1]
+    #     with open(os.path.join(self.runtime.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:
+    #         events = json.load(f)
+    #         self.assertTrue(events is not None)
+    #         self.assertEqual(events[-1]["TaskName"], "Test Task")
+    #         self.assertTrue(len(events[-1]["Message"]) < len(message.encode('utf-8')))
+    #         chars_dropped = len(message.encode('utf-8')) - Constants.TELEMETRY_MSG_SIZE_LIMIT_IN_CHARS + Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_CHARS + Constants.TELEMETRY_EVENT_COUNTER_MSG_SIZE_LIMIT_IN_CHARS
+    #         self.assertTrue(u"a\u20acbc" in events[-1]["Message"])
+    #         self.assertTrue(u"a\u20acb c" * (len(message) + 1 - chars_dropped) + ". [{0} chars dropped]".format(chars_dropped) in events[-1]["Message"])  # len(message) + 1 due to bad unicode will be replaced by �
+    #         f.close()
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/core/tests/Test_TelemetryWriter.py
+++ b/src/core/tests/Test_TelemetryWriter.py
@@ -103,30 +103,15 @@ class TestTelemetryWriter(unittest.TestCase):
             self.assertTrue("a"*(len(message.encode('utf-8')) - chars_dropped) + ". [{0} chars dropped]".format(chars_dropped) in events[-1]["Message"])
             f.close()
 
-    def test_write_event_msg_size_limit_char_more_than_1_bytes(self):
-        """ Perform 1 byte truncation on char that is more than 1 byte, use decode('utf-8', errors='replace') to replace bad unicode with a good 1 byte char (�) """
-        # message = u"a€bc"*3074  # €(\xe2\x82\xac) is 3 bytes char can be written in windows console w/o encoding
-        #message = u'a\xe2\x82\xacbc'  # €(\xe2\x82\xac) is 3 bytes char can be written in windows console w/o encoding
+    def test_write_event_msg_size_limit_char_with_actual_unicode_str(self):
+        """ Perform 1 byte truncation on unicode str that is more than 1 byte, use decode('utf-8', errors='replace') to replace bad unicode with a good 1 byte char (�) """
         message = u"a€bc"*3074  # €(\xe2\x82\xac) is 3 bytes char can be written in windows console w/o encoding
+        self.__assert_write_event_msg_size_limit_char(message)
 
-        print('encode message', type(message.encode('utf-8')))
-        print('encode message', message.encode('utf-8'))
-        print('message type2', type(message))
-        print('message info', message)
-        if isinstance(message, unicode):
-            print('this is unicode string')
-
-        self.runtime.telemetry_writer.write_event(message, Constants.TelemetryEventLevel.Error, "Test Task")
-        latest_event_file = [pos_json for pos_json in os.listdir(self.runtime.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)][-1]
-        with open(os.path.join(self.runtime.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:
-            events = json.load(f)
-            self.assertTrue(events is not None)
-            self.assertEqual(events[-1]["TaskName"], "Test Task")
-            self.assertTrue(len(events[-1]["Message"]) < len(message.encode('utf-8')))
-            chars_dropped = len(message.encode('utf-8')) - Constants.TELEMETRY_MSG_SIZE_LIMIT_IN_CHARS + Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_CHARS + Constants.TELEMETRY_EVENT_COUNTER_MSG_SIZE_LIMIT_IN_CHARS
-            self.assertTrue(u"a\u20acbc" in events[-1]["Message"])
-            self.assertTrue(u"a\u20acbc" * (len(message) + 1 - chars_dropped) + ". [{0} chars dropped]".format(chars_dropped) in events[-1]["Message"])  # len(message) + 1 due to bad unicode will be replaced by �
-            f.close()
+    def test_write_event_msg_size_limit_char_with_unicode_point(self):
+        """ Perform 1 byte truncation on unicode code point str that is more than 1 byte, use decode('utf-8', errors='replace') to replace bad unicode with a good 1 byte char (�) """
+        message = u"a\u20acbc"*3074  # unicode code point €(\xe2\x82\xac) is 3 bytes char can be written in windows console w/o encoding
+        self.__assert_write_event_msg_size_limit_char(message)
 
     # TODO: The following 3 tests cause widespread test suite failures (on master), so leaving it out. And tracking in: Task 10912099: [Bug] Bug in telemetry writer - overwriting prior events in fast execution
     # def test_write_event_size_limit(self):
@@ -318,6 +303,20 @@ class TestTelemetryWriter(unittest.TestCase):
             text_found = re.search('TC=([0-9]+)', events[-1]['Message'])
             f.close()
             self.assertTrue(text_found.string.startswith("Message 1"))
+
+    def __assert_write_event_msg_size_limit_char(self, message):
+
+        self.runtime.telemetry_writer.write_event(message, Constants.TelemetryEventLevel.Error, "Test Task")
+        latest_event_file = [pos_json for pos_json in os.listdir(self.runtime.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)][-1]
+        with open(os.path.join(self.runtime.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:
+            events = json.load(f)
+            self.assertTrue(events is not None)
+            self.assertEqual(events[-1]["TaskName"], "Test Task")
+            self.assertTrue(len(events[-1]["Message"]) < len(message.encode('utf-8')))
+            chars_dropped = len(message.encode('utf-8')) - Constants.TELEMETRY_MSG_SIZE_LIMIT_IN_CHARS + Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_CHARS + Constants.TELEMETRY_EVENT_COUNTER_MSG_SIZE_LIMIT_IN_CHARS
+            self.assertTrue(u"a\u20acbc" in events[-1]["Message"])
+            self.assertTrue(u"a\u20acbc" * (len(message) + 1 - chars_dropped) + ". [{0} chars dropped]".format(chars_dropped) in events[-1]["Message"])  # len(message) + 1 due to bad unicode will be replaced by �
+            f.close()
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/core/tests/Test_TelemetryWriter.py
+++ b/src/core/tests/Test_TelemetryWriter.py
@@ -109,12 +109,6 @@ class TestTelemetryWriter(unittest.TestCase):
         #message = u'a\xe2\x82\xacbc'  # €(\xe2\x82\xac) is 3 bytes char can be written in windows console w/o encoding
         message = u"a€bc"*3074  # €(\xe2\x82\xac) is 3 bytes char can be written in windows console w/o encoding
 
-        # if isinstance(message, unicode):  # For Python 2
-        #     message.encode('utf-8').decode('utf-8')
-        # print('what is message type', type(message))
-        # print('what is message', message)
-        # print('what is message encode', message.decode('utf-8'))
-
         self.runtime.telemetry_writer.write_event(message, Constants.TelemetryEventLevel.Error, "Test Task")
         latest_event_file = [pos_json for pos_json in os.listdir(self.runtime.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)][-1]
         with open(os.path.join(self.runtime.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:
@@ -123,8 +117,8 @@ class TestTelemetryWriter(unittest.TestCase):
             self.assertEqual(events[-1]["TaskName"], "Test Task")
             self.assertTrue(len(events[-1]["Message"]) < len(message.encode('utf-8')))
             chars_dropped = len(message.encode('utf-8')) - Constants.TELEMETRY_MSG_SIZE_LIMIT_IN_CHARS + Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_CHARS + Constants.TELEMETRY_EVENT_COUNTER_MSG_SIZE_LIMIT_IN_CHARS
-            self.assertTrue("a€bc" in events[-1]["Message"])
-            self.assertTrue("a€bc" * (len(message) + 1 - chars_dropped) + ". [{0} chars dropped]".format(chars_dropped) in events[-1]["Message"])  # len(message) + 1 due to bad unicode will be replaced by �
+            self.assertTrue(u"a\u20acbc" in events[-1]["Message"])
+            self.assertTrue(u"a\u20acbc" * (len(message) + 1 - chars_dropped) + ". [{0} chars dropped]".format(chars_dropped) in events[-1]["Message"])  # len(message) + 1 due to bad unicode will be replaced by �
             f.close()
 
     # TODO: The following 3 tests cause widespread test suite failures (on master), so leaving it out. And tracking in: Task 10912099: [Bug] Bug in telemetry writer - overwriting prior events in fast execution

--- a/src/core/tests/Test_TelemetryWriter.py
+++ b/src/core/tests/Test_TelemetryWriter.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2020 Microsoft Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +20,7 @@ import os
 import re
 import time
 import unittest
+
 from core.src.bootstrap.Constants import Constants
 from core.tests.library.ArgumentComposer import ArgumentComposer
 from core.tests.library.RuntimeCompositor import RuntimeCompositor
@@ -103,8 +105,16 @@ class TestTelemetryWriter(unittest.TestCase):
 
     def test_write_event_msg_size_limit_char_more_than_1_bytes(self):
         """ Perform 1 byte truncation on char that is more than 1 byte, use decode('utf-8', errors='replace') to replace bad unicode with a good 1 byte char (�) """
+        # message = u"a€bc"*3074  # €(\xe2\x82\xac) is 3 bytes char can be written in windows console w/o encoding
+        #message = u'a\xe2\x82\xacbc'  # €(\xe2\x82\xac) is 3 bytes char can be written in windows console w/o encoding
+        message = u"a€bc"*3074  # €(\xe2\x82\xac) is 3 bytes char can be written in windows console w/o encoding
 
-        message = "a€bc"*3074  # €(\xe2\x82\xac) is 3 bytes char can be written in windows console w/o encoding
+        # if isinstance(message, unicode):  # For Python 2
+        #     message.encode('utf-8').decode('utf-8')
+        # print('what is message type', type(message))
+        # print('what is message', message)
+        # print('what is message encode', message.decode('utf-8'))
+
         self.runtime.telemetry_writer.write_event(message, Constants.TelemetryEventLevel.Error, "Test Task")
         latest_event_file = [pos_json for pos_json in os.listdir(self.runtime.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)][-1]
         with open(os.path.join(self.runtime.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:

--- a/src/core/tests/Test_TelemetryWriter.py
+++ b/src/core/tests/Test_TelemetryWriter.py
@@ -317,5 +317,7 @@ class TestTelemetryWriter(unittest.TestCase):
             self.assertTrue(u"a\u20acb c" * (len(message) + 1 - chars_dropped) + ". [{0} chars dropped]".format(chars_dropped) in events[-1]["Message"])  # len(message) + 1 due to bad unicode will be replaced by �
             f.close()
 
+
 if __name__ == '__main__':
     unittest.main()
+

--- a/src/core/tests/Test_TelemetryWriter.py
+++ b/src/core/tests/Test_TelemetryWriter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2020 Microsoft Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -102,16 +101,6 @@ class TestTelemetryWriter(unittest.TestCase):
             chars_dropped = len(message.encode('utf-8')) - Constants.TELEMETRY_MSG_SIZE_LIMIT_IN_CHARS + Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_CHARS + Constants.TELEMETRY_EVENT_COUNTER_MSG_SIZE_LIMIT_IN_CHARS
             self.assertTrue("a"*(len(message.encode('utf-8')) - chars_dropped) + ". [{0} chars dropped]".format(chars_dropped) in events[-1]["Message"])
             f.close()
-
-    def test_write_event_msg_size_limit_char_with_actual_unicode_str(self):
-        """ Perform 1 byte truncation on unicode str that is more than 1 byte, use decode('utf-8', errors='replace') to replace bad unicode with a good 1 byte char (�) """
-        message = u"a€bc"*3074  # €(\xe2\x82\xac) is 3 bytes char can be written in windows console w/o encoding
-        self.__assert_write_event_msg_size_limit_char(message)
-
-    def test_write_event_msg_size_limit_char_with_unicode_point(self):
-        """ Perform 1 byte truncation on unicode code point str that is more than 1 byte, use decode('utf-8', errors='replace') to replace bad unicode with a good 1 byte char (�) """
-        message = u"a\u20acbc"*3074  # unicode code point €(\xe2\x82\xac) is 3 bytes char can be written in windows console w/o encoding
-        self.__assert_write_event_msg_size_limit_char(message)
 
     # TODO: The following 3 tests cause widespread test suite failures (on master), so leaving it out. And tracking in: Task 10912099: [Bug] Bug in telemetry writer - overwriting prior events in fast execution
     # def test_write_event_size_limit(self):
@@ -303,19 +292,6 @@ class TestTelemetryWriter(unittest.TestCase):
             text_found = re.search('TC=([0-9]+)', events[-1]['Message'])
             f.close()
             self.assertTrue(text_found.string.startswith("Message 1"))
-
-    def __assert_write_event_msg_size_limit_char(self, message):
-        self.runtime.telemetry_writer.write_event(message, Constants.TelemetryEventLevel.Error, "Test Task")
-        latest_event_file = [pos_json for pos_json in os.listdir(self.runtime.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)][-1]
-        with open(os.path.join(self.runtime.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:
-            events = json.load(f)
-            self.assertTrue(events is not None)
-            self.assertEqual(events[-1]["TaskName"], "Test Task")
-            self.assertTrue(len(events[-1]["Message"]) < len(message.encode('utf-8')))
-            chars_dropped = len(message.encode('utf-8')) - Constants.TELEMETRY_MSG_SIZE_LIMIT_IN_CHARS + Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_CHARS + Constants.TELEMETRY_EVENT_COUNTER_MSG_SIZE_LIMIT_IN_CHARS
-            self.assertTrue(u"a\u20acbc" in events[-1]["Message"])
-            self.assertTrue(u"a\u20acb c" * (len(message) + 1 - chars_dropped) + ". [{0} chars dropped]".format(chars_dropped) in events[-1]["Message"])  # len(message) + 1 due to bad unicode will be replaced by �
-            f.close()
 
 
 if __name__ == '__main__':

--- a/src/core/tests/Test_TelemetryWriter.py
+++ b/src/core/tests/Test_TelemetryWriter.py
@@ -109,6 +109,13 @@ class TestTelemetryWriter(unittest.TestCase):
         #message = u'a\xe2\x82\xacbc'  # €(\xe2\x82\xac) is 3 bytes char can be written in windows console w/o encoding
         message = u"a€bc"*3074  # €(\xe2\x82\xac) is 3 bytes char can be written in windows console w/o encoding
 
+        print('encode message', type(message.encode('utf-8')))
+        print('encode message', message.encode('utf-8'))
+        print('message type2', type(message))
+        print('message info', message)
+        if isinstance(message, unicode):
+            print('this is unicode string')
+
         self.runtime.telemetry_writer.write_event(message, Constants.TelemetryEventLevel.Error, "Test Task")
         latest_event_file = [pos_json for pos_json in os.listdir(self.runtime.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)][-1]
         with open(os.path.join(self.runtime.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:

--- a/src/core/tests/Test_TelemetryWriter.py
+++ b/src/core/tests/Test_TelemetryWriter.py
@@ -315,7 +315,7 @@ class TestTelemetryWriter(unittest.TestCase):
             self.assertTrue(len(events[-1]["Message"]) < len(message.encode('utf-8')))
             chars_dropped = len(message.encode('utf-8')) - Constants.TELEMETRY_MSG_SIZE_LIMIT_IN_CHARS + Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_CHARS + Constants.TELEMETRY_EVENT_COUNTER_MSG_SIZE_LIMIT_IN_CHARS
             self.assertTrue(u"a\u20acbc" in events[-1]["Message"])
-            self.assertTrue(u"a\u20acbc" * (len(message) + 1 - chars_dropped) + ". [{0} chars dropped]".format(chars_dropped) in events[-1]["Message"])  # len(message) + 1 due to bad unicode will be replaced by �
+            self.assertTrue(u"a\u20acb c" * (len(message) + 1 - chars_dropped) + ". [{0} chars dropped]".format(chars_dropped) in events[-1]["Message"])  # len(message) + 1 due to bad unicode will be replaced by �
             f.close()
 
 if __name__ == '__main__':

--- a/src/core/tests/Test_TelemetryWriterBadUnicode.py
+++ b/src/core/tests/Test_TelemetryWriterBadUnicode.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+# Copyright 2024 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.7+
+import json
+import os
+import re
+import unittest
+
+from core.src.bootstrap.Constants import Constants
+from core.tests.library.ArgumentComposer import ArgumentComposer
+from core.tests.library.RuntimeCompositor import RuntimeCompositor
+
+
+class TestTelemetryWriterBadUnicode(unittest.TestCase):
+    def setUp(self):
+        self.runtime = RuntimeCompositor(ArgumentComposer().get_composed_arguments(), True)
+
+    def tearDown(self):
+        self.runtime.stop()
+
+    def test_write_event_msg_size_limit_char_with_actual_unicode_str(self):
+        """ Perform 1 byte truncation on unicode str that is more than 1 byte, use decode('utf-8', errors='replace') to replace bad unicode with a good 1 byte char (�) """
+        message = u"a€bc"*3074  # €(\xe2\x82\xac) is 3 bytes char can be written in windows console w/o encoding
+        self.__assert_write_event_msg_size_limit_char(message)
+
+    def test_write_event_msg_size_limit_char_with_unicode_point(self):
+        """ Perform 1 byte truncation on unicode code point str that is more than 1 byte, use decode('utf-8', errors='replace') to replace bad unicode with a good 1 byte char (�) """
+        message = u"a\u20acbc"*3074  # unicode code point €(\xe2\x82\xac) is 3 bytes char can be written in windows console w/o encoding
+        self.__assert_write_event_msg_size_limit_char(message)
+
+    def __assert_write_event_msg_size_limit_char(self, message):
+        self.runtime.telemetry_writer.write_event(message, Constants.TelemetryEventLevel.Error, "Test Task")
+        latest_event_file = [pos_json for pos_json in os.listdir(self.runtime.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)][-1]
+        with open(os.path.join(self.runtime.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:
+            events = json.load(f)
+            self.assertTrue(events is not None)
+            self.assertEqual(events[-1]["TaskName"], "Test Task")
+            self.assertTrue(len(events[-1]["Message"]) < len(message.encode('utf-8')))
+            chars_dropped = len(message.encode('utf-8')) - Constants.TELEMETRY_MSG_SIZE_LIMIT_IN_CHARS + Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_CHARS + Constants.TELEMETRY_EVENT_COUNTER_MSG_SIZE_LIMIT_IN_CHARS
+            self.assertTrue(u"a\u20acbc" in events[-1]["Message"])
+            self.assertTrue(u"a\u20acb c" * (len(message) + 1 - chars_dropped) + ". [{0} chars dropped]".format(chars_dropped) in events[-1]["Message"])  # len(message) + 1 due to bad unicode will be replaced by �
+            f.close()
+
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
with the fix for unicodeerror using euro symbol in unit test, py27 will throw the below error when running utest locally because locally py27 will not auto recognize/encode those char as in py3,  though the cicd pipeline will not throw any errors and process the unit test as expected, see pictures below:

![image](https://github.com/Azure/LinuxPatchExtension/assets/127874208/8c6c7dab-df1f-4677-b477-da5babb3dabc)

cicd pipeline before code change using the pr1reduce-status_file as example since it has master code merged in :
![image](https://github.com/Azure/LinuxPatchExtension/assets/127874208/dfaffaeb-2db7-4a8c-8ace-b7db14223d8b)


