### PR TITLE
Adding version compare logic to external dependencies to fix distutils not supported issue

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -4,6 +4,8 @@ comment:
   require_changes: false
 github_checks:
     annotations: false
+ignore:
+  - "**/external_dependencies"
 coverage:
   precision: 2
   round: down

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -5,7 +5,7 @@ comment:
 github_checks:
     annotations: false
 ignore:
-  - "**/external_dependencies"
+  - "external_dependencies"
 coverage:
   precision: 2
   round: down

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -5,7 +5,7 @@ comment:
 github_checks:
     annotations: false
 ignore:
-  - "external_dependencies"
+  - "src/core/src/external_dependencies"
 coverage:
   precision: 2
   round: down

--- a/src/core/src/external_dependencies/README.md
+++ b/src/core/src/external_dependencies/README.md
@@ -13,6 +13,15 @@ License: Apache License, version 2.0. License is included with the source, unmod
 
 Reason for inclusion: platform.linux_distribution is being removed in Python 3.8 and this is the commonly recommended replacement online.
 
+# 2. Packaging.Version - an version compare API
+
+Source: https://pypi.org/project/packaging
+
+File(s): version.py
+
+License: Apache License, version 2.0. License is included with the source, unmodified.
+
+Reason for inclusion: distutils.LooseVersion is being removed in Python 3.11.
 
 -----
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). 

--- a/src/core/src/external_dependencies/_structures.py
+++ b/src/core/src/external_dependencies/_structures.py
@@ -1,0 +1,61 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+
+class InfinityType:
+    def __repr__(self) -> str:
+        return "Infinity"
+
+    def __hash__(self) -> int:
+        return hash(repr(self))
+
+    def __lt__(self, other: object) -> bool:
+        return False
+
+    def __le__(self, other: object) -> bool:
+        return False
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, self.__class__)
+
+    def __gt__(self, other: object) -> bool:
+        return True
+
+    def __ge__(self, other: object) -> bool:
+        return True
+
+    def __neg__(self: object) -> "NegativeInfinityType":
+        return NegativeInfinity
+
+
+Infinity = InfinityType()
+
+
+class NegativeInfinityType:
+    def __repr__(self) -> str:
+        return "-Infinity"
+
+    def __hash__(self) -> int:
+        return hash(repr(self))
+
+    def __lt__(self, other: object) -> bool:
+        return True
+
+    def __le__(self, other: object) -> bool:
+        return True
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, self.__class__)
+
+    def __gt__(self, other: object) -> bool:
+        return False
+
+    def __ge__(self, other: object) -> bool:
+        return False
+
+    def __neg__(self: object) -> InfinityType:
+        return Infinity
+
+
+NegativeInfinity = NegativeInfinityType()

--- a/src/core/src/external_dependencies/version.py
+++ b/src/core/src/external_dependencies/version.py
@@ -1,0 +1,563 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+"""
+.. testsetup::
+
+    from packaging.version import parse, Version
+"""
+
+import itertools
+import re
+from typing import Any, Callable, NamedTuple, Optional, SupportsInt, Tuple, Union
+
+from ._structures import Infinity, InfinityType, NegativeInfinity, NegativeInfinityType
+
+__all__ = ["VERSION_PATTERN", "parse", "Version", "InvalidVersion"]
+
+LocalType = Tuple[Union[int, str], ...]
+
+CmpPrePostDevType = Union[InfinityType, NegativeInfinityType, Tuple[str, int]]
+CmpLocalType = Union[
+    NegativeInfinityType,
+    Tuple[Union[Tuple[int, str], Tuple[NegativeInfinityType, Union[int, str]]], ...],
+]
+CmpKey = Tuple[
+    int,
+    Tuple[int, ...],
+    CmpPrePostDevType,
+    CmpPrePostDevType,
+    CmpPrePostDevType,
+    CmpLocalType,
+]
+VersionComparisonMethod = Callable[[CmpKey, CmpKey], bool]
+
+
+class _Version(NamedTuple):
+    epoch: int
+    release: Tuple[int, ...]
+    dev: Optional[Tuple[str, int]]
+    pre: Optional[Tuple[str, int]]
+    post: Optional[Tuple[str, int]]
+    local: Optional[LocalType]
+
+
+def parse(version: str) -> "Version":
+    """Parse the given version string.
+
+    >>> parse('1.0.dev1')
+    <Version('1.0.dev1')>
+
+    :param version: The version string to parse.
+    :raises InvalidVersion: When the version string is not a valid version.
+    """
+    return Version(version)
+
+
+class InvalidVersion(ValueError):
+    """Raised when a version string is not a valid version.
+
+    >>> Version("invalid")
+    Traceback (most recent call last):
+        ...
+    packaging.version.InvalidVersion: Invalid version: 'invalid'
+    """
+
+
+class _BaseVersion:
+    _key: Tuple[Any, ...]
+
+    def __hash__(self) -> int:
+        return hash(self._key)
+
+    # Please keep the duplicated `isinstance` check
+    # in the six comparisons hereunder
+    # unless you find a way to avoid adding overhead function calls.
+    def __lt__(self, other: "_BaseVersion") -> bool:
+        if not isinstance(other, _BaseVersion):
+            return NotImplemented
+
+        return self._key < other._key
+
+    def __le__(self, other: "_BaseVersion") -> bool:
+        if not isinstance(other, _BaseVersion):
+            return NotImplemented
+
+        return self._key <= other._key
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, _BaseVersion):
+            return NotImplemented
+
+        return self._key == other._key
+
+    def __ge__(self, other: "_BaseVersion") -> bool:
+        if not isinstance(other, _BaseVersion):
+            return NotImplemented
+
+        return self._key >= other._key
+
+    def __gt__(self, other: "_BaseVersion") -> bool:
+        if not isinstance(other, _BaseVersion):
+            return NotImplemented
+
+        return self._key > other._key
+
+    def __ne__(self, other: object) -> bool:
+        if not isinstance(other, _BaseVersion):
+            return NotImplemented
+
+        return self._key != other._key
+
+
+# Deliberately not anchored to the start and end of the string, to make it
+# easier for 3rd party code to reuse
+_VERSION_PATTERN = r"""
+    v?
+    (?:
+        (?:(?P<epoch>[0-9]+)!)?                           # epoch
+        (?P<release>[0-9]+(?:\.[0-9]+)*)                  # release segment
+        (?P<pre>                                          # pre-release
+            [-_\.]?
+            (?P<pre_l>alpha|a|beta|b|preview|pre|c|rc)
+            [-_\.]?
+            (?P<pre_n>[0-9]+)?
+        )?
+        (?P<post>                                         # post release
+            (?:-(?P<post_n1>[0-9]+))
+            |
+            (?:
+                [-_\.]?
+                (?P<post_l>post|rev|r)
+                [-_\.]?
+                (?P<post_n2>[0-9]+)?
+            )
+        )?
+        (?P<dev>                                          # dev release
+            [-_\.]?
+            (?P<dev_l>dev)
+            [-_\.]?
+            (?P<dev_n>[0-9]+)?
+        )?
+    )
+    (?:\+(?P<local>[a-z0-9]+(?:[-_\.][a-z0-9]+)*))?       # local version
+"""
+
+VERSION_PATTERN = _VERSION_PATTERN
+"""
+A string containing the regular expression used to match a valid version.
+
+The pattern is not anchored at either end, and is intended for embedding in larger
+expressions (for example, matching a version number as part of a file name). The
+regular expression should be compiled with the ``re.VERBOSE`` and ``re.IGNORECASE``
+flags set.
+
+:meta hide-value:
+"""
+
+
+class Version(_BaseVersion):
+    """This class abstracts handling of a project's versions.
+
+    A :class:`Version` instance is comparison aware and can be compared and
+    sorted using the standard Python interfaces.
+
+    >>> v1 = Version("1.0a5")
+    >>> v2 = Version("1.0")
+    >>> v1
+    <Version('1.0a5')>
+    >>> v2
+    <Version('1.0')>
+    >>> v1 < v2
+    True
+    >>> v1 == v2
+    False
+    >>> v1 > v2
+    False
+    >>> v1 >= v2
+    False
+    >>> v1 <= v2
+    True
+    """
+
+    _regex = re.compile(r"^\s*" + VERSION_PATTERN + r"\s*$", re.VERBOSE | re.IGNORECASE)
+    _key: CmpKey
+
+    def __init__(self, version: str) -> None:
+        """Initialize a Version object.
+
+        :param version:
+            The string representation of a version which will be parsed and normalized
+            before use.
+        :raises InvalidVersion:
+            If the ``version`` does not conform to PEP 440 in any way then this
+            exception will be raised.
+        """
+
+        # Validate the version and parse it into pieces
+        match = self._regex.search(version)
+        if not match:
+            raise InvalidVersion(f"Invalid version: '{version}'")
+
+        # Store the parsed out pieces of the version
+        self._version = _Version(
+            epoch=int(match.group("epoch")) if match.group("epoch") else 0,
+            release=tuple(int(i) for i in match.group("release").split(".")),
+            pre=_parse_letter_version(match.group("pre_l"), match.group("pre_n")),
+            post=_parse_letter_version(
+                match.group("post_l"), match.group("post_n1") or match.group("post_n2")
+            ),
+            dev=_parse_letter_version(match.group("dev_l"), match.group("dev_n")),
+            local=_parse_local_version(match.group("local")),
+        )
+
+        # Generate a key which will be used for sorting
+        self._key = _cmpkey(
+            self._version.epoch,
+            self._version.release,
+            self._version.pre,
+            self._version.post,
+            self._version.dev,
+            self._version.local,
+        )
+
+    def __repr__(self) -> str:
+        """A representation of the Version that shows all internal state.
+
+        >>> Version('1.0.0')
+        <Version('1.0.0')>
+        """
+        return f"<Version('{self}')>"
+
+    def __str__(self) -> str:
+        """A string representation of the version that can be rounded-tripped.
+
+        >>> str(Version("1.0a5"))
+        '1.0a5'
+        """
+        parts = []
+
+        # Epoch
+        if self.epoch != 0:
+            parts.append(f"{self.epoch}!")
+
+        # Release segment
+        parts.append(".".join(str(x) for x in self.release))
+
+        # Pre-release
+        if self.pre is not None:
+            parts.append("".join(str(x) for x in self.pre))
+
+        # Post-release
+        if self.post is not None:
+            parts.append(f".post{self.post}")
+
+        # Development release
+        if self.dev is not None:
+            parts.append(f".dev{self.dev}")
+
+        # Local version segment
+        if self.local is not None:
+            parts.append(f"+{self.local}")
+
+        return "".join(parts)
+
+    @property
+    def epoch(self) -> int:
+        """The epoch of the version.
+
+        >>> Version("2.0.0").epoch
+        0
+        >>> Version("1!2.0.0").epoch
+        1
+        """
+        return self._version.epoch
+
+    @property
+    def release(self) -> Tuple[int, ...]:
+        """The components of the "release" segment of the version.
+
+        >>> Version("1.2.3").release
+        (1, 2, 3)
+        >>> Version("2.0.0").release
+        (2, 0, 0)
+        >>> Version("1!2.0.0.post0").release
+        (2, 0, 0)
+
+        Includes trailing zeroes but not the epoch or any pre-release / development /
+        post-release suffixes.
+        """
+        return self._version.release
+
+    @property
+    def pre(self) -> Optional[Tuple[str, int]]:
+        """The pre-release segment of the version.
+
+        >>> print(Version("1.2.3").pre)
+        None
+        >>> Version("1.2.3a1").pre
+        ('a', 1)
+        >>> Version("1.2.3b1").pre
+        ('b', 1)
+        >>> Version("1.2.3rc1").pre
+        ('rc', 1)
+        """
+        return self._version.pre
+
+    @property
+    def post(self) -> Optional[int]:
+        """The post-release number of the version.
+
+        >>> print(Version("1.2.3").post)
+        None
+        >>> Version("1.2.3.post1").post
+        1
+        """
+        return self._version.post[1] if self._version.post else None
+
+    @property
+    def dev(self) -> Optional[int]:
+        """The development number of the version.
+
+        >>> print(Version("1.2.3").dev)
+        None
+        >>> Version("1.2.3.dev1").dev
+        1
+        """
+        return self._version.dev[1] if self._version.dev else None
+
+    @property
+    def local(self) -> Optional[str]:
+        """The local version segment of the version.
+
+        >>> print(Version("1.2.3").local)
+        None
+        >>> Version("1.2.3+abc").local
+        'abc'
+        """
+        if self._version.local:
+            return ".".join(str(x) for x in self._version.local)
+        else:
+            return None
+
+    @property
+    def public(self) -> str:
+        """The public portion of the version.
+
+        >>> Version("1.2.3").public
+        '1.2.3'
+        >>> Version("1.2.3+abc").public
+        '1.2.3'
+        >>> Version("1.2.3+abc.dev1").public
+        '1.2.3'
+        """
+        return str(self).split("+", 1)[0]
+
+    @property
+    def base_version(self) -> str:
+        """The "base version" of the version.
+
+        >>> Version("1.2.3").base_version
+        '1.2.3'
+        >>> Version("1.2.3+abc").base_version
+        '1.2.3'
+        >>> Version("1!1.2.3+abc.dev1").base_version
+        '1!1.2.3'
+
+        The "base version" is the public version of the project without any pre or post
+        release markers.
+        """
+        parts = []
+
+        # Epoch
+        if self.epoch != 0:
+            parts.append(f"{self.epoch}!")
+
+        # Release segment
+        parts.append(".".join(str(x) for x in self.release))
+
+        return "".join(parts)
+
+    @property
+    def is_prerelease(self) -> bool:
+        """Whether this version is a pre-release.
+
+        >>> Version("1.2.3").is_prerelease
+        False
+        >>> Version("1.2.3a1").is_prerelease
+        True
+        >>> Version("1.2.3b1").is_prerelease
+        True
+        >>> Version("1.2.3rc1").is_prerelease
+        True
+        >>> Version("1.2.3dev1").is_prerelease
+        True
+        """
+        return self.dev is not None or self.pre is not None
+
+    @property
+    def is_postrelease(self) -> bool:
+        """Whether this version is a post-release.
+
+        >>> Version("1.2.3").is_postrelease
+        False
+        >>> Version("1.2.3.post1").is_postrelease
+        True
+        """
+        return self.post is not None
+
+    @property
+    def is_devrelease(self) -> bool:
+        """Whether this version is a development release.
+
+        >>> Version("1.2.3").is_devrelease
+        False
+        >>> Version("1.2.3.dev1").is_devrelease
+        True
+        """
+        return self.dev is not None
+
+    @property
+    def major(self) -> int:
+        """The first item of :attr:`release` or ``0`` if unavailable.
+
+        >>> Version("1.2.3").major
+        1
+        """
+        return self.release[0] if len(self.release) >= 1 else 0
+
+    @property
+    def minor(self) -> int:
+        """The second item of :attr:`release` or ``0`` if unavailable.
+
+        >>> Version("1.2.3").minor
+        2
+        >>> Version("1").minor
+        0
+        """
+        return self.release[1] if len(self.release) >= 2 else 0
+
+    @property
+    def micro(self) -> int:
+        """The third item of :attr:`release` or ``0`` if unavailable.
+
+        >>> Version("1.2.3").micro
+        3
+        >>> Version("1").micro
+        0
+        """
+        return self.release[2] if len(self.release) >= 3 else 0
+
+
+def _parse_letter_version(
+    letter: Optional[str], number: Union[str, bytes, SupportsInt, None]
+) -> Optional[Tuple[str, int]]:
+
+    if letter:
+        # We consider there to be an implicit 0 in a pre-release if there is
+        # not a numeral associated with it.
+        if number is None:
+            number = 0
+
+        # We normalize any letters to their lower case form
+        letter = letter.lower()
+
+        # We consider some words to be alternate spellings of other words and
+        # in those cases we want to normalize the spellings to our preferred
+        # spelling.
+        if letter == "alpha":
+            letter = "a"
+        elif letter == "beta":
+            letter = "b"
+        elif letter in ["c", "pre", "preview"]:
+            letter = "rc"
+        elif letter in ["rev", "r"]:
+            letter = "post"
+
+        return letter, int(number)
+    if not letter and number:
+        # We assume if we are given a number, but we are not given a letter
+        # then this is using the implicit post release syntax (e.g. 1.0-1)
+        letter = "post"
+
+        return letter, int(number)
+
+    return None
+
+
+_local_version_separators = re.compile(r"[\._-]")
+
+
+def _parse_local_version(local: Optional[str]) -> Optional[LocalType]:
+    """
+    Takes a string like abc.1.twelve and turns it into ("abc", 1, "twelve").
+    """
+    if local is not None:
+        return tuple(
+            part.lower() if not part.isdigit() else int(part)
+            for part in _local_version_separators.split(local)
+        )
+    return None
+
+
+def _cmpkey(
+    epoch: int,
+    release: Tuple[int, ...],
+    pre: Optional[Tuple[str, int]],
+    post: Optional[Tuple[str, int]],
+    dev: Optional[Tuple[str, int]],
+    local: Optional[LocalType],
+) -> CmpKey:
+
+    # When we compare a release version, we want to compare it with all of the
+    # trailing zeros removed. So we'll use a reverse the list, drop all the now
+    # leading zeros until we come to something non zero, then take the rest
+    # re-reverse it back into the correct order and make it a tuple and use
+    # that for our sorting key.
+    _release = tuple(
+        reversed(list(itertools.dropwhile(lambda x: x == 0, reversed(release))))
+    )
+
+    # We need to "trick" the sorting algorithm to put 1.0.dev0 before 1.0a0.
+    # We'll do this by abusing the pre segment, but we _only_ want to do this
+    # if there is not a pre or a post segment. If we have one of those then
+    # the normal sorting rules will handle this case correctly.
+    if pre is None and post is None and dev is not None:
+        _pre: CmpPrePostDevType = NegativeInfinity
+    # Versions without a pre-release (except as noted above) should sort after
+    # those with one.
+    elif pre is None:
+        _pre = Infinity
+    else:
+        _pre = pre
+
+    # Versions without a post segment should sort before those with one.
+    if post is None:
+        _post: CmpPrePostDevType = NegativeInfinity
+
+    else:
+        _post = post
+
+    # Versions without a development segment should sort after those with one.
+    if dev is None:
+        _dev: CmpPrePostDevType = Infinity
+
+    else:
+        _dev = dev
+
+    if local is None:
+        # Versions without a local segment should sort before those with one.
+        _local: CmpLocalType = NegativeInfinity
+    else:
+        # Versions with a local segment need that segment parsed to implement
+        # the sorting rules in PEP440.
+        # - Alpha numeric segments sort before numeric segments
+        # - Alpha numeric segments sort lexicographically
+        # - Numeric segments sort numerically
+        # - Shorter versions sort before longer versions when the prefixes
+        #   match exactly
+        _local = tuple(
+            (i, "") if isinstance(i, int) else (NegativeInfinity, i) for i in local
+        )
+
+    return epoch, _release, _pre, _post, _dev, _local

--- a/src/core/src/package_managers/UbuntuProClient.py
+++ b/src/core/src/package_managers/UbuntuProClient.py
@@ -17,7 +17,7 @@
 """This is the Ubuntu Pro Client implementation"""
 import json
 from core.src.bootstrap.Constants import Constants
-
+from core.src.external_dependencies import version as packaging_version
 
 class UbuntuProClient:
     def __init__(self, env_layer, composite_logger):
@@ -50,10 +50,12 @@ class UbuntuProClient:
         is_minimum_ubuntu_pro_version_installed = False
         try:
             from uaclient.api.u.pro.version.v1 import version
-            from distutils.version import LooseVersion  # Importing this module here as there is conflict between "distutils.version" and "uaclient.api.u.pro.version.v1.version when 'LooseVersion' is called."
             version_result = version()
             ubuntu_pro_client_version = version_result.installed_version
-            is_minimum_ubuntu_pro_version_installed = LooseVersion(ubuntu_pro_client_version) >= LooseVersion(Constants.UbuntuProClientSettings.MINIMUM_CLIENT_VERSION)
+            if ubuntu_pro_client_version is not None:
+                #Ubuntu pro client version has os version appended. e.g: "30.0.0~18.04".We need to trim os version to get pro version.
+                trimmed_pro_client_version = ubuntu_pro_client_version.split("~")[0]
+                is_minimum_ubuntu_pro_version_installed = packaging_version.parse(trimmed_pro_client_version) >= packaging_version.parse(Constants.UbuntuProClientSettings.MINIMUM_CLIENT_VERSION)
             if ubuntu_pro_client_version is not None and is_minimum_ubuntu_pro_version_installed:
                 is_ubuntu_pro_client_working = True
                 self.is_ubuntu_pro_client_attached = self.log_ubuntu_pro_client_attached()

--- a/src/core/tests/Test_UbuntuProClient.py
+++ b/src/core/tests/Test_UbuntuProClient.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 # Requires Python 2.7+
-import imp
+import types
 import sys
 import types
 import unittest
@@ -63,7 +63,7 @@ class MockVersionResult(MockSystemModules):
             mock_method = getattr(self, method_name)
             setattr(sys.modules['uaclient.api.u.pro.version.v1'], mock_name, mock_method)
         else:
-            version_module = imp.new_module('version_module')
+            version_module = types.ModuleType('version_module')
             mock_method = getattr(self, method_name)
             setattr(version_module, mock_name, mock_method)
             self.assign_sys_modules_with_mock_module('uaclient.api.u.pro.version.v1', version_module)
@@ -91,7 +91,7 @@ class MockRebootRequiredResult(MockSystemModules):
             mock_method = getattr(self, method_name)
             setattr(sys.modules['uaclient.api.u.pro.security.status.reboot_required.v1'], mock_name, mock_method)
         else:
-            reboot_module = imp.new_module('reboot_module')
+            reboot_module = types.ModuleType('reboot_module')
             mock_method = getattr(self, method_name)
             setattr(reboot_module, mock_name, mock_method)
             self.assign_sys_modules_with_mock_module('uaclient.api.u.pro.security.status.reboot_required.v1', reboot_module)
@@ -135,7 +135,7 @@ class MockUpdatesResult(MockSystemModules):
             mock_method = getattr(self, method_name)
             setattr(sys.modules['uaclient.api.u.pro.packages.updates.v1'], mock_name, mock_method)
         else:
-            update_module = imp.new_module('update_module')
+            update_module = types.ModuleType('update_module')
             mock_method = getattr(self, method_name)
             setattr(update_module, mock_name, mock_method)
             self.assign_sys_modules_with_mock_module('uaclient.api.u.pro.packages.updates.v1', update_module)

--- a/src/core/tests/external_dependencies/Test_structures.py
+++ b/src/core/tests/external_dependencies/Test_structures.py
@@ -1,0 +1,59 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+import pytest
+
+from packaging._structures import Infinity, NegativeInfinity
+
+
+def test_infinity_repr():
+    repr(Infinity) == "Infinity"
+
+
+def test_negative_infinity_repr():
+    repr(NegativeInfinity) == "-Infinity"
+
+
+def test_infinity_hash():
+    assert hash(Infinity) == hash(Infinity)
+
+
+def test_negative_infinity_hash():
+    assert hash(NegativeInfinity) == hash(NegativeInfinity)
+
+
+@pytest.mark.parametrize("left", [1, "a", ("b", 4)])
+def test_infinity_comparison(left):
+    assert left < Infinity
+    assert left <= Infinity
+    assert not left == Infinity
+    assert left != Infinity
+    assert not left > Infinity
+    assert not left >= Infinity
+
+
+@pytest.mark.parametrize("left", [1, "a", ("b", 4)])
+def test_negative_infinity_lesser(left):
+    assert not left < NegativeInfinity
+    assert not left <= NegativeInfinity
+    assert not left == NegativeInfinity
+    assert left != NegativeInfinity
+    assert left > NegativeInfinity
+    assert left >= NegativeInfinity
+
+
+def test_infinity_equal():
+    assert Infinity == Infinity
+
+
+def test_negative_infinity_equal():
+    assert NegativeInfinity == NegativeInfinity
+
+
+def test_negate_infinity():
+    assert isinstance(-Infinity, NegativeInfinity.__class__)
+
+
+def test_negate_negative_infinity():
+    assert isinstance(-NegativeInfinity, Infinity.__class__)

--- a/src/core/tests/external_dependencies/Test_version.py
+++ b/src/core/tests/external_dependencies/Test_version.py
@@ -1,0 +1,773 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+import itertools
+import operator
+
+import pretend
+import pytest
+
+from packaging.version import InvalidVersion, Version, parse
+
+
+def test_parse():
+    assert isinstance(parse("1.0"), Version)
+
+
+def test_parse_raises():
+    with pytest.raises(InvalidVersion):
+        parse("lolwat")
+
+
+# This list must be in the correct sorting order
+VERSIONS = [
+    # Implicit epoch of 0
+    "1.0.dev456",
+    "1.0a1",
+    "1.0a2.dev456",
+    "1.0a12.dev456",
+    "1.0a12",
+    "1.0b1.dev456",
+    "1.0b2",
+    "1.0b2.post345.dev456",
+    "1.0b2.post345",
+    "1.0b2-346",
+    "1.0c1.dev456",
+    "1.0c1",
+    "1.0rc2",
+    "1.0c3",
+    "1.0",
+    "1.0.post456.dev34",
+    "1.0.post456",
+    "1.1.dev1",
+    "1.2+123abc",
+    "1.2+123abc456",
+    "1.2+abc",
+    "1.2+abc123",
+    "1.2+abc123def",
+    "1.2+1234.abc",
+    "1.2+123456",
+    "1.2.r32+123456",
+    "1.2.rev33+123456",
+    # Explicit epoch of 1
+    "1!1.0.dev456",
+    "1!1.0a1",
+    "1!1.0a2.dev456",
+    "1!1.0a12.dev456",
+    "1!1.0a12",
+    "1!1.0b1.dev456",
+    "1!1.0b2",
+    "1!1.0b2.post345.dev456",
+    "1!1.0b2.post345",
+    "1!1.0b2-346",
+    "1!1.0c1.dev456",
+    "1!1.0c1",
+    "1!1.0rc2",
+    "1!1.0c3",
+    "1!1.0",
+    "1!1.0.post456.dev34",
+    "1!1.0.post456",
+    "1!1.1.dev1",
+    "1!1.2+123abc",
+    "1!1.2+123abc456",
+    "1!1.2+abc",
+    "1!1.2+abc123",
+    "1!1.2+abc123def",
+    "1!1.2+1234.abc",
+    "1!1.2+123456",
+    "1!1.2.r32+123456",
+    "1!1.2.rev33+123456",
+]
+
+
+class TestVersion:
+    @pytest.mark.parametrize("version", VERSIONS)
+    def test_valid_versions(self, version):
+        Version(version)
+
+    @pytest.mark.parametrize(
+        "version",
+        [
+            # Non sensical versions should be invalid
+            "french toast",
+            # Versions with invalid local versions
+            "1.0+a+",
+            "1.0++",
+            "1.0+_foobar",
+            "1.0+foo&asd",
+            "1.0+1+1",
+        ],
+    )
+    def test_invalid_versions(self, version):
+        with pytest.raises(InvalidVersion):
+            Version(version)
+
+    @pytest.mark.parametrize(
+        ("version", "normalized"),
+        [
+            # Various development release incarnations
+            ("1.0dev", "1.0.dev0"),
+            ("1.0.dev", "1.0.dev0"),
+            ("1.0dev1", "1.0.dev1"),
+            ("1.0dev", "1.0.dev0"),
+            ("1.0-dev", "1.0.dev0"),
+            ("1.0-dev1", "1.0.dev1"),
+            ("1.0DEV", "1.0.dev0"),
+            ("1.0.DEV", "1.0.dev0"),
+            ("1.0DEV1", "1.0.dev1"),
+            ("1.0DEV", "1.0.dev0"),
+            ("1.0.DEV1", "1.0.dev1"),
+            ("1.0-DEV", "1.0.dev0"),
+            ("1.0-DEV1", "1.0.dev1"),
+            # Various alpha incarnations
+            ("1.0a", "1.0a0"),
+            ("1.0.a", "1.0a0"),
+            ("1.0.a1", "1.0a1"),
+            ("1.0-a", "1.0a0"),
+            ("1.0-a1", "1.0a1"),
+            ("1.0alpha", "1.0a0"),
+            ("1.0.alpha", "1.0a0"),
+            ("1.0.alpha1", "1.0a1"),
+            ("1.0-alpha", "1.0a0"),
+            ("1.0-alpha1", "1.0a1"),
+            ("1.0A", "1.0a0"),
+            ("1.0.A", "1.0a0"),
+            ("1.0.A1", "1.0a1"),
+            ("1.0-A", "1.0a0"),
+            ("1.0-A1", "1.0a1"),
+            ("1.0ALPHA", "1.0a0"),
+            ("1.0.ALPHA", "1.0a0"),
+            ("1.0.ALPHA1", "1.0a1"),
+            ("1.0-ALPHA", "1.0a0"),
+            ("1.0-ALPHA1", "1.0a1"),
+            # Various beta incarnations
+            ("1.0b", "1.0b0"),
+            ("1.0.b", "1.0b0"),
+            ("1.0.b1", "1.0b1"),
+            ("1.0-b", "1.0b0"),
+            ("1.0-b1", "1.0b1"),
+            ("1.0beta", "1.0b0"),
+            ("1.0.beta", "1.0b0"),
+            ("1.0.beta1", "1.0b1"),
+            ("1.0-beta", "1.0b0"),
+            ("1.0-beta1", "1.0b1"),
+            ("1.0B", "1.0b0"),
+            ("1.0.B", "1.0b0"),
+            ("1.0.B1", "1.0b1"),
+            ("1.0-B", "1.0b0"),
+            ("1.0-B1", "1.0b1"),
+            ("1.0BETA", "1.0b0"),
+            ("1.0.BETA", "1.0b0"),
+            ("1.0.BETA1", "1.0b1"),
+            ("1.0-BETA", "1.0b0"),
+            ("1.0-BETA1", "1.0b1"),
+            # Various release candidate incarnations
+            ("1.0c", "1.0rc0"),
+            ("1.0.c", "1.0rc0"),
+            ("1.0.c1", "1.0rc1"),
+            ("1.0-c", "1.0rc0"),
+            ("1.0-c1", "1.0rc1"),
+            ("1.0rc", "1.0rc0"),
+            ("1.0.rc", "1.0rc0"),
+            ("1.0.rc1", "1.0rc1"),
+            ("1.0-rc", "1.0rc0"),
+            ("1.0-rc1", "1.0rc1"),
+            ("1.0C", "1.0rc0"),
+            ("1.0.C", "1.0rc0"),
+            ("1.0.C1", "1.0rc1"),
+            ("1.0-C", "1.0rc0"),
+            ("1.0-C1", "1.0rc1"),
+            ("1.0RC", "1.0rc0"),
+            ("1.0.RC", "1.0rc0"),
+            ("1.0.RC1", "1.0rc1"),
+            ("1.0-RC", "1.0rc0"),
+            ("1.0-RC1", "1.0rc1"),
+            # Various post release incarnations
+            ("1.0post", "1.0.post0"),
+            ("1.0.post", "1.0.post0"),
+            ("1.0post1", "1.0.post1"),
+            ("1.0post", "1.0.post0"),
+            ("1.0-post", "1.0.post0"),
+            ("1.0-post1", "1.0.post1"),
+            ("1.0POST", "1.0.post0"),
+            ("1.0.POST", "1.0.post0"),
+            ("1.0POST1", "1.0.post1"),
+            ("1.0POST", "1.0.post0"),
+            ("1.0r", "1.0.post0"),
+            ("1.0rev", "1.0.post0"),
+            ("1.0.POST1", "1.0.post1"),
+            ("1.0.r1", "1.0.post1"),
+            ("1.0.rev1", "1.0.post1"),
+            ("1.0-POST", "1.0.post0"),
+            ("1.0-POST1", "1.0.post1"),
+            ("1.0-5", "1.0.post5"),
+            ("1.0-r5", "1.0.post5"),
+            ("1.0-rev5", "1.0.post5"),
+            # Local version case insensitivity
+            ("1.0+AbC", "1.0+abc"),
+            # Integer Normalization
+            ("1.01", "1.1"),
+            ("1.0a05", "1.0a5"),
+            ("1.0b07", "1.0b7"),
+            ("1.0c056", "1.0rc56"),
+            ("1.0rc09", "1.0rc9"),
+            ("1.0.post000", "1.0.post0"),
+            ("1.1.dev09000", "1.1.dev9000"),
+            ("00!1.2", "1.2"),
+            ("0100!0.0", "100!0.0"),
+            # Various other normalizations
+            ("v1.0", "1.0"),
+            ("   v1.0\t\n", "1.0"),
+        ],
+    )
+    def test_normalized_versions(self, version, normalized):
+        assert str(Version(version)) == normalized
+
+    @pytest.mark.parametrize(
+        ("version", "expected"),
+        [
+            ("1.0.dev456", "1.0.dev456"),
+            ("1.0a1", "1.0a1"),
+            ("1.0a2.dev456", "1.0a2.dev456"),
+            ("1.0a12.dev456", "1.0a12.dev456"),
+            ("1.0a12", "1.0a12"),
+            ("1.0b1.dev456", "1.0b1.dev456"),
+            ("1.0b2", "1.0b2"),
+            ("1.0b2.post345.dev456", "1.0b2.post345.dev456"),
+            ("1.0b2.post345", "1.0b2.post345"),
+            ("1.0rc1.dev456", "1.0rc1.dev456"),
+            ("1.0rc1", "1.0rc1"),
+            ("1.0", "1.0"),
+            ("1.0.post456.dev34", "1.0.post456.dev34"),
+            ("1.0.post456", "1.0.post456"),
+            ("1.0.1", "1.0.1"),
+            ("0!1.0.2", "1.0.2"),
+            ("1.0.3+7", "1.0.3+7"),
+            ("0!1.0.4+8.0", "1.0.4+8.0"),
+            ("1.0.5+9.5", "1.0.5+9.5"),
+            ("1.2+1234.abc", "1.2+1234.abc"),
+            ("1.2+123456", "1.2+123456"),
+            ("1.2+123abc", "1.2+123abc"),
+            ("1.2+123abc456", "1.2+123abc456"),
+            ("1.2+abc", "1.2+abc"),
+            ("1.2+abc123", "1.2+abc123"),
+            ("1.2+abc123def", "1.2+abc123def"),
+            ("1.1.dev1", "1.1.dev1"),
+            ("7!1.0.dev456", "7!1.0.dev456"),
+            ("7!1.0a1", "7!1.0a1"),
+            ("7!1.0a2.dev456", "7!1.0a2.dev456"),
+            ("7!1.0a12.dev456", "7!1.0a12.dev456"),
+            ("7!1.0a12", "7!1.0a12"),
+            ("7!1.0b1.dev456", "7!1.0b1.dev456"),
+            ("7!1.0b2", "7!1.0b2"),
+            ("7!1.0b2.post345.dev456", "7!1.0b2.post345.dev456"),
+            ("7!1.0b2.post345", "7!1.0b2.post345"),
+            ("7!1.0rc1.dev456", "7!1.0rc1.dev456"),
+            ("7!1.0rc1", "7!1.0rc1"),
+            ("7!1.0", "7!1.0"),
+            ("7!1.0.post456.dev34", "7!1.0.post456.dev34"),
+            ("7!1.0.post456", "7!1.0.post456"),
+            ("7!1.0.1", "7!1.0.1"),
+            ("7!1.0.2", "7!1.0.2"),
+            ("7!1.0.3+7", "7!1.0.3+7"),
+            ("7!1.0.4+8.0", "7!1.0.4+8.0"),
+            ("7!1.0.5+9.5", "7!1.0.5+9.5"),
+            ("7!1.1.dev1", "7!1.1.dev1"),
+        ],
+    )
+    def test_version_str_repr(self, version, expected):
+        assert str(Version(version)) == expected
+        assert repr(Version(version)) == f"<Version({expected!r})>"
+
+    def test_version_rc_and_c_equals(self):
+        assert Version("1.0rc1") == Version("1.0c1")
+
+    @pytest.mark.parametrize("version", VERSIONS)
+    def test_version_hash(self, version):
+        assert hash(Version(version)) == hash(Version(version))
+
+    @pytest.mark.parametrize(
+        ("version", "public"),
+        [
+            ("1.0", "1.0"),
+            ("1.0.dev0", "1.0.dev0"),
+            ("1.0.dev6", "1.0.dev6"),
+            ("1.0a1", "1.0a1"),
+            ("1.0a1.post5", "1.0a1.post5"),
+            ("1.0a1.post5.dev6", "1.0a1.post5.dev6"),
+            ("1.0rc4", "1.0rc4"),
+            ("1.0.post5", "1.0.post5"),
+            ("1!1.0", "1!1.0"),
+            ("1!1.0.dev6", "1!1.0.dev6"),
+            ("1!1.0a1", "1!1.0a1"),
+            ("1!1.0a1.post5", "1!1.0a1.post5"),
+            ("1!1.0a1.post5.dev6", "1!1.0a1.post5.dev6"),
+            ("1!1.0rc4", "1!1.0rc4"),
+            ("1!1.0.post5", "1!1.0.post5"),
+            ("1.0+deadbeef", "1.0"),
+            ("1.0.dev6+deadbeef", "1.0.dev6"),
+            ("1.0a1+deadbeef", "1.0a1"),
+            ("1.0a1.post5+deadbeef", "1.0a1.post5"),
+            ("1.0a1.post5.dev6+deadbeef", "1.0a1.post5.dev6"),
+            ("1.0rc4+deadbeef", "1.0rc4"),
+            ("1.0.post5+deadbeef", "1.0.post5"),
+            ("1!1.0+deadbeef", "1!1.0"),
+            ("1!1.0.dev6+deadbeef", "1!1.0.dev6"),
+            ("1!1.0a1+deadbeef", "1!1.0a1"),
+            ("1!1.0a1.post5+deadbeef", "1!1.0a1.post5"),
+            ("1!1.0a1.post5.dev6+deadbeef", "1!1.0a1.post5.dev6"),
+            ("1!1.0rc4+deadbeef", "1!1.0rc4"),
+            ("1!1.0.post5+deadbeef", "1!1.0.post5"),
+        ],
+    )
+    def test_version_public(self, version, public):
+        assert Version(version).public == public
+
+    @pytest.mark.parametrize(
+        ("version", "base_version"),
+        [
+            ("1.0", "1.0"),
+            ("1.0.dev0", "1.0"),
+            ("1.0.dev6", "1.0"),
+            ("1.0a1", "1.0"),
+            ("1.0a1.post5", "1.0"),
+            ("1.0a1.post5.dev6", "1.0"),
+            ("1.0rc4", "1.0"),
+            ("1.0.post5", "1.0"),
+            ("1!1.0", "1!1.0"),
+            ("1!1.0.dev6", "1!1.0"),
+            ("1!1.0a1", "1!1.0"),
+            ("1!1.0a1.post5", "1!1.0"),
+            ("1!1.0a1.post5.dev6", "1!1.0"),
+            ("1!1.0rc4", "1!1.0"),
+            ("1!1.0.post5", "1!1.0"),
+            ("1.0+deadbeef", "1.0"),
+            ("1.0.dev6+deadbeef", "1.0"),
+            ("1.0a1+deadbeef", "1.0"),
+            ("1.0a1.post5+deadbeef", "1.0"),
+            ("1.0a1.post5.dev6+deadbeef", "1.0"),
+            ("1.0rc4+deadbeef", "1.0"),
+            ("1.0.post5+deadbeef", "1.0"),
+            ("1!1.0+deadbeef", "1!1.0"),
+            ("1!1.0.dev6+deadbeef", "1!1.0"),
+            ("1!1.0a1+deadbeef", "1!1.0"),
+            ("1!1.0a1.post5+deadbeef", "1!1.0"),
+            ("1!1.0a1.post5.dev6+deadbeef", "1!1.0"),
+            ("1!1.0rc4+deadbeef", "1!1.0"),
+            ("1!1.0.post5+deadbeef", "1!1.0"),
+        ],
+    )
+    def test_version_base_version(self, version, base_version):
+        assert Version(version).base_version == base_version
+
+    @pytest.mark.parametrize(
+        ("version", "epoch"),
+        [
+            ("1.0", 0),
+            ("1.0.dev0", 0),
+            ("1.0.dev6", 0),
+            ("1.0a1", 0),
+            ("1.0a1.post5", 0),
+            ("1.0a1.post5.dev6", 0),
+            ("1.0rc4", 0),
+            ("1.0.post5", 0),
+            ("1!1.0", 1),
+            ("1!1.0.dev6", 1),
+            ("1!1.0a1", 1),
+            ("1!1.0a1.post5", 1),
+            ("1!1.0a1.post5.dev6", 1),
+            ("1!1.0rc4", 1),
+            ("1!1.0.post5", 1),
+            ("1.0+deadbeef", 0),
+            ("1.0.dev6+deadbeef", 0),
+            ("1.0a1+deadbeef", 0),
+            ("1.0a1.post5+deadbeef", 0),
+            ("1.0a1.post5.dev6+deadbeef", 0),
+            ("1.0rc4+deadbeef", 0),
+            ("1.0.post5+deadbeef", 0),
+            ("1!1.0+deadbeef", 1),
+            ("1!1.0.dev6+deadbeef", 1),
+            ("1!1.0a1+deadbeef", 1),
+            ("1!1.0a1.post5+deadbeef", 1),
+            ("1!1.0a1.post5.dev6+deadbeef", 1),
+            ("1!1.0rc4+deadbeef", 1),
+            ("1!1.0.post5+deadbeef", 1),
+        ],
+    )
+    def test_version_epoch(self, version, epoch):
+        assert Version(version).epoch == epoch
+
+    @pytest.mark.parametrize(
+        ("version", "release"),
+        [
+            ("1.0", (1, 0)),
+            ("1.0.dev0", (1, 0)),
+            ("1.0.dev6", (1, 0)),
+            ("1.0a1", (1, 0)),
+            ("1.0a1.post5", (1, 0)),
+            ("1.0a1.post5.dev6", (1, 0)),
+            ("1.0rc4", (1, 0)),
+            ("1.0.post5", (1, 0)),
+            ("1!1.0", (1, 0)),
+            ("1!1.0.dev6", (1, 0)),
+            ("1!1.0a1", (1, 0)),
+            ("1!1.0a1.post5", (1, 0)),
+            ("1!1.0a1.post5.dev6", (1, 0)),
+            ("1!1.0rc4", (1, 0)),
+            ("1!1.0.post5", (1, 0)),
+            ("1.0+deadbeef", (1, 0)),
+            ("1.0.dev6+deadbeef", (1, 0)),
+            ("1.0a1+deadbeef", (1, 0)),
+            ("1.0a1.post5+deadbeef", (1, 0)),
+            ("1.0a1.post5.dev6+deadbeef", (1, 0)),
+            ("1.0rc4+deadbeef", (1, 0)),
+            ("1.0.post5+deadbeef", (1, 0)),
+            ("1!1.0+deadbeef", (1, 0)),
+            ("1!1.0.dev6+deadbeef", (1, 0)),
+            ("1!1.0a1+deadbeef", (1, 0)),
+            ("1!1.0a1.post5+deadbeef", (1, 0)),
+            ("1!1.0a1.post5.dev6+deadbeef", (1, 0)),
+            ("1!1.0rc4+deadbeef", (1, 0)),
+            ("1!1.0.post5+deadbeef", (1, 0)),
+        ],
+    )
+    def test_version_release(self, version, release):
+        assert Version(version).release == release
+
+    @pytest.mark.parametrize(
+        ("version", "local"),
+        [
+            ("1.0", None),
+            ("1.0.dev0", None),
+            ("1.0.dev6", None),
+            ("1.0a1", None),
+            ("1.0a1.post5", None),
+            ("1.0a1.post5.dev6", None),
+            ("1.0rc4", None),
+            ("1.0.post5", None),
+            ("1!1.0", None),
+            ("1!1.0.dev6", None),
+            ("1!1.0a1", None),
+            ("1!1.0a1.post5", None),
+            ("1!1.0a1.post5.dev6", None),
+            ("1!1.0rc4", None),
+            ("1!1.0.post5", None),
+            ("1.0+deadbeef", "deadbeef"),
+            ("1.0.dev6+deadbeef", "deadbeef"),
+            ("1.0a1+deadbeef", "deadbeef"),
+            ("1.0a1.post5+deadbeef", "deadbeef"),
+            ("1.0a1.post5.dev6+deadbeef", "deadbeef"),
+            ("1.0rc4+deadbeef", "deadbeef"),
+            ("1.0.post5+deadbeef", "deadbeef"),
+            ("1!1.0+deadbeef", "deadbeef"),
+            ("1!1.0.dev6+deadbeef", "deadbeef"),
+            ("1!1.0a1+deadbeef", "deadbeef"),
+            ("1!1.0a1.post5+deadbeef", "deadbeef"),
+            ("1!1.0a1.post5.dev6+deadbeef", "deadbeef"),
+            ("1!1.0rc4+deadbeef", "deadbeef"),
+            ("1!1.0.post5+deadbeef", "deadbeef"),
+        ],
+    )
+    def test_version_local(self, version, local):
+        assert Version(version).local == local
+
+    @pytest.mark.parametrize(
+        ("version", "pre"),
+        [
+            ("1.0", None),
+            ("1.0.dev0", None),
+            ("1.0.dev6", None),
+            ("1.0a1", ("a", 1)),
+            ("1.0a1.post5", ("a", 1)),
+            ("1.0a1.post5.dev6", ("a", 1)),
+            ("1.0rc4", ("rc", 4)),
+            ("1.0.post5", None),
+            ("1!1.0", None),
+            ("1!1.0.dev6", None),
+            ("1!1.0a1", ("a", 1)),
+            ("1!1.0a1.post5", ("a", 1)),
+            ("1!1.0a1.post5.dev6", ("a", 1)),
+            ("1!1.0rc4", ("rc", 4)),
+            ("1!1.0.post5", None),
+            ("1.0+deadbeef", None),
+            ("1.0.dev6+deadbeef", None),
+            ("1.0a1+deadbeef", ("a", 1)),
+            ("1.0a1.post5+deadbeef", ("a", 1)),
+            ("1.0a1.post5.dev6+deadbeef", ("a", 1)),
+            ("1.0rc4+deadbeef", ("rc", 4)),
+            ("1.0.post5+deadbeef", None),
+            ("1!1.0+deadbeef", None),
+            ("1!1.0.dev6+deadbeef", None),
+            ("1!1.0a1+deadbeef", ("a", 1)),
+            ("1!1.0a1.post5+deadbeef", ("a", 1)),
+            ("1!1.0a1.post5.dev6+deadbeef", ("a", 1)),
+            ("1!1.0rc4+deadbeef", ("rc", 4)),
+            ("1!1.0.post5+deadbeef", None),
+        ],
+    )
+    def test_version_pre(self, version, pre):
+        assert Version(version).pre == pre
+
+    @pytest.mark.parametrize(
+        ("version", "expected"),
+        [
+            ("1.0.dev0", True),
+            ("1.0.dev1", True),
+            ("1.0a1.dev1", True),
+            ("1.0b1.dev1", True),
+            ("1.0c1.dev1", True),
+            ("1.0rc1.dev1", True),
+            ("1.0a1", True),
+            ("1.0b1", True),
+            ("1.0c1", True),
+            ("1.0rc1", True),
+            ("1.0a1.post1.dev1", True),
+            ("1.0b1.post1.dev1", True),
+            ("1.0c1.post1.dev1", True),
+            ("1.0rc1.post1.dev1", True),
+            ("1.0a1.post1", True),
+            ("1.0b1.post1", True),
+            ("1.0c1.post1", True),
+            ("1.0rc1.post1", True),
+            ("1.0", False),
+            ("1.0+dev", False),
+            ("1.0.post1", False),
+            ("1.0.post1+dev", False),
+        ],
+    )
+    def test_version_is_prerelease(self, version, expected):
+        assert Version(version).is_prerelease is expected
+
+    @pytest.mark.parametrize(
+        ("version", "dev"),
+        [
+            ("1.0", None),
+            ("1.0.dev0", 0),
+            ("1.0.dev6", 6),
+            ("1.0a1", None),
+            ("1.0a1.post5", None),
+            ("1.0a1.post5.dev6", 6),
+            ("1.0rc4", None),
+            ("1.0.post5", None),
+            ("1!1.0", None),
+            ("1!1.0.dev6", 6),
+            ("1!1.0a1", None),
+            ("1!1.0a1.post5", None),
+            ("1!1.0a1.post5.dev6", 6),
+            ("1!1.0rc4", None),
+            ("1!1.0.post5", None),
+            ("1.0+deadbeef", None),
+            ("1.0.dev6+deadbeef", 6),
+            ("1.0a1+deadbeef", None),
+            ("1.0a1.post5+deadbeef", None),
+            ("1.0a1.post5.dev6+deadbeef", 6),
+            ("1.0rc4+deadbeef", None),
+            ("1.0.post5+deadbeef", None),
+            ("1!1.0+deadbeef", None),
+            ("1!1.0.dev6+deadbeef", 6),
+            ("1!1.0a1+deadbeef", None),
+            ("1!1.0a1.post5+deadbeef", None),
+            ("1!1.0a1.post5.dev6+deadbeef", 6),
+            ("1!1.0rc4+deadbeef", None),
+            ("1!1.0.post5+deadbeef", None),
+        ],
+    )
+    def test_version_dev(self, version, dev):
+        assert Version(version).dev == dev
+
+    @pytest.mark.parametrize(
+        ("version", "expected"),
+        [
+            ("1.0", False),
+            ("1.0.dev0", True),
+            ("1.0.dev6", True),
+            ("1.0a1", False),
+            ("1.0a1.post5", False),
+            ("1.0a1.post5.dev6", True),
+            ("1.0rc4", False),
+            ("1.0.post5", False),
+            ("1!1.0", False),
+            ("1!1.0.dev6", True),
+            ("1!1.0a1", False),
+            ("1!1.0a1.post5", False),
+            ("1!1.0a1.post5.dev6", True),
+            ("1!1.0rc4", False),
+            ("1!1.0.post5", False),
+            ("1.0+deadbeef", False),
+            ("1.0.dev6+deadbeef", True),
+            ("1.0a1+deadbeef", False),
+            ("1.0a1.post5+deadbeef", False),
+            ("1.0a1.post5.dev6+deadbeef", True),
+            ("1.0rc4+deadbeef", False),
+            ("1.0.post5+deadbeef", False),
+            ("1!1.0+deadbeef", False),
+            ("1!1.0.dev6+deadbeef", True),
+            ("1!1.0a1+deadbeef", False),
+            ("1!1.0a1.post5+deadbeef", False),
+            ("1!1.0a1.post5.dev6+deadbeef", True),
+            ("1!1.0rc4+deadbeef", False),
+            ("1!1.0.post5+deadbeef", False),
+        ],
+    )
+    def test_version_is_devrelease(self, version, expected):
+        assert Version(version).is_devrelease is expected
+
+    @pytest.mark.parametrize(
+        ("version", "post"),
+        [
+            ("1.0", None),
+            ("1.0.dev0", None),
+            ("1.0.dev6", None),
+            ("1.0a1", None),
+            ("1.0a1.post5", 5),
+            ("1.0a1.post5.dev6", 5),
+            ("1.0rc4", None),
+            ("1.0.post5", 5),
+            ("1!1.0", None),
+            ("1!1.0.dev6", None),
+            ("1!1.0a1", None),
+            ("1!1.0a1.post5", 5),
+            ("1!1.0a1.post5.dev6", 5),
+            ("1!1.0rc4", None),
+            ("1!1.0.post5", 5),
+            ("1.0+deadbeef", None),
+            ("1.0.dev6+deadbeef", None),
+            ("1.0a1+deadbeef", None),
+            ("1.0a1.post5+deadbeef", 5),
+            ("1.0a1.post5.dev6+deadbeef", 5),
+            ("1.0rc4+deadbeef", None),
+            ("1.0.post5+deadbeef", 5),
+            ("1!1.0+deadbeef", None),
+            ("1!1.0.dev6+deadbeef", None),
+            ("1!1.0a1+deadbeef", None),
+            ("1!1.0a1.post5+deadbeef", 5),
+            ("1!1.0a1.post5.dev6+deadbeef", 5),
+            ("1!1.0rc4+deadbeef", None),
+            ("1!1.0.post5+deadbeef", 5),
+        ],
+    )
+    def test_version_post(self, version, post):
+        assert Version(version).post == post
+
+    @pytest.mark.parametrize(
+        ("version", "expected"),
+        [
+            ("1.0.dev1", False),
+            ("1.0", False),
+            ("1.0+foo", False),
+            ("1.0.post1.dev1", True),
+            ("1.0.post1", True),
+        ],
+    )
+    def test_version_is_postrelease(self, version, expected):
+        assert Version(version).is_postrelease is expected
+
+    @pytest.mark.parametrize(
+        ("left", "right", "op"),
+        # Below we'll generate every possible combination of VERSIONS that
+        # should be True for the given operator
+        itertools.chain(
+            *
+            # Verify that the less than (<) operator works correctly
+            [
+                [(x, y, operator.lt) for y in VERSIONS[i + 1 :]]
+                for i, x in enumerate(VERSIONS)
+            ]
+            +
+            # Verify that the less than equal (<=) operator works correctly
+            [
+                [(x, y, operator.le) for y in VERSIONS[i:]]
+                for i, x in enumerate(VERSIONS)
+            ]
+            +
+            # Verify that the equal (==) operator works correctly
+            [[(x, x, operator.eq) for x in VERSIONS]]
+            +
+            # Verify that the not equal (!=) operator works correctly
+            [
+                [(x, y, operator.ne) for j, y in enumerate(VERSIONS) if i != j]
+                for i, x in enumerate(VERSIONS)
+            ]
+            +
+            # Verify that the greater than equal (>=) operator works correctly
+            [
+                [(x, y, operator.ge) for y in VERSIONS[: i + 1]]
+                for i, x in enumerate(VERSIONS)
+            ]
+            +
+            # Verify that the greater than (>) operator works correctly
+            [
+                [(x, y, operator.gt) for y in VERSIONS[:i]]
+                for i, x in enumerate(VERSIONS)
+            ]
+        ),
+    )
+    def test_comparison_true(self, left, right, op):
+        assert op(Version(left), Version(right))
+
+    @pytest.mark.parametrize(
+        ("left", "right", "op"),
+        # Below we'll generate every possible combination of VERSIONS that
+        # should be False for the given operator
+        itertools.chain(
+            *
+            # Verify that the less than (<) operator works correctly
+            [
+                [(x, y, operator.lt) for y in VERSIONS[: i + 1]]
+                for i, x in enumerate(VERSIONS)
+            ]
+            +
+            # Verify that the less than equal (<=) operator works correctly
+            [
+                [(x, y, operator.le) for y in VERSIONS[:i]]
+                for i, x in enumerate(VERSIONS)
+            ]
+            +
+            # Verify that the equal (==) operator works correctly
+            [
+                [(x, y, operator.eq) for j, y in enumerate(VERSIONS) if i != j]
+                for i, x in enumerate(VERSIONS)
+            ]
+            +
+            # Verify that the not equal (!=) operator works correctly
+            [[(x, x, operator.ne) for x in VERSIONS]]
+            +
+            # Verify that the greater than equal (>=) operator works correctly
+            [
+                [(x, y, operator.ge) for y in VERSIONS[i + 1 :]]
+                for i, x in enumerate(VERSIONS)
+            ]
+            +
+            # Verify that the greater than (>) operator works correctly
+            [
+                [(x, y, operator.gt) for y in VERSIONS[i:]]
+                for i, x in enumerate(VERSIONS)
+            ]
+        ),
+    )
+    def test_comparison_false(self, left, right, op):
+        assert not op(Version(left), Version(right))
+
+    @pytest.mark.parametrize("op", ["lt", "le", "eq", "ge", "gt", "ne"])
+    def test_dunder_op_returns_notimplemented(self, op):
+        method = getattr(Version, f"__{op}__")
+        assert method(Version("1"), 1) is NotImplemented
+
+    @pytest.mark.parametrize(("op", "expected"), [("eq", False), ("ne", True)])
+    def test_compare_other(self, op, expected):
+        other = pretend.stub(**{f"__{op}__": lambda other: NotImplemented})
+
+        assert getattr(operator, op)(Version("1"), other) is expected
+
+    def test_major_version(self):
+        assert Version("2.1.0").major == 2
+
+    def test_minor_version(self):
+        assert Version("2.1.0").minor == 1
+        assert Version("2").minor == 0
+
+    def test_micro_version(self):
+        assert Version("2.1.3").micro == 3
+        assert Version("2.1").micro == 0
+        assert Version("2").micro == 0

--- a/src/tools/Package-Core.py
+++ b/src/tools/Package-Core.py
@@ -33,6 +33,7 @@ VERY_FIRST_IMPORTS = [
     'from abc import ABCMeta, abstractmethod\n',
     'from datetime import timedelta\n',
     'from external_dependencies import distro\n',
+    'from external_dependencies import version as packaging_version\n'
     'try:\n import urllib2 as urlreq   #Python 2.x \nexcept:\n import urllib.request as urlreq   #Python 3.x\n']
 GLOBAL_IMPORTS = set()
 


### PR DESCRIPTION
Distutils.version is unsupported from python 3.11+. There is not direct version compare for the same. As per suggestion in this thread (https://peps.python.org/pep-0632/#migration-advice), we have taken the version.py (and its dependencies) from packaging module. 

Verified this to be working in ubuntu 18.04 where it will be used.

