### PR TITLE
get ci.yml to read contents ouput

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,14 +49,15 @@ jobs:
       - name: Read test output
         id: getoutput
         run: |
-          echo "contents=$(cat err.txt)" >> $env:GITHUB_ENV
+          echo "contents=$(cat err.txt)" > output.txt
       - name: Check if all tests passed
         shell: cmd
-        if: contains(steps.getoutput.outputs.CONTENTS, 'FAILED (failures=')
         run: |
-          echo "There are failed tests"
-          echo "%CONTENTS%"
-          exit 1
+          findstr /C:"FAILED (failures=" output.txt >nul
+          if errorlevel 1 (
+            type output.txt
+            exit /b 1
+          )
   codecov-python-27:
     runs-on: windows-latest
     needs: codecov-python-39

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,18 +46,13 @@ jobs:
           flags: python39
           name: python-39
           fail_ci_if_error: true
-      - name: Read test output
-        id: getoutput
-        run: |
-          echo "CONTENTS=$(cat err.txt)" > $GITHUB_ENV
-      - name: Check if all tests passed
+      - name: Read test output and Check if all tests passed
         shell: bash
         run: |
           CONTENTS=$(cat err.txt)
-          echo "Contents: $CONTENTS"
           if echo "$CONTENTS" | grep -q 'FAILED (failures='; then
             echo "There are failed tests"
-            echo "$CONTENTS"
+            echo "Contents: $CONTENTS"
             exit 1
           fi
   codecov-python-27:
@@ -117,17 +112,12 @@ jobs:
           flags: python27
           name: python-27
           fail_ci_if_error: true
-      - name: Read test output
-        id: getoutput
-        run: |
-          echo "CONTENTS=$(cat err2.txt)" > $GITHUB_ENV
-      - name: Check if all tests passed
+      - name: Read test output and Check if all tests passed
         shell: bash
         run: |
           CONTENTS=$(cat err2.txt)
-          echo "Contents: $CONTENTS"
           if echo "$CONTENTS" | grep -q 'FAILED (failures='; then
             echo "There are failed tests"
-            echo "$CONTENTS"
+            echo "Contents: $CONTENTS"
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,10 @@ jobs:
       - name: Read test output
         id: getoutput
         run: |
-          echo "contents=$(cat err2.txt)" >> $env:GITHUB_ENV
+          echo "contents=$(cat err.txt)" >> $env:GITHUB_ENV
       - name: Check if all tests passed
         shell: cmd
-        if: contains(env.CONTENTS, 'FAILED (failures=')
+        if: contains(steps.getoutput.outputs.CONTENTS, 'FAILED (failures=')
         run: |
           echo "There are failed tests"
           echo "%CONTENTS%"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,14 +48,12 @@ jobs:
           fail_ci_if_error: true
       - name: Read test output
         id: getoutput
-        run: |
-          echo "contents=$(cat err.txt)" >> $env:GITHUB_OUTPUT
+        run: echo "contents=$(Get-Content err2.txt)" >> $env:GITHUB_OUTPUT
       - name: Check if all tests passed
-        shell: cmd
-        if: "contains(${{ steps.getoutput.outputs.CONTENTS}} , 'FAILED (failures=')"
+        if: "contains(env.CONTENTS, 'FAILED (failures=')"
         run: |
           echo "There are failed tests"
-          echo "${{ steps.getoutput.outputs.CONTENTS}}"
+          echo "${{ env.CONTENTS }}"
           exit 1
   codecov-python-27:
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,10 +119,15 @@ jobs:
           fail_ci_if_error: true
       - name: Read test output
         id: getoutput
-        run: echo "::set-output name=contents::$(cat err2.txt)"
-      - name: Check if all tests passed
-        if: contains( steps.getoutput.outputs.contents, 'FAILED (failures=' )
-        shell: cmd
         run: |
-          echo "${{ steps.getoutput.outputs.contents }}"
-          exit 1
+          echo "CONTENTS=$(cat err2.txt)" > $GITHUB_ENV
+      - name: Check if all tests passed
+        shell: bash
+        run: |
+          CONTENTS=$(cat err2.txt)
+          echo "Contents: $CONTENTS"
+          if echo "$CONTENTS" | grep -q 'FAILED (failures='; then
+            echo "There are failed tests"
+            echo "$CONTENTS"
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         id: getoutput
         run: echo "contents=$(Get-Content err.txt)" >> $env:GITHUB_OUTPUT
       - name: Check if all tests passed
-        if: "contains(steps.getoutput.outputs.CONTENTS, 'FAILED (failures=') && not(contains(steps.getoutput.outputs.CONTENTS, 'OK'))"
+        if: "contains(steps.getoutput.outputs.CONTENTS, 'FAILED (failures=') && !(contains(steps.getoutput.outputs.CONTENTS, 'OK'))"
         run: |
           echo "${{ steps.getoutput.outputs.CONTENTS}}"
           echo "There are failed tests"
@@ -116,7 +116,7 @@ jobs:
         id: getoutput
         run: echo "contents=$(Get-Content err2.txt)" >> $env:GITHUB_OUTPUT
       - name: Check if all tests passed
-        if: "contains(steps.getoutput.outputs.CONTENTS, 'FAILED (failures=') && not(contains(steps.getoutput.outputs.CONTENTS, 'OK'))"
+        if: "contains(steps.getoutput.outputs.CONTENTS, 'FAILED (failures=') && !(contains(steps.getoutput.outputs.CONTENTS, 'OK'))"
         run: |
           echo "${{ steps.getoutput.outputs.CONTENTS}}"
           echo "There are failed tests"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         if: "contains(${{ steps.getoutput.outputs.CONTENTS}}, 'FAILED (failures=')"
         run: |
           echo "There are failed tests"
-          echo "${{ env.CONTENTS }}"
+          echo "${{ steps.getoutput.outputs.CONTENTS}}"
           exit 1
   codecov-python-27:
     runs-on: windows-latest
@@ -114,11 +114,9 @@ jobs:
           fail_ci_if_error: true
       - name: Read test output
         id: getoutput
-        run: |
-          echo "contents=$(cat err2.txt)" >> $env:GITHUB_OUTPUT
+        run: echo "contents=$(Get-Content err2.txt)" >> $env:GITHUB_OUTPUT
       - name: Check if all tests passed
-        shell: cmd
-        if: "contains(${{ steps.getoutput.outputs.CONTENTS}} , 'FAILED (failures=')"
+        if: "contains(${{ steps.getoutput.outputs.CONTENTS}}, 'FAILED (failures=')"
         run: |
           echo "There are failed tests"
           echo "${{ steps.getoutput.outputs.CONTENTS}}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           fail_ci_if_error: true
       - name: Read test output
         id: getoutput
-        run: echo "contents=$(Get-Content err2.txt)" >> $env:GITHUB_OUTPUT
+        run: echo "contents=$(Get-Content err.txt)" >> $env:GITHUB_OUTPUT
       - name: Check if all tests passed
         if: "contains(env.CONTENTS, 'FAILED (failures=')"
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,15 +49,15 @@ jobs:
       - name: Read test output
         id: getoutput
         run: |
-          echo "contents=$(cat err.txt)" > output.txt
+          echo "CONTENTS=$(cat err.txt)" >> $GITHUB_ENV
       - name: Check if all tests passed
-        shell: cmd
+        shell: bash
         run: |
-          findstr /C:"FAILED (failures=" output.txt >nul
-          if errorlevel 1 (
-            type output.txt
-            exit /b 1
-          )
+          if echo "$CONTENTS" | grep -q 'FAILED (failures='; then
+            echo "There are failed tests"
+            echo "$CONTENTS"
+            exit 1
+          fi
   codecov-python-27:
     runs-on: windows-latest
     needs: codecov-python-39

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,15 +50,11 @@ jobs:
         id: getoutput
         run: echo "contents=$(Get-Content err.txt)" >> $env:GITHUB_OUTPUT
       - name: Check if all tests passed
-        shell: cmd
-        if: "contains(env.CONTENTS, 'FAILED (failures=')"
+        if: "contains(steps.getoutput.outputs.CONTENTS, 'FAILED (failures=') && !(contains(steps.getoutput.outputs.CONTENTS, 'OK'))"
         run: |
-          if echo "${{ env.CONTENTS }}" | findstr /C:"FAILED (failures=" > nul
-          then
-            echo "There are failed tests"
-            echo %CONTENTS%
-            exit 1
-          fi
+          echo "${{ steps.getoutput.outputs.CONTENTS}}"
+          echo "There are failed tests"
+          exit 1
   codecov-python-27:
     runs-on: windows-latest
     needs: codecov-python-39

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,12 +48,12 @@ jobs:
           fail_ci_if_error: true
       - name: Read test output
         id: getoutput
-        run: echo "contents=$(Get-Content err.txt)" >> $env:GITHUB_OUTPUT
+        run: echo "::set-output name=contents::$(cat err.txt)"
       - name: Check if all tests passed
-        if: "contains(steps.getoutput.outputs.CONTENTS, 'FAILED (failures=') && !(contains(steps.getoutput.outputs.CONTENTS, 'OK'))"
+        if: contains( steps.getoutput.outputs.contents, 'FAILED (failures=' )
+        shell: cmd
         run: |
-          echo "${{ steps.getoutput.outputs.CONTENTS}}"
-          echo "There are failed tests"
+          echo "${{ steps.getoutput.outputs.contents }}"
           exit 1
   codecov-python-27:
     runs-on: windows-latest
@@ -114,10 +114,10 @@ jobs:
           fail_ci_if_error: true
       - name: Read test output
         id: getoutput
-        run: echo "contents=$(Get-Content err2.txt)" >> $env:GITHUB_OUTPUT
+        run: echo "::set-output name=contents::$(cat err2.txt)"
       - name: Check if all tests passed
-        if: "contains(steps.getoutput.outputs.CONTENTS, 'FAILED (failures=') && !(contains(steps.getoutput.outputs.CONTENTS, 'OK'))"
+        if: contains( steps.getoutput.outputs.contents, 'FAILED (failures=' )
+        shell: cmd
         run: |
-          echo "${{ steps.getoutput.outputs.CONTENTS}}"
-          echo "There are failed tests"
+          echo "${{ steps.getoutput.outputs.contents }}"
           exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,11 @@ jobs:
       - name: Check if all tests passed
         shell: bash
         run: |
-          echo "Contents: ${env.CONTENTS}"
-          if echo "${ env.CONTENTS }" | grep -q 'FAILED (failures='; then
+          CONTENTS=$(cat err.txt)
+          echo "Contents: $CONTENTS"
+          if echo "$CONTENTS" | grep -q 'FAILED (failures='; then
             echo "There are failed tests"
-            echo "${ env.CONTENTS }"
+            echo "$CONTENTS"
             exit 1
           fi
   codecov-python-27:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,13 +49,14 @@ jobs:
       - name: Read test output
         id: getoutput
         run: |
-          echo "CONTENTS=$(cat err.txt)" >> $GITHUB_ENV
+          echo "CONTENTS=$(cat err.txt)" > $GITHUB_ENV
       - name: Check if all tests passed
         shell: bash
         run: |
-          if echo "${{ env.CONTENTS }}" | grep -q 'FAILED (failures='; then
+          echo "Contents: ${env.CONTENTS}"
+          if echo "${ env.CONTENTS }" | grep -q 'FAILED (failures='; then
             echo "There are failed tests"
-            echo "${{ env.CONTENTS }}"
+            echo "${ env.CONTENTS }"
             exit 1
           fi
   codecov-python-27:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,12 +48,14 @@ jobs:
           fail_ci_if_error: true
       - name: Read test output
         id: getoutput
-        run: echo "::set-output name=contents::$(cat err.txt)"
-      - name: Check if all tests passed
-        if: contains( steps.getoutput.outputs.contents, 'FAILED (failures=' )
-        shell: cmd
         run: |
-          echo "${{ steps.getoutput.outputs.contents }}"
+          echo "contents=$(cat err2.txt)" >> $env:GITHUB_ENV
+      - name: Check if all tests passed
+        shell: cmd
+        if: contains(env.CONTENTS, 'FAILED (failures=')
+        run: |
+          echo "There are failed tests"
+          echo "%CONTENTS%"
           exit 1
   codecov-python-27:
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,12 +48,14 @@ jobs:
           fail_ci_if_error: true
       - name: Read test output
         id: getoutput
-        run: echo "contents=$(cat err.txt)" >> $GITHUB_OUTPUT
-      - name: Check if all tests passed
-        if: contains( steps.getoutput.outputs.contents, 'FAILED (failures=' )
-        shell: cmd
         run: |
-          echo "${{ steps.getoutput.outputs.contents }}"
+          echo "contents=$(cat err.txt)" >> $env:GITHUB_OUTPUT
+      - name: Check if all tests passed
+        shell: cmd
+        if: "contains(${{ steps.getoutput.outputs.CONTENTS}} , 'FAILED (failures=')"
+        run: |
+          echo "There are failed tests"
+          echo "${{ steps.getoutput.outputs.CONTENTS}}"
           exit 1
   codecov-python-27:
     runs-on: windows-latest
@@ -114,10 +116,12 @@ jobs:
           fail_ci_if_error: true
       - name: Read test output
         id: getoutput
-        run: echo "contents=$(cat err2.txt)" >> $GITHUB_OUTPUT
-      - name: Check if all tests passed
-        if: contains( steps.getoutput.outputs.contents, 'FAILED (failures=' )
         run: |
-          echo "${{ steps.getoutput.outputs.contents }}"
+          echo "contents=$(cat err2.txt)" >> $env:GITHUB_OUTPUT
+      - name: Check if all tests passed
+        shell: cmd
+        if: "contains(${{ steps.getoutput.outputs.CONTENTS}} , 'FAILED (failures=')"
+        run: |
           echo "There are failed tests"
+          echo "${{ steps.getoutput.outputs.CONTENTS}}"
           exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,10 @@ jobs:
         id: getoutput
         run: echo "contents=$(Get-Content err.txt)" >> $env:GITHUB_OUTPUT
       - name: Check if all tests passed
-        if: "contains(${{ steps.getoutput.outputs.CONTENTS}}, 'FAILED (failures=')"
+        if: "contains(steps.getoutput.outputs.CONTENTS, 'FAILED (failures=') && not(contains(steps.getoutput.outputs.CONTENTS, 'OK'))"
         run: |
-          echo "There are failed tests"
           echo "${{ steps.getoutput.outputs.CONTENTS}}"
+          echo "There are failed tests"
           exit 1
   codecov-python-27:
     runs-on: windows-latest
@@ -116,8 +116,8 @@ jobs:
         id: getoutput
         run: echo "contents=$(Get-Content err2.txt)" >> $env:GITHUB_OUTPUT
       - name: Check if all tests passed
-        if: "contains(${{ steps.getoutput.outputs.CONTENTS}}, 'FAILED (failures=')"
+        if: "contains(steps.getoutput.outputs.CONTENTS, 'FAILED (failures=') && not(contains(steps.getoutput.outputs.CONTENTS, 'OK'))"
         run: |
-          echo "There are failed tests"
           echo "${{ steps.getoutput.outputs.CONTENTS}}"
+          echo "There are failed tests"
           exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,9 +53,9 @@ jobs:
       - name: Check if all tests passed
         shell: bash
         run: |
-          if echo "$CONTENTS" | grep -q 'FAILED (failures='; then
+          if echo "${{ env.CONTENTS }}" | grep -q 'FAILED (failures='; then
             echo "There are failed tests"
-            echo "$CONTENTS"
+            echo "${{ env.CONTENTS }}"
             exit 1
           fi
   codecov-python-27:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,11 +50,15 @@ jobs:
         id: getoutput
         run: echo "contents=$(Get-Content err.txt)" >> $env:GITHUB_OUTPUT
       - name: Check if all tests passed
-        if: "contains(steps.getoutput.outputs.CONTENTS, 'FAILED (failures=') && !(contains(steps.getoutput.outputs.CONTENTS, 'OK'))"
+        shell: cmd
+        if: "contains(env.CONTENTS, 'FAILED (failures=')"
         run: |
-          echo "${{ steps.getoutput.outputs.CONTENTS}}"
-          echo "There are failed tests"
-          exit 1
+          if echo "${{ env.CONTENTS }}" | findstr /C:"FAILED (failures=" > nul
+          then
+            echo "There are failed tests"
+            echo %CONTENTS%
+            exit 1
+          fi
   codecov-python-27:
     runs-on: windows-latest
     needs: codecov-python-39

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         id: getoutput
         run: echo "contents=$(Get-Content err.txt)" >> $env:GITHUB_OUTPUT
       - name: Check if all tests passed
-        if: "contains(env.CONTENTS, 'FAILED (failures=')"
+        if: "contains(${{ steps.getoutput.outputs.CONTENTS}}, 'FAILED (failures=')"
         run: |
           echo "There are failed tests"
           echo "${{ env.CONTENTS }}"

--- a/src/core/tests/Test_StatusHandlerTruncation.py
+++ b/src/core/tests/Test_StatusHandlerTruncation.py
@@ -469,7 +469,7 @@ class TestStatusHandlerTruncation(unittest.TestCase):
         self.assertEqual(substatus_file_data["status"]["operation"], operation)
         self.assertEqual(substatus_summary_data["name"], patch_summary)
         self.assertEqual(substatus_summary_data["status"], status.lower())
-        # remove comment if the codecov report pass
+
         if is_under_internal_size_limit:
             # Assert status file size < 126kb n 128kb
             substatus_file_in_bytes = len(json.dumps(substatus_file_data).encode('utf-8'))
@@ -478,7 +478,7 @@ class TestStatusHandlerTruncation(unittest.TestCase):
 
             if is_truncated:
                 self.assertEqual(status_file_patch_count, self.__expected_truncated_patch_count)
-                self.assertTrue(status_file_patch_count < patch_count)  # Assert length of truncated patches < patch_count post truncation
+                self.assertTrue(status_file_patch_count > patch_count)  # Assert length of truncated patches < patch_count post truncation
                 self.assertTrue(substatus_file_in_bytes < len(json.dumps(complete_substatus_file_data).encode('utf-8')))  # Assert truncated status file size < completed status file size
 
                 if self.__test_scenario == 'assessment_only':

--- a/src/core/tests/Test_StatusHandlerTruncation.py
+++ b/src/core/tests/Test_StatusHandlerTruncation.py
@@ -478,7 +478,7 @@ class TestStatusHandlerTruncation(unittest.TestCase):
 
             if is_truncated:
                 self.assertEqual(status_file_patch_count, self.__expected_truncated_patch_count)
-                self.assertTrue(status_file_patch_count > patch_count)  # Assert length of truncated patches < patch_count post truncation
+                self.assertTrue(status_file_patch_count < patch_count)  # Assert length of truncated patches < patch_count post truncation
                 self.assertTrue(substatus_file_in_bytes < len(json.dumps(complete_substatus_file_data).encode('utf-8')))  # Assert truncated status file size < completed status file size
 
                 if self.__test_scenario == 'assessment_only':

--- a/src/core/tests/Test_StatusHandlerTruncation.py
+++ b/src/core/tests/Test_StatusHandlerTruncation.py
@@ -469,7 +469,7 @@ class TestStatusHandlerTruncation(unittest.TestCase):
         self.assertEqual(substatus_file_data["status"]["operation"], operation)
         self.assertEqual(substatus_summary_data["name"], patch_summary)
         self.assertEqual(substatus_summary_data["status"], status.lower())
-
+        # remove comment if the codecov report pass
         if is_under_internal_size_limit:
             # Assert status file size < 126kb n 128kb
             substatus_file_in_bytes = len(json.dumps(substatus_file_data).encode('utf-8'))

--- a/src/core/tests/Test_StatusHandlerTruncation.py
+++ b/src/core/tests/Test_StatusHandlerTruncation.py
@@ -478,7 +478,7 @@ class TestStatusHandlerTruncation(unittest.TestCase):
 
             if is_truncated:
                 self.assertEqual(status_file_patch_count, self.__expected_truncated_patch_count)
-                self.assertTrue(status_file_patch_count < patch_count)  # Assert length of truncated patches < patch_count post truncation
+                self.assertTrue(status_file_patch_count > patch_count)  # Assert length of truncated patches < patch_count post truncation
                 self.assertTrue(substatus_file_in_bytes < len(json.dumps(complete_substatus_file_data).encode('utf-8')))  # Assert truncated status file size < completed status file size
 
                 if self.__test_scenario == 'assessment_only':

--- a/src/core/tests/Test_StatusHandlerTruncation.py
+++ b/src/core/tests/Test_StatusHandlerTruncation.py
@@ -479,7 +479,7 @@ class TestStatusHandlerTruncation(unittest.TestCase):
             if is_truncated:
                 self.assertEqual(status_file_patch_count, self.__expected_truncated_patch_count)
                 self.assertTrue(status_file_patch_count < patch_count)  # Assert length of truncated patches < patch_count post truncation
-                self.assertTrue(substatus_file_in_bytes > len(json.dumps(complete_substatus_file_data).encode('utf-8')))  # Assert truncated status file size < completed status file size
+                self.assertTrue(substatus_file_in_bytes < len(json.dumps(complete_substatus_file_data).encode('utf-8')))  # Assert truncated status file size < completed status file size
 
                 if self.__test_scenario == 'assessment_only':
                     self.assertEqual(patch_count - status_file_patch_count, self.runtime.status_handler.get_num_assessment_patches_removed())  # Assert # assessment removed packages

--- a/src/core/tests/Test_StatusHandlerTruncation.py
+++ b/src/core/tests/Test_StatusHandlerTruncation.py
@@ -478,8 +478,8 @@ class TestStatusHandlerTruncation(unittest.TestCase):
 
             if is_truncated:
                 self.assertEqual(status_file_patch_count, self.__expected_truncated_patch_count)
-                self.assertTrue(status_file_patch_count > patch_count)  # Assert length of truncated patches < patch_count post truncation
-                self.assertTrue(substatus_file_in_bytes < len(json.dumps(complete_substatus_file_data).encode('utf-8')))  # Assert truncated status file size < completed status file size
+                self.assertTrue(status_file_patch_count < patch_count)  # Assert length of truncated patches < patch_count post truncation
+                self.assertTrue(substatus_file_in_bytes > len(json.dumps(complete_substatus_file_data).encode('utf-8')))  # Assert truncated status file size < completed status file size
 
                 if self.__test_scenario == 'assessment_only':
                     self.assertEqual(patch_count - status_file_patch_count, self.runtime.status_handler.get_num_assessment_patches_removed())  # Assert # assessment removed packages


### PR DESCRIPTION
* pipeline isn't picking up failed unit test, output false positive, see picture below both pipeline are passed, but end with error 1:
![image](https://github.com/Azure/LinuxPatchExtension/assets/127874208/47971370-3851-4648-a170-c0d2aacf49b9)
![image](https://github.com/Azure/LinuxPatchExtension/assets/127874208/c580b244-db91-4cf2-9cab-a4fc9f142f75)
* the cause of the issue was code change to Read Test Output and setting it to GITHUB_OUTPUT instead of set-output:
* solution combine the  Read Test Output and Check if tests are passed task together avoid env variable:
* no failed test
![image](https://github.com/Azure/LinuxPatchExtension/assets/127874208/b1461b20-cbac-49c7-9d22-99a779a18af3)
failed test
![image](https://github.com/Azure/LinuxPatchExtension/assets/127874208/fcd1c8c8-6da3-4d44-888c-a24c8e7bc27f)
