### PR TITLE
Refreshing cache with machine source prior to ending execution

### DIFF
--- a/src/core/src/CoreMain.py
+++ b/src/core/src/CoreMain.py
@@ -29,6 +29,7 @@ class CoreMain(object):
         stdout_file_mirror = bootstrapper.stdout_file_mirror
         telemetry_writer = bootstrapper.telemetry_writer
         lifecycle_manager = status_handler = execution_config = None
+        package_manager = None
 
         # Init operation statuses
         patch_operation_requested = Constants.UNKNOWN
@@ -101,7 +102,6 @@ class CoreMain(object):
                     patch_installer.mark_installation_completed()
                     overall_patch_installation_operation_successful = True
                 self.update_patch_substatus_if_pending(patch_operation_requested, overall_patch_installation_operation_successful, patch_assessment_successful, configure_patching_successful, status_handler, composite_logger)
-                package_manager.refresh_repo()
         except Exception as error:
             # Privileged operation handling for non-production use
             if Constants.EnvLayer.PRIVILEGED_OP_MARKER in repr(error):
@@ -133,6 +133,9 @@ class CoreMain(object):
         finally:
             if status_handler is not None:
                 status_handler.log_truncated_patches()
+
+            if package_manager is not None:
+                package_manager.refresh_repo_safely()
 
             # clean up temp folder of files created by Core after execution completes
             if self.is_temp_folder_available(bootstrapper.env_layer, execution_config):

--- a/src/core/src/CoreMain.py
+++ b/src/core/src/CoreMain.py
@@ -101,7 +101,7 @@ class CoreMain(object):
                     patch_installer.mark_installation_completed()
                     overall_patch_installation_operation_successful = True
                 self.update_patch_substatus_if_pending(patch_operation_requested, overall_patch_installation_operation_successful, patch_assessment_successful, configure_patching_successful, status_handler, composite_logger)
-
+                package_manager.refresh_repo()
         except Exception as error:
             # Privileged operation handling for non-production use
             if Constants.EnvLayer.PRIVILEGED_OP_MARKER in repr(error):

--- a/src/core/src/package_managers/PackageManager.py
+++ b/src/core/src/package_managers/PackageManager.py
@@ -66,7 +66,7 @@ class PackageManager(object):
         try:
             self.refresh_repo()
         except Exception as error:
-            self.composite_logger.log_error("Error in refreshing cache from machine sources. [Error={0}]".format(repr(error)))
+            self.composite_logger.log_debug("Error in refreshing cache from machine sources. [Error={0}]".format(repr(error)))
 
     # region Get Available Updates
     @abstractmethod

--- a/src/core/src/package_managers/PackageManager.py
+++ b/src/core/src/package_managers/PackageManager.py
@@ -61,6 +61,13 @@ class PackageManager(object):
         """Resynchronize the package index files from their sources."""
         pass
 
+    def refresh_repo_safely(self):
+        """Resynchronize the package index files from machine sources."""
+        try:
+            self.refresh_repo()
+        except Exception as error:
+            self.composite_logger.log_error("Error in refreshing cache from machine sources. [Error={0}]".format(repr(error)))
+
     # region Get Available Updates
     @abstractmethod
     def invoke_package_manager_advanced(self, command, raise_on_exception=True):

--- a/src/core/src/package_managers/ZypperPackageManager.py
+++ b/src/core/src/package_managers/ZypperPackageManager.py
@@ -100,7 +100,7 @@ class ZypperPackageManager(PackageManager):
                 self.composite_logger.log_warning("Unable to refresh repo (retries exhausted after reboot).")
                 raise
             else:
-                self.composite_logger.log_warning("Setting force_reboot flag to True.")
+                self.composite_logger.log_debug("Setting force_reboot flag to True.")
                 self.force_reboot = True
 
     def __refresh_repo_services(self):

--- a/src/core/tests/Test_CoreMain.py
+++ b/src/core/tests/Test_CoreMain.py
@@ -291,7 +291,7 @@ class TestCoreMain(unittest.TestCase):
         self.assertEqual(len(substatus_file_data), 2)
         self.assertTrue(substatus_file_data[0]["name"] == Constants.PATCH_ASSESSMENT_SUMMARY)
         self.assertTrue(substatus_file_data[0]["status"].lower() == Constants.STATUS_ERROR.lower())
-        self.assertEqual(len(json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"]), 2)
+        self.assertEqual(len(json.loads(substatus_file_data[0]["formattedMessage"]["message"])["errors"]["details"]), 3)
         self.assertTrue(substatus_file_data[1]["name"] == Constants.CONFIGURE_PATCHING_SUMMARY)
         self.assertTrue(substatus_file_data[1]["status"].lower() == Constants.STATUS_SUCCESS.lower())
         runtime.stop()


### PR DESCRIPTION
Refreshes cache with machine source before ending execution, since we have set private sources list in our code in places. Reverting to machine default to ensure default machine experience for customers