### PR TITLE
Matching 20% increase in throttling limit at VM Agent

### DIFF
--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -315,8 +315,8 @@ class Constants(object):
     TELEMETRY_DIR_SIZE_LIMIT_IN_CHARS = 41943040
     TELEMETRY_BUFFER_FOR_DROPPED_COUNT_MSG_IN_CHARS = 25  # buffer for the chars dropped text added at the end of the truncated telemetry message
     TELEMETRY_EVENT_COUNTER_MSG_SIZE_LIMIT_IN_CHARS = 15  # buffer for telemetry event counter text added at the end of every message sent to telemetry
-    TELEMETRY_MAX_EVENT_COUNT_THROTTLE = 60
-    TELEMETRY_MAX_TIME_IN_SECONDS_FOR_EVENT_COUNT_THROTTLE = 60
+    TELEMETRY_MAX_EVENT_COUNT_THROTTLE = 360
+    TELEMETRY_MAX_TIME_IN_SECONDS_FOR_EVENT_COUNT_THROTTLE = 300
 
     # Telemetry Event Level
     class TelemetryEventLevel(EnumBackport):


### PR DESCRIPTION
Changes:
- Matches a 20% increase in throttling limit at the VM Agent in 2023
- Smooths out the throttling by spreading it out to the exact band the agent uses - 360 events per 5 minutes (300 seconds)

Variances found in testing in the apt deb-style PR and covered separately here.