### PR TITLE
Hotfix changes for strict SDP having some updates show up as 'new' packages

### DIFF
--- a/src/core/src/package_managers/AptitudePackageManager.py
+++ b/src/core/src/package_managers/AptitudePackageManager.py
@@ -54,7 +54,7 @@ class AptitudePackageManager(PackageManager):
         # Install update
         # --only-upgrade: upgrade only single package (only if it is installed)
         self.single_package_upgrade_cmd = '''sudo DEBIAN_FRONTEND=noninteractive LANG=en_US.UTF8 ''' + optional_accept_eula_in_cmd + ''' apt-get -y --only-upgrade true install '''
-        self.install_security_updates_azgps_coordinated_cmd = '''sudo DEBIAN_FRONTEND=noninteractive LANG=en_US.UTF8 ''' + optional_accept_eula_in_cmd + ''' apt-get -y --only-upgrade true upgrade <SOURCES> '''
+        self.install_security_updates_azgps_coordinated_cmd = '''sudo DEBIAN_FRONTEND=noninteractive LANG=en_US.UTF8 ''' + optional_accept_eula_in_cmd + ''' apt-get -y --only-upgrade true dist-upgrade <SOURCES> '''
 
         # Package manager exit code(s)
         self.apt_exitcode_ok = 0


### PR DESCRIPTION
This is to address an issue with 'new' packages getting kept back by the package manager.

_"The following packages have been kept back:
 auoms azsec-monitor linux-azure linux-cloud-tools-azure linux-headers-azure
 linux-image-azure linux-tools-azure
 0 upgraded, 0 newly installed, 0 to remove and 7 not upgraded."_

The change in the PR is needed to capture some of the additional updates.