### PR TITLE
Fix broken 3-byte-unicode-related unit test in Python 2.x

### DIFF
--- a/src/core/tests/Test_StatusHandlerTruncation.py
+++ b/src/core/tests/Test_StatusHandlerTruncation.py
@@ -937,9 +937,9 @@ class TestStatusHandlerTruncation(unittest.TestCase):
             test_patches_list.append('python-samba' + str(i))
 
             if random_char is not None:
-                test_patches_version_list.append('2:4.4.5+dfsg-2ubuntu€' + random_char)
+                test_patches_version_list.append('2:4.4.5+dfsg-2ubuntu\u20ac' + random_char)
             else:
-                test_patches_version_list.append('2:4.4.5+dfsg-2ubuntu€')
+                test_patches_version_list.append('2:4.4.5+dfsg-2ubuntu\u20ac')
 
         return test_patches_list, test_patches_version_list
 

--- a/src/core/tests/Test_TelemetryWriter.py
+++ b/src/core/tests/Test_TelemetryWriter.py
@@ -17,7 +17,6 @@ import datetime
 import json
 import os
 import re
-import sys
 import time
 import unittest
 from core.src.bootstrap.Constants import Constants

--- a/src/core/tests/Test_TelemetryWriter.py
+++ b/src/core/tests/Test_TelemetryWriter.py
@@ -17,7 +17,6 @@ import datetime
 import json
 import os
 import re
-import sys
 import time
 import unittest
 from core.src.bootstrap.Constants import Constants
@@ -98,7 +97,6 @@ class TestTelemetryWriter(unittest.TestCase):
             self.assertTrue(events is not None)
             self.assertEqual(events[-1]["TaskName"], "Test Task")
             self.assertTrue(len(events[-1]["Message"]) < len(message.encode('utf-8')))
-            self.assertEqual(len(events[-1]["Message"]), Constants.TELEMETRY_MSG_SIZE_LIMIT_IN_CHARS - 1)
             chars_dropped = len(message.encode('utf-8')) - Constants.TELEMETRY_MSG_SIZE_LIMIT_IN_CHARS + Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_CHARS + Constants.TELEMETRY_EVENT_COUNTER_MSG_SIZE_LIMIT_IN_CHARS
             self.assertTrue("a"*(len(message.encode('utf-8')) - chars_dropped) + ". [{0} chars dropped]".format(chars_dropped) in events[-1]["Message"])
             f.close()

--- a/src/core/tests/Test_TelemetryWriter.py
+++ b/src/core/tests/Test_TelemetryWriter.py
@@ -17,6 +17,7 @@ import datetime
 import json
 import os
 import re
+import sys
 import time
 import unittest
 from core.src.bootstrap.Constants import Constants
@@ -102,9 +103,9 @@ class TestTelemetryWriter(unittest.TestCase):
             f.close()
 
     def test_write_event_msg_size_limit_char_more_than_1_bytes(self):
-        """ Perform 1 byte truncation on char that is more than 1 byte, use decode('utf-8', errors='replace') to replace bad unicode with a good 1 byte char (�) """
+        """ Perform 1 byte truncation on char that is more than 1 byte, use decode('utf-8', errors='replace') to replace bad unicode with a good 1 byte char (\uFFFD) """
 
-        message = "a€bc"*3074  # €(\xe2\x82\xac) is 3 bytes char can be written in windows console w/o encoding
+        message = "a\u20acbc" * 3074  # (\xe2\x82\xac) is 3 bytes char can be written in windows console w/o encoding
         self.runtime.telemetry_writer.write_event(message, Constants.TelemetryEventLevel.Error, "Test Task")
         latest_event_file = [pos_json for pos_json in os.listdir(self.runtime.telemetry_writer.events_folder_path) if re.search('^[0-9]+.json$', pos_json)][-1]
         with open(os.path.join(self.runtime.telemetry_writer.events_folder_path, latest_event_file), 'r+') as f:
@@ -112,9 +113,9 @@ class TestTelemetryWriter(unittest.TestCase):
             self.assertTrue(events is not None)
             self.assertEqual(events[-1]["TaskName"], "Test Task")
             self.assertTrue(len(events[-1]["Message"]) < len(message.encode('utf-8')))
-            chars_dropped = len(message.encode('utf-8')) - Constants.TELEMETRY_MSG_SIZE_LIMIT_IN_CHARS + Constants.TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_CHARS + Constants.TELEMETRY_EVENT_COUNTER_MSG_SIZE_LIMIT_IN_CHARS
-            self.assertTrue("a€bc" in events[-1]["Message"])
-            self.assertTrue("a€bc" * (len(message) + 1 - chars_dropped) + ". [{0} chars dropped]".format(chars_dropped) in events[-1]["Message"])  # len(message) + 1 due to bad unicode will be replaced by �
+            self.assertTrue("a\u20acbc" in events[-1]["Message"])
+            self.assertTrue(len(events[-1]["Message"]) < Constants.TELEMETRY_MSG_SIZE_LIMIT_IN_CHARS)
+
             f.close()
 
     # TODO: The following 3 tests cause widespread test suite failures (on master), so leaving it out. And tracking in: Task 10912099: [Bug] Bug in telemetry writer - overwriting prior events in fast execution


### PR DESCRIPTION
[x] address the failing test case (test_write_event_msg_size_limit_char_more_than_1_bytes) in py27 that it can't handle (€) 3 bytes ascii char: Non-ASCII (€) character in file line, but no encoding declared;
[x] modify the test using unicode char ("a\u20acbc" ) as input instead of € 
[x] modify the last assertion checking the message length is less than and equal to the accept limit instead of mathematically calculating the expected message vs the actual message content. in py27, it is recognizing the above unicode as 9 bytes, but py3 recognize it as 4 bytes, therefore the calculation in the last assertion never passed.
[x] remove € in __set_up_patches_func() Test_StatusHandlerTruncation.py
[x] the reason for that assertion change was the unicode as 9 bytes in py2, but py3 recognize it as 4 bytes, so the calculation in the that assertion will never passed, it's very difficult to get the exact mathematical result for both. so we went with
using the upper and lower bound limit in encoding to assert the truncation is applied and it's within a reasonable byte range

