### PR TITLE
combine Read test output and check if all tests passed and use bash s…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,15 +46,15 @@ jobs:
           flags: python39
           name: python-39
           fail_ci_if_error: true
-      - name: Read test output
-        id: getoutput
-        run: echo "contents=$(cat err.txt)" >> $GITHUB_OUTPUT
-      - name: Check if all tests passed
-        if: contains( steps.getoutput.outputs.contents, 'FAILED (failures=' )
-        shell: cmd
+      - name: Read test output and Check if all tests passed
+        shell: bash
         run: |
-          echo "${{ steps.getoutput.outputs.contents }}"
-          exit 1
+          CONTENTS=$(cat err.txt)
+          if echo "$CONTENTS" | grep -q 'FAILED (failures='; then
+            echo "There are failed tests"
+            echo "Contents: $CONTENTS"
+            exit 1
+          fi
   codecov-python-27:
     runs-on: windows-latest
     needs: codecov-python-39
@@ -112,12 +112,12 @@ jobs:
           flags: python27
           name: python-27
           fail_ci_if_error: true
-      - name: Read test output
-        id: getoutput
-        run: echo "contents=$(cat err2.txt)" >> $GITHUB_OUTPUT
-      - name: Check if all tests passed
-        if: contains( steps.getoutput.outputs.contents, 'FAILED (failures=' )
+      - name: Read test output and Check if all tests passed
+        shell: bash
         run: |
-          echo "${{ steps.getoutput.outputs.contents }}"
-          echo "There are failed tests"
-          exit 1
+          CONTENTS=$(cat err2.txt)
+          if echo "$CONTENTS" | grep -q 'FAILED (failures='; then
+            echo "There are failed tests"
+            echo "Contents: $CONTENTS"
+            exit 1
+          fi


### PR DESCRIPTION
pipeline isn't picking up failed unit test, output false positive, see picture below both pipeline are passed, but end with error 1:
![image](https://github.com/Azure/LinuxPatchExtension/assets/127874208/66b4962f-6097-4078-9d6a-d433bd81c311)
![image](https://github.com/Azure/LinuxPatchExtension/assets/127874208/f08c6633-235d-43b1-a15d-213d8ee656d7)
the cause of the issue was code change to Read Test Output and setting it to GITHUB_OUTPUT instead of set-output:
solution combine the Read Test Output and Check if tests are passed task together avoid env variable:
no failed test
![image](https://github.com/Azure/LinuxPatchExtension/assets/127874208/867492dc-6548-4214-b19c-ccda794e38c5)
failed test
![image](https://github.com/Azure/LinuxPatchExtension/assets/127874208/f70bc648-9853-475f-bdd6-328a55f36b26)
