### PR TITLE
Bugfix/disable rhel8+ security plugin

### DIFF
--- a/src/core/src/package_managers/YumPackageManager.py
+++ b/src/core/src/package_managers/YumPackageManager.py
@@ -142,11 +142,11 @@ class YumPackageManager(PackageManager):
 
     def get_security_updates(self):
         """Get missing security updates"""
-        if self.__is_image_rhel8_higher_skip_security_plugin():
-            return [], []
-
         self.composite_logger.log("\nDiscovering 'security' packages...")
-        self.install_yum_security_prerequisite()
+
+        if not self.__is_image_rhel8_higher():
+            self.install_yum_security_prerequisite()
+
         out = self.invoke_package_manager(self.yum_check_security)
         security_packages, security_package_versions = self.extract_packages_and_versions(out)
 
@@ -179,10 +179,10 @@ class YumPackageManager(PackageManager):
         self.composite_logger.log("Discovered " + str(len(other_packages)) + " 'other' package entries.")
         return other_packages, other_package_versions
 
-    def __is_image_rhel8_higher_skip_security_plugin(self):
-        """Check image RHEL8+ to disable install yum-plugin-security """
+    def __is_image_rhel8_higher(self):
+        """ Check if image is RHEL8+ set true else false """
         if self.env_layer.platform.linux_distribution() is not None:
-            os_offer, os_version, os_code = self.env_layer.platform.linux_distribution();
+            os_offer, os_version, os_code = self.env_layer.platform.linux_distribution()
 
             if "Red Hat Enterprise Linux" in os_offer and int(os_version.split('.')[0]) >= 8:
                 self.composite_logger.log_debug("Disable RHEL8+ install yum-plugin-security: Os Version " + str(os_version))

--- a/src/core/src/package_managers/YumPackageManager.py
+++ b/src/core/src/package_managers/YumPackageManager.py
@@ -142,7 +142,7 @@ class YumPackageManager(PackageManager):
 
     def get_security_updates(self):
         """Get missing security updates"""
-        if self.__is_image_rhel8_higher_for_security_plugin():
+        if self.__is_image_rhel8_higher_skip_security_plugin():
             return [], []
 
         self.composite_logger.log("\nDiscovering 'security' packages...")
@@ -180,16 +180,13 @@ class YumPackageManager(PackageManager):
         self.composite_logger.log("Discovered " + str(len(other_packages)) + " 'other' package entries.")
         return other_packages, other_package_versions
 
-    def __is_image_rhel8_higher_for_security_plugin(self):
-
+    def __is_image_rhel8_higher_skip_security_plugin(self):
+        """Check image RHEL8+ to disable yum-plugin-security """
         if self.env_layer.platform.linux_distribution() is not None:
             os_offer, os_version, os_code = self.env_layer.platform.linux_distribution();
-            print('what is ', os_offer)
-            print('what is os_version', os_version)
-            print('what is os_code', os_code)
 
             if "Red Hat Enterprise Linux" in os_offer and int(os_version.split('.')[0]) >= 8:
-                print('did this get called Linux')
+                self.composite_logger.log_debug("Disable RHEL8+ yum-plugin-security: Os Version " + str(os_version))
                 return True
 
         return False

--- a/src/core/src/package_managers/YumPackageManager.py
+++ b/src/core/src/package_managers/YumPackageManager.py
@@ -144,7 +144,7 @@ class YumPackageManager(PackageManager):
         """Get missing security updates"""
         self.composite_logger.log("\nDiscovering 'security' packages...")
 
-        if not self.__is_image_rhel8_higher():
+        if not self.__is_image_rhel8_or_higher():
             self.install_yum_security_prerequisite()
 
         out = self.invoke_package_manager(self.yum_check_security)
@@ -179,8 +179,8 @@ class YumPackageManager(PackageManager):
         self.composite_logger.log("Discovered " + str(len(other_packages)) + " 'other' package entries.")
         return other_packages, other_package_versions
 
-    def __is_image_rhel8_higher(self):
-        """ Check if image is RHEL8+ set true else false """
+    def __is_image_rhel8_or_higher(self):
+        """ Check if image is RHEL8+ return true else false """
         if self.env_layer.platform.linux_distribution() is not None:
             os_offer, os_version, os_code = self.env_layer.platform.linux_distribution()
 

--- a/src/core/src/package_managers/YumPackageManager.py
+++ b/src/core/src/package_managers/YumPackageManager.py
@@ -142,6 +142,9 @@ class YumPackageManager(PackageManager):
 
     def get_security_updates(self):
         """Get missing security updates"""
+        if self.__is_image_rhel8_higher_for_security_plugin():
+            return [], []
+
         self.composite_logger.log("\nDiscovering 'security' packages...")
         self.install_yum_security_prerequisite()
         out = self.invoke_package_manager(self.yum_check_security)
@@ -160,6 +163,7 @@ class YumPackageManager(PackageManager):
         other_package_versions = []
 
         all_packages, all_package_versions = self.get_all_updates(True)
+
         security_packages, security_package_versions = self.get_security_updates()
         if len(security_packages) == 0 and 'CentOS' in str(self.env_layer.platform.linux_distribution()):  # deliberately terminal - erring on the side of caution to avoid dissat in uninformed customers
             self.composite_logger.log_error("Please review patch management documentation for information on classification-based patching on YUM.")
@@ -175,6 +179,20 @@ class YumPackageManager(PackageManager):
 
         self.composite_logger.log("Discovered " + str(len(other_packages)) + " 'other' package entries.")
         return other_packages, other_package_versions
+
+    def __is_image_rhel8_higher_for_security_plugin(self):
+
+        if self.env_layer.platform.linux_distribution() is not None:
+            os_offer, os_version, os_code = self.env_layer.platform.linux_distribution();
+            print('what is ', os_offer)
+            print('what is os_version', os_version)
+            print('what is os_code', os_code)
+
+            if "Red Hat Enterprise Linux" in os_offer and int(os_version.split('.')[0]) >= 8:
+                print('did this get called Linux')
+                return True
+
+        return False
 
     def set_max_patch_publish_date(self, max_patch_publish_date=str()):
         pass

--- a/src/core/src/package_managers/YumPackageManager.py
+++ b/src/core/src/package_managers/YumPackageManager.py
@@ -185,7 +185,7 @@ class YumPackageManager(PackageManager):
             os_offer, os_version, os_code = self.env_layer.platform.linux_distribution()
 
             if "Red Hat Enterprise Linux" in os_offer and int(os_version.split('.')[0]) >= 8:
-                self.composite_logger.log_debug("Disable RHEL8+ install yum-plugin-security: Os Version " + str(os_version))
+                self.composite_logger.log_debug("Verify RHEL image version: " + str(os_version))
                 return True
 
         return False

--- a/src/core/src/package_managers/YumPackageManager.py
+++ b/src/core/src/package_managers/YumPackageManager.py
@@ -163,7 +163,6 @@ class YumPackageManager(PackageManager):
         other_package_versions = []
 
         all_packages, all_package_versions = self.get_all_updates(True)
-
         security_packages, security_package_versions = self.get_security_updates()
         if len(security_packages) == 0 and 'CentOS' in str(self.env_layer.platform.linux_distribution()):  # deliberately terminal - erring on the side of caution to avoid dissat in uninformed customers
             self.composite_logger.log_error("Please review patch management documentation for information on classification-based patching on YUM.")
@@ -181,12 +180,12 @@ class YumPackageManager(PackageManager):
         return other_packages, other_package_versions
 
     def __is_image_rhel8_higher_skip_security_plugin(self):
-        """Check image RHEL8+ to disable yum-plugin-security """
+        """Check image RHEL8+ to disable install yum-plugin-security """
         if self.env_layer.platform.linux_distribution() is not None:
             os_offer, os_version, os_code = self.env_layer.platform.linux_distribution();
 
             if "Red Hat Enterprise Linux" in os_offer and int(os_version.split('.')[0]) >= 8:
-                self.composite_logger.log_debug("Disable RHEL8+ yum-plugin-security: Os Version " + str(os_version))
+                self.composite_logger.log_debug("Disable RHEL8+ install yum-plugin-security: Os Version " + str(os_version))
                 return True
 
         return False

--- a/src/core/tests/Test_YumPackageManager.py
+++ b/src/core/tests/Test_YumPackageManager.py
@@ -626,7 +626,7 @@ class TestYumPackageManager(unittest.TestCase):
         self.assertTrue(available_updates[0] == "grub2-tools.x86_64")
         self.assertTrue(package_versions[0] == "1:2.02-142.el8")
 
-    def test_rhel8_image_lower_with_security_plugin(self):
+    def test_rhel7_image_with_security_plugin(self):
         """Unit test for yum package manager rhel images below 8 and Classification = Security"""
         # mock linux_distribution
         backup_envlayer_platform_linux_distribution = LegacyEnvLayerExtensions.LegacyPlatform.linux_distribution

--- a/src/core/tests/Test_YumPackageManager.py
+++ b/src/core/tests/Test_YumPackageManager.py
@@ -347,7 +347,6 @@ class TestYumPackageManager(unittest.TestCase):
 
         # test for get_available_updates
         available_updates, package_versions = package_manager.get_available_updates(package_filter)
-        print('available updates', package_versions)
         self.assertIsNotNone(available_updates)
         self.assertIsNotNone(package_versions)
         self.assertEqual(len(available_updates), 4)
@@ -684,8 +683,6 @@ class TestYumPackageManager(unittest.TestCase):
         self.assertIsNotNone(package_filter)
 
         return package_manager.get_available_updates(package_filter)
-
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/core/tests/Test_YumPackageManager.py
+++ b/src/core/tests/Test_YumPackageManager.py
@@ -18,6 +18,7 @@ import os
 import unittest
 from core.src.bootstrap.Constants import Constants
 from core.tests.library.ArgumentComposer import ArgumentComposer
+from core.tests.library.LegacyEnvLayerExtensions import LegacyEnvLayerExtensions
 from core.tests.library.RuntimeCompositor import RuntimeCompositor
 
 
@@ -35,6 +36,12 @@ class TestYumPackageManager(unittest.TestCase):
 
     def mock_write_with_retry_raise_exception(self, file_path_or_handle, data, mode='a+'):
         raise Exception
+
+    def mock_linux7_distribution_to_return_redhat(self):
+        return ['Red Hat Enterprise Linux Server', '7', 'Maipo']
+
+    def mock_linux8_distribution_to_return_redhat(self):
+        return ['Red Hat Enterprise Linux Server', '8', 'Ootpa']
     #endregion Mocks
 
     def mock_do_processes_require_restart_raise_exception(self):
@@ -340,6 +347,7 @@ class TestYumPackageManager(unittest.TestCase):
 
         # test for get_available_updates
         available_updates, package_versions = package_manager.get_available_updates(package_filter)
+        print('available updates', package_versions)
         self.assertIsNotNone(available_updates)
         self.assertIsNotNone(package_versions)
         self.assertEqual(len(available_updates), 4)
@@ -618,6 +626,66 @@ class TestYumPackageManager(unittest.TestCase):
         self.assertEqual(len(package_versions), 1)
         self.assertTrue(available_updates[0] == "grub2-tools.x86_64")
         self.assertTrue(package_versions[0] == "1:2.02-142.el8")
+
+    def test_rhel8_image_lower_with_security_plugin(self):
+        """Unit test for yum package manager rhel images below 8 and Classification = Security"""
+        # mock linux_distribution
+        backup_envlayer_platform_linux_distribution = LegacyEnvLayerExtensions.LegacyPlatform.linux_distribution
+        LegacyEnvLayerExtensions.LegacyPlatform.linux_distribution = self.mock_linux7_distribution_to_return_redhat
+
+        available_updates, package_versions = self.__set_up_happy_path_method()
+
+        # test for get_available_updates
+        self.assertIsNotNone(available_updates)
+        self.assertIsNotNone(package_versions)
+        self.assertEqual(len(available_updates), 2)
+        self.assertEqual(len(package_versions), 2)
+        self.assertEqual(available_updates[0], "libgcc.i686")
+        self.assertEqual(package_versions[0], "4.8.5-28.el7")
+        self.assertEqual(available_updates[1], "tcpdump.x86_64")
+        self.assertEqual(package_versions[1], "14:4.9.2-3.el7")
+
+        # restore linux_distribution
+        LegacyEnvLayerExtensions.LegacyPlatform.linux_distribution = backup_envlayer_platform_linux_distribution
+
+    def test_rhel8_image_higher_no_security_plugin(self):
+        """Unit test for yum package manager rhel images >= 8 and Classification = Security, no security packages"""
+        # mock linux_distribution
+        backup_envlayer_platform_linux_distribution = LegacyEnvLayerExtensions.LegacyPlatform.linux_distribution
+        LegacyEnvLayerExtensions.LegacyPlatform.linux_distribution = self.mock_linux8_distribution_to_return_redhat
+
+        available_updates, package_versions = self.__set_up_happy_path_method()
+
+        # test for get_available_updates
+        self.assertIsNotNone(available_updates)
+        self.assertIsNotNone(package_versions)
+        self.assertEqual(len(available_updates), 1)
+        self.assertEqual(len(package_versions), 1)
+        self.assertEqual(available_updates[0], "tcpdump.x86_64")
+        self.assertEqual(package_versions[0], "14:4.9.2-3.el7")
+
+        # restore linux_distribution
+        LegacyEnvLayerExtensions.LegacyPlatform.linux_distribution = backup_envlayer_platform_linux_distribution
+
+    def __set_up_happy_path_method(self):
+        self.runtime.set_legacy_test_type('HappyPath')
+        package_manager = self.container.get('package_manager')
+        self.assertIsNotNone(package_manager)
+        self.runtime.stop()
+
+        argument_composer = ArgumentComposer()
+        argument_composer.classifications_to_include = [Constants.PackageClassification.SECURITY]
+        argument_composer.patches_to_include = ["ssh", "tcpdump"]
+        argument_composer.patches_to_exclude = ["ssh*", "test"]
+        self.runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.YUM)
+        self.container = self.runtime.container
+
+        package_filter = self.container.get('package_filter')
+        self.assertIsNotNone(package_filter)
+
+        return package_manager.get_available_updates(package_filter)
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/core/tests/Test_YumPackageManager.py
+++ b/src/core/tests/Test_YumPackageManager.py
@@ -632,41 +632,23 @@ class TestYumPackageManager(unittest.TestCase):
         backup_envlayer_platform_linux_distribution = LegacyEnvLayerExtensions.LegacyPlatform.linux_distribution
         LegacyEnvLayerExtensions.LegacyPlatform.linux_distribution = self.mock_linux7_distribution_to_return_redhat
 
-        available_updates, package_versions = self.__set_up_happy_path_method()
-
-        # test for get_available_updates
-        self.assertIsNotNone(available_updates)
-        self.assertIsNotNone(package_versions)
-        self.assertEqual(len(available_updates), 2)
-        self.assertEqual(len(package_versions), 2)
-        self.assertEqual(available_updates[0], "libgcc.i686")
-        self.assertEqual(package_versions[0], "4.8.5-28.el7")
-        self.assertEqual(available_updates[1], "tcpdump.x86_64")
-        self.assertEqual(package_versions[1], "14:4.9.2-3.el7")
+        self.__assert_test_rhel8_image()
 
         # restore linux_distribution
         LegacyEnvLayerExtensions.LegacyPlatform.linux_distribution = backup_envlayer_platform_linux_distribution
 
     def test_rhel8_image_higher_no_security_plugin(self):
-        """Unit test for yum package manager rhel images >= 8 and Classification = Security, no security packages"""
+        """Unit test for yum package manager rhel images >= 8 and Classification = Security"""
         # mock linux_distribution
         backup_envlayer_platform_linux_distribution = LegacyEnvLayerExtensions.LegacyPlatform.linux_distribution
         LegacyEnvLayerExtensions.LegacyPlatform.linux_distribution = self.mock_linux8_distribution_to_return_redhat
 
-        available_updates, package_versions = self.__set_up_happy_path_method()
-
-        # test for get_available_updates
-        self.assertIsNotNone(available_updates)
-        self.assertIsNotNone(package_versions)
-        self.assertEqual(len(available_updates), 1)
-        self.assertEqual(len(package_versions), 1)
-        self.assertEqual(available_updates[0], "tcpdump.x86_64")
-        self.assertEqual(package_versions[0], "14:4.9.2-3.el7")
+        self.__assert_test_rhel8_image()
 
         # restore linux_distribution
         LegacyEnvLayerExtensions.LegacyPlatform.linux_distribution = backup_envlayer_platform_linux_distribution
 
-    def __set_up_happy_path_method(self):
+    def __assert_test_rhel8_image(self):
         self.runtime.set_legacy_test_type('HappyPath')
         package_manager = self.container.get('package_manager')
         self.assertIsNotNone(package_manager)
@@ -682,7 +664,17 @@ class TestYumPackageManager(unittest.TestCase):
         package_filter = self.container.get('package_filter')
         self.assertIsNotNone(package_filter)
 
-        return package_manager.get_available_updates(package_filter)
+        available_updates, package_versions = package_manager.get_available_updates(package_filter)
+
+        # test for get_available_updates
+        self.assertIsNotNone(available_updates)
+        self.assertIsNotNone(package_versions)
+        self.assertEqual(len(available_updates), 2)
+        self.assertEqual(len(package_versions), 2)
+        self.assertEqual(available_updates[0], "libgcc.i686")
+        self.assertEqual(package_versions[0], "4.8.5-28.el7")
+        self.assertEqual(available_updates[1], "tcpdump.x86_64")
+        self.assertEqual(package_versions[1], "14:4.9.2-3.el7")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
[x] per BUG item 28214906 - disable yum install security plugin on rhel8+ images
test result:
rhel810 images
![image](https://github.com/user-attachments/assets/8268e745-0202-48ff-82c5-3352259693e8)
prior code change assessment call:
![image](https://github.com/user-attachments/assets/4345fda4-520a-490b-9314-f3653304aa50)
post code change assessment call;
![image](https://github.com/user-attachments/assets/95917fda-ef26-4fb4-9a15-f97e104d4635)
post code change installation call:
![image](https://github.com/user-attachments/assets/c7ecdae9-1c31-42f0-9c43-e77c4ec9d40c)
![image](https://github.com/user-attachments/assets/4ccb3caf-00a6-4016-8736-fcecb0d32bbd)


