### PR TITLE
Expanding support for yum install --assumeno cmd to include yum4

### DIFF
--- a/src/core/src/package_managers/YumPackageManager.py
+++ b/src/core/src/package_managers/YumPackageManager.py
@@ -309,7 +309,7 @@ class YumPackageManager(PackageManager):
         return False
 
     def extract_dependencies(self, output, packages):
-        # Sample output for the cmd 'sudo yum update --assumeno selinux-policy.noarch' is :
+        # In Yum 3: Sample output for the cmd 'sudo yum update --assumeno selinux-policy.noarch' is :
         #
         # Loaded plugins: langpacks, product-id, search-disabled-repos
         # Resolving Dependencies
@@ -325,25 +325,125 @@ class YumPackageManager(PackageManager):
         # ---> Package selinux-policy-targeted.noarch 0:3.13.1-102.el7_3.16 will be an update
         # --> Finished Dependency Resolution
 
+        # In Yum 4: Sample 1 (Upgrades are available, no installation required):
+        # Sample output for the cmd 'sudo yum update --assumeno selinux-policy.noarch' is :
+        #
+        # Last metadata expiration check: 0:08:56 ago on Tue 25 Jul 2023 02:14:28 PM UTC.
+        # Package selinux-policy-3.14.3-95.el8_6.6.noarch is already installed.
+        # Dependencies resolved.
+        # ==================================================================================================
+        # Package                   Arch    Version           Repository                               Size
+        # ==================================================================================================
+        # Upgrading:
+        # selinux-policy            noarch  3.14.3-95.el8_6.8 rhel-8-for-x86_64-baseos-eus-rhui-rpms  651 k
+        # selinux-policy-targeted   noarch  3.14.3-95.el8_6.8 rhel-8-for-x86_64-baseos-eus-rhui-rpms   15 M
+        #
+        # Transaction Summary
+        # ==================================================================================================
+        # Upgrade  2 Packages
+        #
+        # Total download size: 16 M
+        # Operation aborted..
+
+        # In Yum 4: Sample 2 (No upgrades available, installations required):
+        # Sample output for the cmd 'sudo yum update --assumeno kernel-modules.x86_64' is :
+        #
+        # Last metadata expiration check: 0:09:14 ago on Tue 25 Jul 2023 02:14:28 PM UTC.
+        # Package kernel-modules-4.18.0-372.9.1.el8.x86_64 is already installed.
+        # Package kernel-modules-4.18.0-372.52.1.el8_6.x86_64 is already installed.
+        # Dependencies resolved.
+        # =============================================================================================
+        # Package          Arch    Version               Repository                               Size
+        # =============================================================================================
+        # Installing dependencies:
+        # kernel-core      x86_64  4.18.0-372.64.1.el8_6 rhel-8-for-x86_64-baseos-eus-rhui-rpms   40 M
+        # kernel-modules   x86_64  4.18.0-372.64.1.el8_6 rhel-8-for-x86_64-baseos-eus-rhui-rpms   32 M
+        #
+        # Transaction Summary
+        # =============================================================================================
+        # Install  2 Packages
+        #
+        # Total download size: 72 M
+        # Installed size: 93 M
+        # Operation aborted.
+
+        # In Yum 4: Sample 3 (Both upgrades and installations required):
+        # Sample output for the cmd 'sudo yum update --assumeno kernel-modules.x86_64' is :
+        #
+        # Last metadata expiration check: 0:01:56 ago on Tue 25 Jul 2023 12:01:47 PM UTC.
+        # Dependencies resolved.
+        # ================================================================================================
+        # Package             Arch    Version               Repository                               Size
+        # ================================================================================================
+        # Upgrading:
+        # kernel-tools        x86_64  4.18.0-372.64.1.el8_6 rhel-8-for-x86_64-baseos-eus-rhui-rpms  8.4 M
+        # kernel-tools-libs   x86_64  4.18.0-372.64.1.el8_6 rhel-8-for-x86_64-baseos-eus-rhui-rpms  8.2 M
+        # openssl             x86_64  1:1.1.1k-9.el8_6      rhel-8-for-x86_64-baseos-eus-rhui-rpms  710 k
+        # openssl-libs        x86_64  1:1.1.1k-9.el8_6      rhel-8-for-x86_64-baseos-eus-rhui-rpms  1.5 M
+        # Installing dependencies:
+        # kernel-core         x86_64  4.18.0-372.64.1.el8_6 rhel-8-for-x86_64-baseos-eus-rhui-rpms   40 M
+        # kernel-modules      x86_64  4.18.0-372.64.1.el8_6 rhel-8-for-x86_64-baseos-eus-rhui-rpms   32 M
+        #
+        # Transaction Summary
+        # ================================================================================================
+        # Install  2 Packages
+        # Upgrade  4 Packages
+
+        # In Yum 4: Sample 4 (dependent patch detail split over 2 lines):
+        # Sample output for the cmd 'sudo yum update --assumeno polkit.x86_64' is :
+        #
+        # Last metadata expiration check: 0:08:47 ago on Tue 25 Jul 2023 02:14:28 PM UTC.
+        # Package polkit-0.115-13.el8_5.2.x86_64 is already installed.
+        # Dependencies resolved.
+        # ================================================================================
+        # Package   Arch   Version          Repository                              Size
+        # ================================================================================
+        # Upgrading:
+        # polkit    x86_64 0.115-14.el8_6.1 rhel-8-for-x86_64-baseos-eus-rhui-rpms 154 k
+        # polkit-libs
+        #           x86_64 0.115-14.el8_6.1 rhel-8-for-x86_64-baseos-eus-rhui-rpms  77 k
+        #
+        # Transaction Summary
+        # ================================================================================
+        # Upgrade  2 Packages
+        #
+        # Total download size: 231 k
+        # Operation aborted.
+
         dependencies = []
+        package_arch_to_look_for = ["x86_64", "noarch", "i686"]
+
         lines = output.strip().split('\n')
 
-        for line in lines:
-            if line.find(" will be updated") < 0 and line.find(" will be an update") < 0 and line.find(" will be installed") < 0:
+        for line_index in range(0, len(lines)):
+            line = re.split(r'\s+', (lines[line_index].replace("--->", "")).strip())
+            next_line = []
+            dependent_package_name = ""
+
+            if line_index < len(lines) - 1:
+                next_line = re.split(r'\s+', (lines[line_index + 1].replace("--->", "")).strip())
+
+            if self.is_valid_update(line, package_arch_to_look_for):
+                dependent_package_name = self.get_product_name_with_arch(line, package_arch_to_look_for)
+            elif self.is_valid_update(line+next_line, package_arch_to_look_for):
+                dependent_package_name = self.get_product_name_with_arch(line+next_line, package_arch_to_look_for)
+            else:
                 self.composite_logger.log_debug(" - Inapplicable line: " + str(line))
                 continue
 
-            updates_line = re.split(r'\s+', line.strip())
-            if len(updates_line) != 7:
-                self.composite_logger.log_debug(" - Inapplicable line: " + str(line))
-                continue
-
-            dependent_package_name = self.get_product_name(updates_line[2])
-            if len(dependent_package_name) != 0 and dependent_package_name not in packages:
+            if len(dependent_package_name) != 0 and dependent_package_name not in packages and dependent_package_name not in dependencies:
                 self.composite_logger.log_debug(" - Dependency detected: " + dependent_package_name)
                 dependencies.append(dependent_package_name)
 
         return dependencies
+
+    def is_valid_update(self, package_details_in_output, package_arch_to_look_for):
+        return len(package_details_in_output) == 6 and self.is_arch_in_package_details(package_details_in_output[1], package_arch_to_look_for)
+
+    @staticmethod
+    def is_arch_in_package_details(package_detail, package_arch_to_look_for):
+        # Using a list comprehension to determine if chunk is a package
+        return len([p for p in package_arch_to_look_for if p in package_detail]) == 1
 
     def get_dependent_list(self, packages):
         package_names = ""
@@ -379,6 +479,10 @@ class YumPackageManager(PackageManager):
         """Retrieve product architecture only"""
         product_name, arch = self.get_product_name_and_arch(package_name)
         return arch
+
+    def get_product_name_with_arch(self, package_detail, package_arch_to_look_for):
+        """Retrieve product name with arch separated by '.'. Note: This format is default in yum3. Refer samples noted within func extract_dependencies() for more clarity"""
+        return package_detail[0] + "." + package_detail[1] if package_detail[1] in package_arch_to_look_for else package_detail[1]
 
     def get_package_version_without_epoch(self, package_version):
         """Returns the package version stripped of any epoch"""

--- a/src/core/tests/Test_YumPackageManager.py
+++ b/src/core/tests/Test_YumPackageManager.py
@@ -676,5 +676,46 @@ class TestYumPackageManager(unittest.TestCase):
         self.assertEqual(available_updates[1], "tcpdump.x86_64")
         self.assertEqual(package_versions[1], "14:4.9.2-3.el7")
 
+    def test_get_dependent_list_yum_version_4(self):
+        # Creating new RuntimeCompositor with test_type YumVersion4Dependency because there are some command runs in constructor of YumPackageManager
+        # for which the sample output is in the test_type YumVersion4Dependency.
+        self.runtime.stop()  # First stopping the existing runtime
+        self.runtime = RuntimeCompositor(ArgumentComposer().get_composed_arguments(), True, Constants.YUM, test_type="YumVersion4Dependency")
+
+        self.container = self.runtime.container
+        package_manager = self.container.get('package_manager')
+        #self.assertEqual(package_manager.yum_version, 4)
+        dependent_list = package_manager.get_dependent_list(["iptables.x86_64"])
+        self.assertEqual(len(dependent_list), 2)
+        self.assertEqual(dependent_list[0], "iptables-ebtables.x86_64")
+        self.assertEqual(dependent_list[1], "iptables-libs.x86_64")
+
+    def test_get_dependent_list_yum_version_4_update_in_two_lines(self):
+        # Creating new RuntimeCompositor with test_type YumVersion4Dependency because there are some command runs in constructor of YumPackageManager
+        # for which the sample output is in the test_type YumVersion4Dependency.
+        self.runtime.stop()  # First stopping the existing runtime
+        self.runtime = RuntimeCompositor(ArgumentComposer().get_composed_arguments(), True, Constants.YUM, test_type="YumVersion4DependencyInTwoLines")
+
+        self.container = self.runtime.container
+        package_manager = self.container.get('package_manager')
+        dependent_list = package_manager.get_dependent_list(["polkit.x86_64"])
+        self.assertEqual(len(dependent_list), 1)
+        self.assertEqual(dependent_list[0], "polkit-libs.x86_64")
+
+    def test_get_dependent_list_yum_version_4_update_in_two_lines_with_unexpected_output(self):
+        # This test is for adding code coverage for code handling unexpected output in the command for get dependencies.
+        # There are two packages in the output and for the second package i.e. polkit-libs, the package name is not present. Only other package details are present.
+        # So, there are 0 dependencies expected.
+
+        # Creating new RuntimeCompositor with test_type YumVersion4Dependency because there are some command runs in constructor of YumPackageManager
+        # for which the sample output is in the test_type YumVersion4Dependency.
+        self.runtime.stop()  # First stopping the existing runtime
+        self.runtime = RuntimeCompositor(ArgumentComposer().get_composed_arguments(), True, Constants.YUM, test_type="YumVersion4DependencyInTwoLinesWithUnexpectedOutput")
+
+        self.container = self.runtime.container
+        package_manager = self.container.get('package_manager')
+        dependent_list = package_manager.get_dependent_list(["polkit.x86_64"])
+        self.assertEqual(len(dependent_list), 0)
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/core/tests/library/LegacyEnvLayerExtensions.py
+++ b/src/core/tests/library/LegacyEnvLayerExtensions.py
@@ -19,9 +19,9 @@ from core.src.bootstrap.Constants import Constants
 
 
 class LegacyEnvLayerExtensions():
-    def __init__(self, package_manager_name):
+    def __init__(self, package_manager_name, test_type="HappyPath"):
         self.legacy_package_manager_name = package_manager_name
-        self.legacy_test_type = "HappyPath"
+        self.legacy_test_type = test_type
         self.temp_folder_path = ""
 
     class LegacyPlatform(object):
@@ -1214,6 +1214,99 @@ class LegacyEnvLayerExtensions():
                                  "1:2.02-123.el8                                      " + \
                                  "@System\n"
 
+            elif self.legacy_test_type == 'YumVersion4Dependency':
+                if self.legacy_package_manager_name is Constants.YUM:
+                    if cmd.find("--version") > -1:
+                        code = 0
+                        output = "4.7.0\n" + \
+                                 "  Installed: dnf-0:4.7.0-8.el8.noarch at Mon 29 May 2023 02:58:31 PM GMT\n" + \
+                                 "  Built    : Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla> at Fri 18 Mar 2022 03:21:28 PM GMT" + \
+                                 "\n" + \
+                                 "  Installed: rpm-0:4.14.3-24.el8_6.x86_64 at Mon 29 May 2023 05:07:36 PM GMT" + \
+                                 "  Built    : Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla> at Wed 14 Sep 2022 09:12:50 AM GMT"
+                    if cmd.find("assumeno --skip-broken iptables") > -1:
+                        code = 0
+                        output = "Updating Subscription Management repositories.\n" + \
+                                 "Unable to read consumer identity\n" + \
+                                 "\n" + \
+                                 "This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.\n" + \
+                                 "\n" + \
+                                 "Last metadata expiration check: 0:12:39 ago on Mon 27 Feb 2023 12:10:02 PM UTC.\n" + \
+                                 "Package iptables-libs-1.8.4-17.el8_4.1.x86_64 is already installed.\n" + \
+                                 "Dependencies resolved.\n" + \
+                                 "===========================================================================================\n" + \
+                                 " Package             Arch    Version          Repository                               Size\n" + \
+                                 "===========================================================================================\n" + \
+                                 "Upgrading:\n" + \
+                                 " iptables            x86_64  1.8.4-17.el8_4.2 rhel-8-for-x86_64-baseos-eus-rhui-rpms  584 k\n" + \
+                                 " iptables-ebtables   x86_64  1.8.4-17.el8_4.2 rhel-8-for-x86_64-baseos-eus-rhui-rpms   72 k\n" + \
+                                 " iptables-libs       x86_64  1.8.4-17.el8_4.2 rhel-8-for-x86_64-baseos-eus-rhui-rpms  108 k\n" + \
+                                 "\n" + \
+                                 "Transaction Summary\n" + \
+                                 "===========================================================================================\n" + \
+                                 "Upgrade  3 Packages\n" + \
+                                 "\n" + \
+                                 "Total download size: 764 k\n" + \
+                                 "Operation aborted."
+            elif self.legacy_test_type == 'YumVersion4DependencyInTwoLines':
+                if self.legacy_package_manager_name is Constants.YUM:
+                    if cmd.find("--version") > -1:
+                        code = 0
+                        output = "4.7.0\n" + \
+                                 "  Installed: dnf-0:4.7.0-8.el8.noarch at Mon 29 May 2023 02:58:31 PM GMT\n" + \
+                                 "  Built    : Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla> at Fri 18 Mar 2022 03:21:28 PM GMT" + \
+                                 "\n" + \
+                                 "  Installed: rpm-0:4.14.3-24.el8_6.x86_64 at Mon 29 May 2023 05:07:36 PM GMT" + \
+                                 "  Built    : Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla> at Wed 14 Sep 2022 09:12:50 AM GMT"
+                    if cmd.find("assumeno --skip-broken polkit") > -1:
+                        code = 0
+                        output = "Last metadata expiration check: 0:08:47 ago on Tue 25 Jul 2023 02:14:28 PM UTC.\n" + \
+                                 "Package polkit-0.115-13.el8_5.2.x86_64 is already installed.\n" + \
+                                 "Dependencies resolved.\n" + \
+                                 "================================================================================\n" + \
+                                 " Package   Arch   Version          Repository                              Size \n" + \
+                                 "================================================================================\n" + \
+                                 "Upgrading:\n" + \
+                                 " polkit    x86_64 0.115-14.el8_6.1 rhel-8-for-x86_64-baseos-eus-rhui-rpms 154 k\n" + \
+                                 " polkit-libs\n" + \
+                                 "           x86_64 0.115-14.el8_6.1 rhel-8-for-x86_64-baseos-eus-rhui-rpms  77 k\n" + \
+                                 "\n" + \
+                                 "Transaction Summary\n" + \
+                                 "================================================================================\n" + \
+                                 "Upgrade  2 Packages\n" + \
+                                 "\n" + \
+                                 "Total download size: 231 k\n" + \
+                                 "Operation aborted.\n"
+            elif self.legacy_test_type == 'YumVersion4DependencyInTwoLinesWithUnexpectedOutput':
+                if self.legacy_package_manager_name is Constants.YUM:
+                    if cmd.find("--version") > -1:
+                        code = 0
+                        output = "4.7.0\n" + \
+                                 "  Installed: dnf-0:4.7.0-8.el8.noarch at Mon 29 May 2023 02:58:31 PM GMT\n" + \
+                                 "  Built    : Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla> at Fri 18 Mar 2022 03:21:28 PM GMT" + \
+                                 "\n" + \
+                                 "  Installed: rpm-0:4.14.3-24.el8_6.x86_64 at Mon 29 May 2023 05:07:36 PM GMT" + \
+                                 "  Built    : Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla> at Wed 14 Sep 2022 09:12:50 AM GMT"
+                    if cmd.find("assumeno --skip-broken polkit") > -1:
+                        # The below is example for unexpected output. For the second package i.e. polkit-libs, the package name is not present.
+                        # Only other package details are present. This scenario is added for code coverage.
+                        code = 0
+                        output = "Last metadata expiration check: 0:08:47 ago on Tue 25 Jul 2023 02:14:28 PM UTC.\n" + \
+                                 "Package polkit-0.115-13.el8_5.2.x86_64 is already installed.\n" + \
+                                 "Dependencies resolved.\n" + \
+                                 "================================================================================\n" + \
+                                 " Package   Arch   Version          Repository                              Size \n" + \
+                                 "================================================================================\n" + \
+                                 "Upgrading:\n" + \
+                                 " polkit    x86_64 0.115-14.el8_6.1 rhel-8-for-x86_64-baseos-eus-rhui-rpms 154 k\n" + \
+                                 "           x86_64 0.115-14.el8_6.1 rhel-8-for-x86_64-baseos-eus-rhui-rpms  77 k\n" + \
+                                 "\n" + \
+                                 "Transaction Summary\n" + \
+                                 "================================================================================\n" + \
+                                 "Upgrade  2 Packages\n" + \
+                                 "\n" + \
+                                 "Total download size: 231 k\n" + \
+                                 "Operation aborted.\n"
             major_version = self.get_python_major_version()
             if major_version == 2:
                 return code, output.decode('utf8', 'ignore').encode('ascii', 'ignore')

--- a/src/core/tests/library/RuntimeCompositor.py
+++ b/src/core/tests/library/RuntimeCompositor.py
@@ -41,7 +41,7 @@ except ImportError:
 
 
 class RuntimeCompositor(object):
-    def __init__(self, argv=Constants.DEFAULT_UNSPECIFIED_VALUE, legacy_mode=False, package_manager_name=Constants.APT, vm_cloud_type=Constants.VMCloudType.AZURE):
+    def __init__(self, argv=Constants.DEFAULT_UNSPECIFIED_VALUE, legacy_mode=False, package_manager_name=Constants.APT, vm_cloud_type=Constants.VMCloudType.AZURE, test_type="HappyPath"):
         # Init data
         self.current_env = Constants.DEV
         os.environ[Constants.LPE_ENV_VARIABLE] = self.current_env
@@ -77,7 +77,7 @@ class RuntimeCompositor(object):
         # Reconfigure env layer for legacy mode tests
         self.env_layer = bootstrapper.env_layer
         if legacy_mode:
-            self.legacy_env_layer_extensions = LegacyEnvLayerExtensions(package_manager_name)
+            self.legacy_env_layer_extensions = LegacyEnvLayerExtensions(package_manager_name, test_type)
             self.reconfigure_env_layer_to_legacy_mode()
 
         # Core components


### PR DESCRIPTION
Problem statement: Yum 3 and Yum 4 have different output syntax for yum install --assumeno cmd, which used to get dependent packages. Existing implementation was syntax specific, covering only yum 3 scenarios resulting in all dependent packages within yum 4 to NOT be identified.
Since dependent packages were never identified in yum 4, any exclusion rules on these were never applied, causing excluded packages to also get installed.

Fix: Adding capability to read o/p format of the cmd in yum 4.

Tests
- Manual tests: pending
- UTs: Added
