### PR TITLE
use nodejs20 instead of 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
       PYTHONTRACEMALLOC: 1
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
       - name: Set up Python 3.9
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v2
         with:
           python-version: 3.9
       - name: Set up Node.js 20
@@ -45,7 +45,7 @@ jobs:
           cd ../../extension/tests
           coverage xml
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v2
         with:
           flags: python39
           name: python-39

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.9
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
       - name: Install dependencies
         run: pip install coverage
       - name: Run extension tests
@@ -41,7 +45,7 @@ jobs:
           cd ../../extension/tests
           coverage xml
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v3.14.0
         with:
           flags: python39
           name: python-39
@@ -74,6 +78,10 @@ jobs:
             choco install python2 -y
             SETX PATH "%PATH%;C:\Python27"
           )
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
@@ -107,7 +115,7 @@ jobs:
           cd ../../extension/tests
           coverage xml
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v3.14.0
         with:
           flags: python27
           name: python-27

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.9
-      - name: Set up Node.js 20
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
       - name: Install dependencies
         run: pip install coverage
       - name: Run extension tests
@@ -78,10 +74,6 @@ jobs:
             choco install python2 -y
             SETX PATH "%PATH%;C:\Python27"
           )
-      - name: Set up Node.js 20
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
       - name: Cache dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v3
         with:
           python-version: 3.9
       - name: Set up Node.js 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v3
         with:
           node-version: '20'
       - name: Install dependencies
@@ -45,7 +45,7 @@ jobs:
           cd ../../extension/tests
           coverage xml
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3.14.0
+        uses: codecov/codecov-action@v3
         with:
           flags: python39
           name: python-39
@@ -79,7 +79,7 @@ jobs:
             SETX PATH "%PATH%;C:\Python27"
           )
       - name: Set up Node.js 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v3
         with:
           node-version: '20'
       - name: Cache dependencies
@@ -115,7 +115,7 @@ jobs:
           cd ../../extension/tests
           coverage xml
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3.14.0
+        uses: codecov/codecov-action@v3
         with:
           flags: python27
           name: python-27

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,13 @@ jobs:
       PYTHONTRACEMALLOC: 1
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Python 3.9
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Set up Node.js 20
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
       - name: Install dependencies
@@ -45,7 +45,7 @@ jobs:
           cd ../../extension/tests
           coverage xml
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3.1.5
         with:
           flags: python39
           name: python-39
@@ -64,9 +64,9 @@ jobs:
     needs: codecov-python-39
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Restore Python 2.7 cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: C:\Python27
           key: python27-cache
@@ -79,11 +79,11 @@ jobs:
             SETX PATH "%PATH%;C:\Python27"
           )
       - name: Set up Node.js 20
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: '%UserProfile%\.cache\pip'
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
@@ -115,7 +115,7 @@ jobs:
           cd ../../extension/tests
           coverage xml
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v3.1.5
         with:
           flags: python27
           name: python-27


### PR DESCRIPTION
* update ci.yml to use latest action version that uses nodejs20 to fix below warning msg:

![image](https://github.com/Azure/LinuxPatchExtension/assets/127874208/95418b90-e100-4779-b667-612567194d44)

post code change:

![image](https://github.com/Azure/LinuxPatchExtension/assets/127874208/d672793b-5933-4ccd-b73f-3df1da6f8199)
