### PR TITLE
Matching log-source tagging for diagnosability with previous apt changes

### DIFF
--- a/src/core/src/package_managers/AptitudePackageManager.py
+++ b/src/core/src/package_managers/AptitudePackageManager.py
@@ -317,7 +317,7 @@ class AptitudePackageManager(PackageManager):
             all_updates_versions = self.all_update_versions_cached
 
         if cached and not len(all_updates) == 0:
-            self.composite_logger.log_debug("[APM] Get all updates : [Cached={0}][PackagesCount={1}]]".format(cached, len(all_updates)))
+            self.composite_logger.log_debug("[APM] Get all updates : [Cached={0}][PackagesCount={1}]]".format(str(cached), len(all_updates)))
             return all_updates, all_updates_versions
 
         # when cached is False, query both default way and using Ubuntu Pro Client.

--- a/src/core/src/package_managers/YumPackageManager.py
+++ b/src/core/src/package_managers/YumPackageManager.py
@@ -285,21 +285,21 @@ class YumPackageManager(PackageManager):
         # Loaded plugins: product-id, search-disabled-repos, subscription-manager
         # Installed Packages
         # kernel.x86_64                                                                                   3.10.0-514.el7                                                                                    @anaconda/7.3
-        self.composite_logger.log_verbose("[YPM] Checking package install status. [PackageName={0}][PackageVersion={1}]".format(package_name, package_version))
+        self.composite_logger.log_verbose("[YPM] Checking package install status. [PackageName={0}][PackageVersion={1}]".format(str(package_name), str(package_version)))
         cmd = self.single_package_check_installed.replace('<PACKAGE-NAME>', package_name)
         output = self.invoke_package_manager(cmd)
         packages, package_versions = self.extract_packages_and_versions_including_duplicates(output)
 
         for index, package in enumerate(packages):
             if package == package_name and (package_versions[index] == package_version):
-                self.composite_logger.log_debug("[YPM] > Installed version match found. [PackageName={0}][PackageVersion={1}]".format(package_name, package_version))
+                self.composite_logger.log_debug("[YPM] > Installed version match found. [PackageName={0}][PackageVersion={1}]".format(str(package_name), str(package_version)))
                 return True
             else:
                 self.composite_logger.log_verbose("[YPM] > Did not match: " + package + " (" + package_versions[index] + ")")
 
         # sometimes packages are removed entirely from the system during installation of other packages
         # so let's check that the package is still needed before
-        self.composite_logger.log_debug(" - Installed version match NOT found for: " + str(package_name) + "(" + str(package_version) + ")")
+        self.composite_logger.log_debug("[YPM] > Installed version match NOT found. [PackageName={0}][PackageVersion={1}]".format(str(package_name), str(package_version)))
         return False
 
     def extract_dependencies(self, output, packages):
@@ -875,8 +875,8 @@ class YumPackageManager(PackageManager):
         self.composite_logger.log_debug("[Customer-environment-error] Updating client package to avoid errors from older certificates using command: [Command={0}]".format(str(command)))
         code, out = self.env_layer.run_command_output(command, False, False)
         if code != self.yum_exitcode_no_applicable_packages:
-            error_msg = 'Customer environment error (expired SSL certs):  [Command={0}][Code={1}][Out={2}]'.format(command,str(code),out)
-            self.composite_logger.log_error(error_msg)
+            error_msg = 'Customer environment error (expired SSL certs):  [Command={0}][Code={1}]'.format(command,str(code))
+            self.composite_logger.log_error("{0}[Out={1}]".format(error_msg, out))
             self.status_handler.add_error_to_status(error_msg, Constants.PatchOperationErrorCodes.PACKAGE_MANAGER_FAILURE)
             raise Exception(error_msg, "[{0}]".format(Constants.ERROR_ADDED_TO_STATUS))
         else:

--- a/src/core/src/package_managers/YumPackageManager.py
+++ b/src/core/src/package_managers/YumPackageManager.py
@@ -97,7 +97,7 @@ class YumPackageManager(PackageManager):
         
         self.yum_update_client_package = "sudo yum update -y --disablerepo='*' --enablerepo='*microsoft*'"
         
-        self.package_install_expected_avg_time_in_seconds = 90 # As per telemetry data, the average time to install package is around 90 seconds for yum.
+        self.package_install_expected_avg_time_in_seconds = 90  # As per telemetry data, the average time to install package is around 90 seconds for yum.
 
     def refresh_repo(self):
         pass  # Refresh the repo is no ops in YUM
@@ -105,44 +105,39 @@ class YumPackageManager(PackageManager):
     # region Get Available Updates
     def invoke_package_manager_advanced(self, command, raise_on_exception=True):
         """Get missing updates using the command input"""
-        self.composite_logger.log_debug('\nInvoking package manager using: ' + command)
+        self.composite_logger.log_verbose("[YPM] Invoking package manager. [Command={0}]".format(str(command)))
         code, out = self.env_layer.run_command_output(command, False, False)
 
         code, out = self.try_mitigate_issues_if_any(command, code, out)
 
         if code not in [self.yum_exitcode_ok, self.yum_exitcode_no_applicable_packages, self.yum_exitcode_updates_available]:
-            self.composite_logger.log('[ERROR] Package manager was invoked using: ' + command)
-            self.composite_logger.log_warning(" - Return code from package manager: " + str(code))
-            self.composite_logger.log_warning(" - Output from package manager: \n|\t" + "\n|\t".join(out.splitlines()))
-            self.telemetry_writer.write_execution_error(command, code, out)
-            error_msg = 'Unexpected return code (' + str(code) + ') from package manager on command: ' + command
+            self.composite_logger.log_warning('[ERROR] Customer environment error. [Command={0}][Code={1}][Output={2}]'.format(command, str(code), str(out)))
+            error_msg = "Customer environment error: Investigate and resolve unexpected return code ({0}) from package manager on command: {1}".format(str(code), command)
             self.status_handler.add_error_to_status(error_msg, Constants.PatchOperationErrorCodes.PACKAGE_MANAGER_FAILURE)
             if raise_on_exception:
                 raise Exception(error_msg, "[{0}]".format(Constants.ERROR_ADDED_TO_STATUS))
             # more return codes should be added as appropriate
         else:  # verbose diagnostic log
-            self.composite_logger.log_verbose("\n\n==[SUCCESS]===============================================================")
-            self.composite_logger.log_debug(" - Return code from package manager: " + str(code))
-            self.composite_logger.log_debug(" - Output from package manager: \n|\t" + "\n|\t".join(out.splitlines()))
-            self.composite_logger.log_verbose("==========================================================================\n\n")
+            self.composite_logger.log_debug('[YPM] Invoked package manager. [Command={0}][Code={1}][Output={2}]'.format(command, str(code), str(out)))
         return out, code
 
     # region Classification-based (incl. All) update check
     def get_all_updates(self, cached=False):
         """Get all missing updates"""
-        self.composite_logger.log_debug("\nDiscovering all packages...")
+        self.composite_logger.log_verbose("[YPM] Discovering all packages...")
         if cached and not len(self.all_updates_cached) == 0:
-            self.composite_logger.log_debug(" - Returning cached package data.")
+            self.composite_logger.log_debug("[YPM] Get all updates : [Cached={0}][PackagesCount={1}]]".format(str(cached), len(self.all_updates_cached)))
             return self.all_updates_cached, self.all_update_versions_cached  # allows for high performance reuse in areas of the code explicitly aware of the cache
 
         out = self.invoke_package_manager(self.yum_check)
         self.all_updates_cached, self.all_update_versions_cached = self.extract_packages_and_versions(out)
-        self.composite_logger.log_debug("Discovered " + str(len(self.all_updates_cached)) + " package entries.")
+
+        self.composite_logger.log_debug("[YPM] Get all updates : [Cached={0}][PackagesCount={1}]]".format(str(False), len(self.all_updates_cached)))
         return self.all_updates_cached, self.all_update_versions_cached
 
     def get_security_updates(self):
         """Get missing security updates"""
-        self.composite_logger.log("\nDiscovering 'security' packages...")
+        self.composite_logger.log_verbose("[YPM] Discovering 'security' packages...")
 
         if not self.__is_image_rhel8_or_higher():
             self.install_yum_security_prerequisite()
@@ -153,12 +148,12 @@ class YumPackageManager(PackageManager):
         if len(security_packages) == 0 and 'CentOS' in str(self.env_layer.platform.linux_distribution()):   # deliberately non-terminal
             self.composite_logger.log_warning("Classification-based patching is only supported on YUM if the machine is independently configured to receive classification information.")
 
-        self.composite_logger.log("Discovered " + str(len(security_packages)) + " 'security' package entries.")
+        self.composite_logger.log_debug("[YPM] Discovered 'security' packages. [Count={0}]".format(len(security_packages)))
         return security_packages, security_package_versions
 
     def get_other_updates(self):
         """Get missing other updates"""
-        self.composite_logger.log("\nDiscovering 'other' packages...")
+        self.composite_logger.log_verbose("[YPM] Discovering 'other' packages...")
         other_packages = []
         other_package_versions = []
 
@@ -176,7 +171,7 @@ class YumPackageManager(PackageManager):
                 other_packages.append(package)
                 other_package_versions.append(all_package_versions[index])
 
-        self.composite_logger.log("Discovered " + str(len(other_packages)) + " 'other' package entries.")
+        self.composite_logger.log_debug("[YPM] Discovered 'other' packages. [Count={0}]".format(len(other_packages)))
         return other_packages, other_package_versions
 
     def __is_image_rhel8_or_higher(self):
@@ -185,7 +180,7 @@ class YumPackageManager(PackageManager):
             os_offer, os_version, os_code = self.env_layer.platform.linux_distribution()
 
             if "Red Hat Enterprise Linux" in os_offer and int(os_version.split('.')[0]) >= 8:
-                self.composite_logger.log_debug("Verify RHEL image version: " + str(os_version))
+                self.composite_logger.log_debug("[YPM] RHEL version >= 8 detected. [DetectedVersion={0}]".format(str(os_version)))
                 return True
 
         return False
@@ -195,9 +190,8 @@ class YumPackageManager(PackageManager):
 
     def install_yum_security_prerequisite(self):
         """Not installed by default in versions prior to RHEL 7. This step is idempotent and fast, so we're not writing more complex code."""
-        self.composite_logger.log_debug('Ensuring RHEL yum-plugin-security is present.')
         code, out = self.env_layer.run_command_output(self.yum_check_security_prerequisite, False, False)
-        self.composite_logger.log_debug(" - Code: " + str(code) + ", Output : \n|\t" + "\n|\t".join(out.splitlines()))
+        self.composite_logger.log_verbose("[YPM] Ensuring RHEL yum-plugin-security is present. [Code={0}][Out={1}]".format(str(code), out))
     # endregion
 
     # region Output Parser(s)
@@ -209,7 +203,7 @@ class YumPackageManager(PackageManager):
 
     def extract_packages_and_versions_including_duplicates(self, output):
         """Returns packages and versions from given output"""
-        self.composite_logger.log_verbose("\nExtracting package and version data...")
+        self.composite_logger.log_verbose("[YPM] Extracting package and version data...")
         packages = []
         versions = []
         package_extensions = Constants.SUPPORTED_PACKAGE_ARCH
@@ -246,7 +240,7 @@ class YumPackageManager(PackageManager):
                 versions.append(line[1])
                 line_index += 1
             else:
-                self.composite_logger.log_verbose(" - Inapplicable line (" + str(line_index) + "): " + lines[line_index])
+                self.composite_logger.log_verbose("[YPM] > Inapplicable line (" + str(line_index) + "): " + lines[line_index])
 
         return packages, versions
     # endregion
@@ -266,7 +260,7 @@ class YumPackageManager(PackageManager):
             excluded_string += excluded_package + ' '
         cmd = self.all_but_excluded_upgrade_cmd + excluded_string
 
-        self.composite_logger.log_debug("[FAIL SAFE MODE] UPDATING PACKAGES USING COMMAND: " + cmd)
+        self.composite_logger.log_debug("[YPM][FAIL SAFE MODE] UPDATING PACKAGES USING COMMAND: " + cmd)
         self.invoke_package_manager(cmd)
 
     def install_security_updates_azgps_coordinated(self):
@@ -291,17 +285,17 @@ class YumPackageManager(PackageManager):
         # Loaded plugins: product-id, search-disabled-repos, subscription-manager
         # Installed Packages
         # kernel.x86_64                                                                                   3.10.0-514.el7                                                                                    @anaconda/7.3
-        self.composite_logger.log_verbose("\nCHECKING PACKAGE INSTALL STATUS FOR: " + str(package_name) + " (" + str(package_version) + ")")
+        self.composite_logger.log_verbose("[YPM] Checking package install status. [PackageName={0}][PackageVersion={1}]".format(package_name, package_version))
         cmd = self.single_package_check_installed.replace('<PACKAGE-NAME>', package_name)
         output = self.invoke_package_manager(cmd)
         packages, package_versions = self.extract_packages_and_versions_including_duplicates(output)
 
         for index, package in enumerate(packages):
             if package == package_name and (package_versions[index] == package_version):
-                self.composite_logger.log_debug(" - Installed version match found for: " + str(package_name) + "(" + str(package_version) + ")")
+                self.composite_logger.log_debug("[YPM] > Installed version match found. [PackageName={0}][PackageVersion={1}]".format(package_name, package_version))
                 return True
             else:
-                self.composite_logger.log_verbose(" - Did not match: " + package + " (" + package_versions[index] + ")")
+                self.composite_logger.log_verbose("[YPM] > Did not match: " + package + " (" + package_versions[index] + ")")
 
         # sometimes packages are removed entirely from the system during installation of other packages
         # so let's check that the package is still needed before
@@ -329,11 +323,11 @@ class YumPackageManager(PackageManager):
             elif self.is_valid_update(line+next_line, package_arch_to_look_for):
                 dependent_package_name = self.get_product_name_with_arch(line+next_line, package_arch_to_look_for)
             else:
-                self.composite_logger.log_verbose(" - Inapplicable line: " + str(line))
+                self.composite_logger.log_verbose("[YPM] > Inapplicable line: " + str(line))
                 continue
 
             if len(dependent_package_name) != 0 and dependent_package_name not in packages and dependent_package_name not in dependencies:
-                self.composite_logger.log_verbose(" - Dependency detected: " + dependent_package_name)
+                self.composite_logger.log_verbose("[YPM] > Dependency detected: " + dependent_package_name)
                 dependencies.append(dependent_package_name)
 
         return dependencies
@@ -357,10 +351,10 @@ class YumPackageManager(PackageManager):
                 package_names += ' '
             package_names += package
 
-        self.composite_logger.log_debug("\nRESOLVING DEPENDENCIES USING COMMAND: " + str(self.single_package_upgrade_simulation_cmd + package_names))
+        self.composite_logger.log_verbose("[YPM] Resolving dependencies. [Command={0}]".format(str(self.single_package_upgrade_simulation_cmd + package_names)))
         output = self.invoke_package_manager(self.single_package_upgrade_simulation_cmd + package_names)
         dependencies = self.extract_dependencies(output, packages)
-        self.composite_logger.log_debug(str(len(dependencies)) + " dependent packages were found for packages '" + str(packages) + "'.")
+        self.composite_logger.log_verbose("[YPM] Resolved dependencies. [Packages={0}][DependencyCount={1}]".format(str(packages), len(dependencies)))
         return dependencies
 
     def get_product_name(self, package_name):
@@ -394,11 +388,11 @@ class YumPackageManager(PackageManager):
         package_version_split = str(package_version).split(':', 1)
 
         if len(package_version_split) == 2:
-            self.composite_logger.log_debug("   - Removed epoch from version (" + package_version + "): " + package_version_split[1])
+            self.composite_logger.log_verbose("[YPM]   > Removed epoch from version (" + package_version + "): " + package_version_split[1])
             return package_version_split[1]
 
         if len(package_version_split) != 1:
-            self.composite_logger.log_error("Unexpected error during version epoch removal from: " + package_version)
+            self.composite_logger.log_error("[YPM] Unexpected error during version epoch removal from package version. [PackageVersion={0}]".format(package_version))
 
         return package_version
 
@@ -569,79 +563,78 @@ class YumPackageManager(PackageManager):
     def disable_auto_os_update(self):
         """ Disables auto OS updates on the machine only if they are enable_on_reboot and logs the default settings the machine comes with """
         try:
-            self.composite_logger.log("Disabling auto OS updates in all identified services...")
+            self.composite_logger.log_verbose("[YPM] Disabling auto OS updates in all identified services...")
             self.disable_auto_os_update_for_yum_cron()
             self.disable_auto_os_update_for_dnf_automatic()
             self.disable_auto_os_update_for_packagekit()
-            self.composite_logger.log_debug("Successfully disabled auto OS updates")
+            self.composite_logger.log_debug("[YPM] Successfully disabled auto OS updates")
 
         except Exception as error:
-            self.composite_logger.log_error("Could not disable auto OS updates. [Error={0}]".format(repr(error)))
+            self.composite_logger.log_error("[YPM] Could not disable auto OS updates. [Error={0}]".format(repr(error)))
             raise
 
     def disable_auto_os_update_for_yum_cron(self):
         """ Disables auto OS updates, using yum cron service, and logs the default settings the machine comes with """
-        self.composite_logger.log("Disabling auto OS updates using yum-cron")
+        self.composite_logger.log_verbose("[YPM] Disabling auto OS updates using yum-cron")
         self.__init_auto_update_for_yum_cron()
 
         self.backup_image_default_patch_configuration_if_not_exists()
         if not self.is_auto_update_service_installed(self.yum_cron_install_check_cmd):
-            self.composite_logger.log_debug("Cannot disable as yum-cron is not installed on the machine")
+            self.composite_logger.log_debug("[YPM] Cannot disable as yum-cron is not installed on the machine")
             return
 
-        self.composite_logger.log_debug("Preemptively disabling auto OS updates using yum-cron")
+        self.composite_logger.log_verbose("[YPM] Preemptively disabling auto OS updates using yum-cron")
         self.update_os_patch_configuration_sub_setting(self.download_updates_identifier_text, "no", self.yum_cron_config_pattern_match_text)
         self.update_os_patch_configuration_sub_setting(self.apply_updates_identifier_text, "no", self.yum_cron_config_pattern_match_text)
         self.disable_auto_update_on_reboot(self.yum_cron_disable_on_reboot_cmd)
 
-        self.composite_logger.log("Successfully disabled auto OS updates using yum-cron")
+        self.composite_logger.log_debug("[YPM] Successfully disabled auto OS updates using yum-cron")
 
     def disable_auto_os_update_for_dnf_automatic(self):
         """ Disables auto OS updates, using dnf-automatic service, and logs the default settings the machine comes with """
-        self.composite_logger.log("Disabling auto OS updates using dnf-automatic")
+        self.composite_logger.log_verbose("[YPM] Disabling auto OS updates using dnf-automatic")
         self.__init_auto_update_for_dnf_automatic()
 
         self.backup_image_default_patch_configuration_if_not_exists()
 
         if not self.is_auto_update_service_installed(self.dnf_automatic_install_check_cmd):
-            self.composite_logger.log_debug("Cannot disable as dnf-automatic is not installed on the machine")
+            self.composite_logger.log_debug("[YPM] Cannot disable as dnf-automatic is not installed on the machine")
             return
 
-        self.composite_logger.log_debug("Preemptively disabling auto OS updates using dnf-automatic")
+        self.composite_logger.log_verbose("[YPM] Preemptively disabling auto OS updates using dnf-automatic")
         self.update_os_patch_configuration_sub_setting(self.download_updates_identifier_text, "no", self.dnf_automatic_config_pattern_match_text)
         self.update_os_patch_configuration_sub_setting(self.apply_updates_identifier_text, "no", self.dnf_automatic_config_pattern_match_text)
         self.disable_auto_update_on_reboot(self.dnf_automatic_disable_on_reboot_cmd)
 
-        self.composite_logger.log("Successfully disabled auto OS updates using dnf-automatic")
+        self.composite_logger.log_debug("[YPM] Successfully disabled auto OS updates using dnf-automatic")
 
     def disable_auto_os_update_for_packagekit(self):
         """ Disables auto OS updates, using packagekit service, and logs the default settings the machine comes with """
-        self.composite_logger.log("Disabling auto OS updates using packagekit")
+        self.composite_logger.log_verbose("[YPM] Disabling auto OS updates using packagekit")
         self.__init_auto_update_for_packagekit()
 
         self.backup_image_default_patch_configuration_if_not_exists()
 
         if not self.is_auto_update_service_installed(self.packagekit_install_check_cmd):
-            self.composite_logger.log_debug("Cannot disable as packagekit is not installed on the machine")
+            self.composite_logger.log_debug("[YPM] Cannot disable as packagekit is not installed on the machine")
             return
 
-        self.composite_logger.log_debug("Preemptively disabling auto OS updates using packagekit")
+        self.composite_logger.log_verbose("[YPM] Preemptively disabling auto OS updates using packagekit")
         #todo: uncomment after finding the correct value
         # self.update_os_patch_configuration_sub_setting(self.download_updates_identifier_text, "false", self.packagekit_config_pattern_match_text)
         self.update_os_patch_configuration_sub_setting(self.apply_updates_identifier_text, "false", self.packagekit_config_pattern_match_text)
         self.disable_auto_update_on_reboot(self.packagekit_disable_on_reboot_cmd)
 
-        self.composite_logger.log("Successfully disabled auto OS updates using packagekit")
+        self.composite_logger.log_debug("[YPM] Successfully disabled auto OS updates using packagekit")
 
     def is_service_set_to_enable_on_reboot(self, command):
         """ Checking if auto update is enable_on_reboot on the machine. An enable_on_reboot service will be activated (if currently inactive) on machine reboot """
-        self.composite_logger.log_debug("Checking if auto update service is set to enable on reboot...")
         code, out = self.env_layer.run_command_output(command, False, False)
-        self.composite_logger.log_debug(" - Code: " + str(code) + ", Output: \n|\t" + "\n|\t".join(out.splitlines()))
+        self.composite_logger.log_debug("[YPM] Checked if auto update service is set to enable on reboot. [Code={0}][Out={1}]".format(str(code), out))
         if len(out.strip()) > 0 and code == 0 and 'enabled' in out:
-            self.composite_logger.log_debug("Auto OS update service will enable on reboot")
+            self.composite_logger.log_debug("[YPM] > Auto OS update service will enable on reboot")
             return True
-        self.composite_logger.log_debug("Auto OS update service will NOT enable on reboot")
+        self.composite_logger.log_debug("[YPM] > Auto OS update service will NOT enable on reboot")
         return False
 
     def backup_image_default_patch_configuration_if_not_exists(self):
@@ -669,7 +662,7 @@ class YumPackageManager(PackageManager):
                         }
                     } """
         try:
-            self.composite_logger.log_debug("Ensuring there is a backup of the default patch state for [AutoOSUpdateService={0}]".format(str(self.current_auto_os_update_service)))
+            self.composite_logger.log_debug("[YPM] Ensuring there is a backup of the default patch state for [AutoOSUpdateService={0}]".format(str(self.current_auto_os_update_service)))
             image_default_patch_configuration_backup = {}
 
             # read existing backup since it also contains backup from other update services. We need to preserve any existing data within the backup file
@@ -682,11 +675,11 @@ class YumPackageManager(PackageManager):
             # verify if existing backup is valid if not, write to backup
             is_backup_valid = self.is_image_default_patch_configuration_backup_valid(image_default_patch_configuration_backup)
             if is_backup_valid:
-                self.composite_logger.log_debug("Since extension has a valid backup, no need to log the current settings again. [Default Auto OS update settings={0}] [File path={1}]"
+                self.composite_logger.log_debug("[YPM] Since extension has a valid backup, no need to log the current settings again. [Default Auto OS update settings={0}] [File path={1}]"
                                                 .format(str(image_default_patch_configuration_backup), self.image_default_patch_configuration_backup_path))
             else:
-                self.composite_logger.log_debug("Since the backup is invalid, will add a new backup with the current auto OS update settings")
-                self.composite_logger.log_debug("Fetching current auto OS update settings for [AutoOSUpdateService={0}]".format(str(self.current_auto_os_update_service)))
+                self.composite_logger.log_debug("[YPM] Since the backup is invalid, will add a new backup with the current auto OS update settings")
+                self.composite_logger.log_debug("[YPM] Fetching current auto OS update settings for [AutoOSUpdateService={0}]".format(str(self.current_auto_os_update_service)))
                 is_service_installed, enable_on_reboot_value, download_updates_value, apply_updates_value = self.__get_current_auto_os_updates_setting_on_machine()
 
                 backup_image_default_patch_configuration_json_to_add = {
@@ -700,11 +693,11 @@ class YumPackageManager(PackageManager):
 
                 image_default_patch_configuration_backup.update(backup_image_default_patch_configuration_json_to_add)
 
-                self.composite_logger.log_debug("Logging default system configuration settings for auto OS updates. [Settings={0}] [Log file path={1}]"
+                self.composite_logger.log_debug("[YPM] Logging default system configuration settings for auto OS updates. [Settings={0}] [Log file path={1}]"
                                                 .format(str(image_default_patch_configuration_backup), self.image_default_patch_configuration_backup_path))
                 self.env_layer.file_system.write_with_retry(self.image_default_patch_configuration_backup_path, '{0}'.format(json.dumps(image_default_patch_configuration_backup)), mode='w+')
         except Exception as error:
-            error_message = "Exception during fetching and logging default auto update settings on the machine. [Exception={0}]".format(repr(error))
+            error_message = "[YPM] Exception during fetching and logging default auto update settings on the machine. [Exception={0}]".format(repr(error))
             self.composite_logger.log_error(error_message)
             self.status_handler.add_error_to_status(error_message, Constants.PatchOperationErrorCodes.DEFAULT_ERROR)
             raise
@@ -727,10 +720,10 @@ class YumPackageManager(PackageManager):
                 and self.yum_cron_apply_updates_identifier_text in image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.YUM_CRON] \
                 and self.yum_cron_enable_on_reboot_identifier_text in image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.YUM_CRON] \
                 and self.yum_cron_installation_state_identifier_text in image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.YUM_CRON]:
-            self.composite_logger.log_debug("Extension has a valid backup for default yum-cron configuration settings")
+            self.composite_logger.log_debug("[YPM] Extension has a valid backup for default yum-cron configuration settings")
             return True
         else:
-            self.composite_logger.log_debug("Extension does not have a valid backup for default yum-cron configuration settings")
+            self.composite_logger.log_debug("[YPM] Extension does not have a valid backup for default yum-cron configuration settings")
             return False
 
     def is_backup_valid_for_dnf_automatic(self, image_default_patch_configuration_backup):
@@ -739,10 +732,10 @@ class YumPackageManager(PackageManager):
                 and self.dnf_automatic_apply_updates_identifier_text in image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.DNF_AUTOMATIC] \
                 and self.dnf_automatic_enable_on_reboot_identifier_text in image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.DNF_AUTOMATIC] \
                 and self.dnf_automatic_installation_state_identifier_text in image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.DNF_AUTOMATIC]:
-            self.composite_logger.log_debug("Extension has a valid backup for default dnf-automatic configuration settings")
+            self.composite_logger.log_debug("[YPM] Extension has a valid backup for default dnf-automatic configuration settings")
             return True
         else:
-            self.composite_logger.log_debug("Extension does not have a valid backup for default dnf-automatic configuration settings")
+            self.composite_logger.log_debug("[YPM] Extension does not have a valid backup for default dnf-automatic configuration settings")
             return False
 
     def is_backup_valid_for_packagekit(self, image_default_patch_configuration_backup):
@@ -751,10 +744,10 @@ class YumPackageManager(PackageManager):
                 and self.packagekit_apply_updates_identifier_text in image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.PACKAGEKIT] \
                 and self.packagekit_enable_on_reboot_identifier_text in image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.PACKAGEKIT] \
                 and self.packagekit_installation_state_identifier_text in image_default_patch_configuration_backup[Constants.YumAutoOSUpdateServices.PACKAGEKIT]:
-            self.composite_logger.log_debug("Extension has a valid backup for default packagekit configuration settings")
+            self.composite_logger.log_debug("[YPM] Extension has a valid backup for default packagekit configuration settings")
             return True
         else:
-            self.composite_logger.log_debug("Extension does not have a valid backup for default packagekit configuration settings")
+            self.composite_logger.log_debug("[YPM] Extension does not have a valid backup for default packagekit configuration settings")
             return False
 
     def __get_current_auto_os_updates_setting_on_machine(self):
@@ -772,7 +765,7 @@ class YumPackageManager(PackageManager):
             is_service_installed = True
             enable_on_reboot_value = self.is_service_set_to_enable_on_reboot(self.enable_on_reboot_check_cmd)
 
-            self.composite_logger.log_debug("Checking if auto updates are currently enabled...")
+            self.composite_logger.log_debug("[YPM] Checking if auto updates are currently enabled...")
             image_default_patch_configuration = self.env_layer.file_system.read_with_retry(self.os_patch_configuration_settings_file_path, raise_if_not_found=False)
             if image_default_patch_configuration is not None:
                 settings = image_default_patch_configuration.strip().split('\n')
@@ -786,25 +779,25 @@ class YumPackageManager(PackageManager):
                         apply_updates_value = match.group(1)
 
             if download_updates_value == "":
-                self.composite_logger.log_debug("Machine did not have any value set for [Setting={0}]".format(str(self.download_updates_identifier_text)))
+                self.composite_logger.log_debug("[YPM] Machine did not have any value set for [Setting={0}]".format(str(self.download_updates_identifier_text)))
             else:
-                self.composite_logger.log_verbose("Current value set for [{0}={1}]".format(str(self.download_updates_identifier_text), str(download_updates_value)))
+                self.composite_logger.log_verbose("[YPM] Current value set for [{0}={1}]".format(str(self.download_updates_identifier_text), str(download_updates_value)))
 
             if apply_updates_value == "":
-                self.composite_logger.log_debug("Machine did not have any value set for [Setting={0}]".format(str(self.apply_updates_identifier_text)))
+                self.composite_logger.log_debug("[YPM] Machine did not have any value set for [Setting={0}]".format(str(self.apply_updates_identifier_text)))
             else:
-                self.composite_logger.log_verbose("Current value set for [{0}={1}]".format(str(self.apply_updates_identifier_text), str(apply_updates_value)))
+                self.composite_logger.log_verbose("[YPM] Current value set for [{0}={1}]".format(str(self.apply_updates_identifier_text), str(apply_updates_value)))
 
             return is_service_installed, enable_on_reboot_value, download_updates_value, apply_updates_value
 
         except Exception as error:
-            raise Exception("Error occurred in fetching current auto OS update settings from the machine. [Exception={0}]".format(repr(error)))
+            raise Exception("[YPM] Error occurred in fetching current auto OS update settings from the machine. [Exception={0}]".format(repr(error)))
 
     def update_os_patch_configuration_sub_setting(self, patch_configuration_sub_setting, value="no", config_pattern_match_text=""):
         """ Updates (or adds if it doesn't exist) the given patch_configuration_sub_setting with the given value in os_patch_configuration_settings_file """
         try:
             # note: adding space between the patch_configuration_sub_setting and value since, we will have to do that if we have to add a patch_configuration_sub_setting that did not exist before
-            self.composite_logger.log_debug("Updating system configuration settings for auto OS updates. [Patch Configuration Sub Setting={0}] [Value={1}]".format(str(patch_configuration_sub_setting), value))
+            self.composite_logger.log_debug("[YPM] Updating system configuration settings for auto OS updates. [Patch Configuration Sub Setting={0}] [Value={1}]".format(str(patch_configuration_sub_setting), value))
             os_patch_configuration_settings = self.env_layer.file_system.read_with_retry(self.os_patch_configuration_settings_file_path)
             patch_configuration_sub_setting_to_update = patch_configuration_sub_setting + ' = ' + value
             patch_configuration_sub_setting_found_in_file = False
@@ -825,35 +818,32 @@ class YumPackageManager(PackageManager):
 
             self.env_layer.file_system.write_with_retry(self.os_patch_configuration_settings_file_path, '{0}'.format(updated_patch_configuration_sub_setting.lstrip()), mode='w+')
         except Exception as error:
-            error_msg = "Error occurred while updating system configuration settings for auto OS updates. [Patch Configuration={0}] [Error={1}]".format(str(patch_configuration_sub_setting), repr(error))
+            error_msg = "[YPM] Error occurred while updating system configuration settings for auto OS updates. [Patch Configuration={0}] [Error={1}]".format(str(patch_configuration_sub_setting), repr(error))
             self.composite_logger.log_error(error_msg)
             self.status_handler.add_error_to_status(error_msg, Constants.PatchOperationErrorCodes.DEFAULT_ERROR)
             raise
 
     def disable_auto_update_on_reboot(self, command):
-        self.composite_logger.log_debug("Disabling auto update on reboot using command: " + str(command))
+        self.composite_logger.log_verbose("[YPM] Disabling auto update on reboot. [Command={0}] ".format(command))
         code, out = self.env_layer.run_command_output(command, False, False)
-        self.composite_logger.log_debug(" - Code: " + str(code) + ", Output: \n|\t" + "\n|\t".join(out.splitlines()))
 
         if code != 0:
-            self.composite_logger.log('[ERROR] Command invoked: ' + command)
-            self.telemetry_writer.write_execution_error(command, code, out)
+            self.composite_logger.log_error("[YPM][ERROR] Error disabling auto update on reboot. [Command={0}][Code={1}][Output={2}]".format(command, str(code), out))
             error_msg = 'Unexpected return code (' + str(code) + ') on command: ' + command
             self.status_handler.add_error_to_status(error_msg, Constants.PatchOperationErrorCodes.OPERATION_FAILED)
             raise Exception(error_msg, "[{0}]".format(Constants.ERROR_ADDED_TO_STATUS))
-
-        self.composite_logger.log_debug("Auto update on reboot disabled")
+        else:
+            self.composite_logger.log_debug("[YPM] Disabled auto update on reboot. [Command={0}][Code={1}][Output={2}]".format(command, str(code), out))
 
     def is_auto_update_service_installed(self, install_check_cmd):
         """ Checks if the auto update service is enable_on_reboot on the VM """
-        self.composite_logger.log_debug("Checking if auto update service is installed...")
         code, out = self.env_layer.run_command_output(install_check_cmd, False, False)
-        self.composite_logger.log_debug(" - Code: " + str(code) + ", Output: \n|\t" + "\n|\t".join(out.splitlines()))
+        self.composite_logger.log_debug("[YPM] Checked if auto update service is installed. [Command={0}][Code={1}][Output={2}]".format(install_check_cmd, str(code), out))
         if len(out.strip()) > 0 and code == 0:
-            self.composite_logger.log_debug("Auto OS update service is installed on the machine")
+            self.composite_logger.log_debug("[YPM] > Auto OS update service is installed on the machine")
             return True
         else:
-            self.composite_logger.log_debug("Auto OS update service is NOT installed on the machine")
+            self.composite_logger.log_debug("[YPM] > Auto OS update service is NOT installed on the machine")
             return False
     # endregion
 
@@ -870,14 +860,14 @@ class YumPackageManager(PackageManager):
 
     def check_known_issues_and_attempt_fix(self, output):
         """ Checks if issue falls into known issues and attempts to mitigate """
-        self.composite_logger.log_debug("Checking against known errors: [Out={0}]".format(output))
+        self.composite_logger.log_debug("[YPM] Checking against known errors: [Out={0}]".format(output))
         for error in self.known_errors_and_fixes:
             if error in output:
-                self.composite_logger.log_debug("Found a match within known errors list, attempting a fix...")
+                self.composite_logger.log_debug("[YPM] Found a match within known errors list, attempting a fix...")
                 self.known_errors_and_fixes[error]()
                 return True
 
-        self.composite_logger.log_error("Customer Environment Error: Not a known error. Please investigate and address. [Out={0}]".format(output))
+        self.composite_logger.log_error("[YPM] Customer Environment Error: Not a known error. Please investigate and address. [Out={0}]".format(output))
         return False
 
     def fix_ssl_certificate_issue(self):
@@ -901,44 +891,44 @@ class YumPackageManager(PackageManager):
         try:
             pending_file_exists = os.path.isfile(self.REBOOT_PENDING_FILE_PATH)  # not intended for yum, but supporting as back-compat
             pending_processes_exist = self.do_processes_require_restart()
-            self.composite_logger.log_debug(" - Reboot required debug flags (yum): " + str(pending_file_exists) + ", " + str(pending_processes_exist) + ".")
+            self.composite_logger.log_debug("[YPM] > Reboot required debug flags (yum): " + str(pending_file_exists) + ", " + str(pending_processes_exist) + ".")
             return pending_file_exists or pending_processes_exist
         except Exception as error:
-            self.composite_logger.log_error('Error while checking for reboot pending (yum): ' + repr(error))
+            self.composite_logger.log_error('[YPM] Error while checking for reboot pending (yum): ' + repr(error))
             return True  # defaults for safety
 
     def do_processes_require_restart(self):
         """Signals whether processes require a restart due to updates"""
-        self.composite_logger.log_debug("Checking if process requires reboot")
+        self.composite_logger.log_verbose("[YPM] Checking if process requires reboot")
         # Checking using yum-utils
         code, out = self.env_layer.run_command_output(self.yum_utils_prerequisite, False, False)  # idempotent, doesn't install if already present
-        self.composite_logger.log_debug("Idempotent yum-utils existence check. [Code={0}][Out={1}]".format(str(code), out))
+        self.composite_logger.log_verbose("[YPM] Idempotent yum-utils existence check. [Code={0}][Out={1}]".format(str(code), out))
 
         # Checking for restart for distros with -r flag such as RHEL 7+
         code, out = self.env_layer.run_command_output(self.needs_restarting_with_flag, False, False)
-        self.composite_logger.log_verbose(" - Code: " + str(code) + ", Output: \n|\t" + "\n|\t".join(out.splitlines()))
+        self.composite_logger.log_verbose("[YPM] > Code: " + str(code) + ", Output: \n|\t" + "\n|\t".join(out.splitlines()))
         if out.find("Reboot is required") < 0:
-            self.composite_logger.log_verbose(" - Reboot not detected to be required (L1).")
+            self.composite_logger.log_debug("[YPM] > Reboot not detected to be required (L1).")
         else:
-            self.composite_logger.log_verbose(" - Reboot is detected to be required (L1).")
+            self.composite_logger.log_debug("[YPM] > Reboot is detected to be required (L1).")
             return True
 
         # Checking for restart for distro without -r flag such as RHEL 6 and CentOS 6
         if str(self.env_layer.platform.linux_distribution()[1]).split('.')[0] == '6':
             code, out = self.env_layer.run_command_output(self.needs_restarting, False, False)
-            self.composite_logger.log_debug(" - Code: " + str(code) + ", Output: \n|\t" + "\n|\t".join(out.splitlines()))
+            self.composite_logger.log_verbose("[YPM] > Code: " + str(code) + ", Output: \n|\t" + "\n|\t".join(out.splitlines()))
             if len(out.strip()) == 0 and code == 0:
-                self.composite_logger.log_verbose(" - Reboot not detected to be required (L2).")
+                self.composite_logger.log_debug("[YPM] > Reboot not detected to be required (L2).")
             else:
-                self.composite_logger.log_verbose(" - Reboot is detected to be required (L2).")
+                self.composite_logger.log_debug("[YPM] > Reboot is detected to be required (L2).")
                 return True
 
         # Double-checking using yum ps (where available)
         code, out = self.env_layer.run_command_output(self.yum_ps_prerequisite, False, False)  # idempotent, doesn't install if already present
         if out.find("Unable to find a match: yum-plugin-security") < 0:
-            self.composite_logger.log_debug("[Info] yum-plugin-ps is not present. This is okay on RHEL8+. [Code={0}][Out={1}]".format(str(code), out))
+            self.composite_logger.log_debug("[YPM][Info] yum-plugin-ps is not present. This is okay on RHEL8+. [Code={0}][Out={1}]".format(str(code), out))
         else:
-            self.composite_logger.log_debug("Idempotent yum-plugin-ps existence check. [Code={0}][Out={1}]".format(str(code), out))
+            self.composite_logger.log_debug("[YPM] Idempotent yum-plugin-ps existence check. [Code={0}][Out={1}]".format(str(code), out))
 
         output = self.invoke_package_manager(self.yum_ps)
         lines = output.strip().split('\n')
@@ -950,16 +940,16 @@ class YumPackageManager(PackageManager):
         for line in lines:
             if not process_list_flag:  # keep going until the process list starts
                 if line.find("pid") < 0 and line.find("proc") < 0 and line.find("uptime") < 0:
-                    self.composite_logger.log_verbose(" - Inapplicable line: " + str(line))
+                    self.composite_logger.log_verbose("[YPM] > Inapplicable line: " + str(line))
                     continue
                 else:
-                    self.composite_logger.log_verbose(" - Process list started: " + str(line))
+                    self.composite_logger.log_verbose("[YPM] > Process list started: " + str(line))
                     process_list_flag = True
                     continue
 
             process_details = re.split(r'\s+', line.strip())
             if len(process_details) < 7:
-                self.composite_logger.log_verbose(" - Inapplicable line: " + str(line))
+                self.composite_logger.log_verbose("[YPM] > Inapplicable line: " + str(line))
                 continue
             else:
                 # The first string should be process ID and hence it should be integer.
@@ -967,14 +957,14 @@ class YumPackageManager(PackageManager):
                 try:
                     int(process_details[0])
                 except Exception:
-                    self.composite_logger.log_verbose(" - Inapplicable line: " + str(line))
+                    self.composite_logger.log_verbose("[YPM] > Inapplicable line: " + str(line))
                     continue
 
-                self.composite_logger.log_verbose(" - Applicable line: " + str(line))
+                self.composite_logger.log_verbose("[YPM] > Applicable line: " + str(line))
                 process_count += 1
                 process_list_verbose += process_details[1] + " (" + process_details[0] + "), "  # process name and id
 
-        self.composite_logger.log(" - Processes requiring restart (" + str(process_count) + "): [" + process_list_verbose + "<eol>]")
+        self.composite_logger.log_debug("[YPM] Processes requiring restart (" + str(process_count) + "): [" + process_list_verbose + "<eol>]")
         return process_count != 0  # True if there were any
     # endregion Reboot Management
 

--- a/src/core/src/package_managers/ZypperPackageManager.py
+++ b/src/core/src/package_managers/ZypperPackageManager.py
@@ -87,40 +87,40 @@ class ZypperPackageManager(PackageManager):
         # # commands for YaST2 online update configuration
         # self.__init_constants_for_yast2_online_update_configuration()
 
-        self.package_install_expected_avg_time_in_seconds = 240 # As per telemetry data, the average time to install package is around 232 seconds for zypper.
+        self.package_install_expected_avg_time_in_seconds = 240  # As per telemetry data, the average time to install package is around 232 seconds for zypper.
 
     def refresh_repo(self):
-        self.composite_logger.log("Refreshing local repo...")
+        self.composite_logger.log_debug("[ZPM] Refreshing local repo...")
         # self.invoke_package_manager(self.repo_clean)  # purges local metadata for rebuild - addresses a possible customer environment error
         try:
             self.invoke_package_manager(self.repo_refresh)
         except Exception as error:
             # Reboot if not already done
             if self.status_handler.get_installation_reboot_status() == Constants.RebootStatus.COMPLETED:
-                self.composite_logger.log_warning("Unable to refresh repo (retries exhausted after reboot).")
+                self.composite_logger.log_warning("[ZPM] Unable to refresh repo (retries exhausted after reboot). [Error={0}]".format(str(error)))
                 raise
             else:
-                self.composite_logger.log_debug("Setting force_reboot flag to True.")
+                self.composite_logger.log_debug("[ZPM] Setting force_reboot flag to True. [Error={0}]".format(str(error)))
                 self.force_reboot = True
 
     def __refresh_repo_services(self):
         """ Similar to refresh_repo, but refreshes services in case no repos are defined. """
-        self.composite_logger.log("Refreshing local repo services...")
+        self.composite_logger.log_debug("[ZPM] Refreshing local repo services...")
         try:
             self.invoke_package_manager(self.repo_refresh_services)
         except Exception as error:
             # Reboot if not already done
             if self.status_handler.get_installation_reboot_status() == Constants.RebootStatus.COMPLETED:
-                self.composite_logger.log_warning("Unable to refresh repo services (retries exhausted after reboot).")
+                self.composite_logger.log_warning("[ZPM] Unable to refresh repo services (retries exhausted after reboot). [Error={0}]".format(str(error)))
                 raise
             else:
-                self.composite_logger.log_warning("Setting force_reboot flag to True after refreshing repo services.")
+                self.composite_logger.log_warning("[ZPM] Setting force_reboot flag to True after refreshing repo services. [Error={0}]".format(str(error)))
                 self.force_reboot = True
 
     # region Get Available Updates
     def invoke_package_manager_advanced(self, command, raise_on_exception=True):
         """Get missing updates using the command input"""
-        self.composite_logger.log_debug('\nInvoking package manager using: ' + command)
+        self.composite_logger.log_verbose("[ZPM] Invoking package manager. [Command={0}]".format(str(command)))
         repo_refresh_services_attempted = False
 
         for i in range(1, self.package_manager_max_retries + 1):
@@ -131,18 +131,18 @@ class ZypperPackageManager(PackageManager):
             if code not in self.zypper_success_exit_codes:  # more known return codes should be added as appropriate
                 # Refresh repo services if no repos are defined
                 if code == self.zypper_exitcode_no_repos and command != self.repo_refresh_services and not repo_refresh_services_attempted:
-                    self.composite_logger.log_warning("Warning: no repos defined on command: {0}".format(str(command)))
+                    self.composite_logger.log_warning("[ZPM] Warning: No repos defined on command: {0}".format(str(command)))
                     self.__refresh_repo_services()
                     repo_refresh_services_attempted = True
                     continue
 
                 if code == self.zypper_exitcode_zypp_exit_err_commit:
                     # Run command again with --replacefiles to fix file conflicts
-                    self.composite_logger.log_warning("Warning: package conflict detected on command: {0}".format(str(command)))
+                    self.composite_logger.log_warning("[ZPM] Warning: Package conflict detected on command: {0}".format(str(command)))
                     modified_command = self.modify_upgrade_or_patch_command_to_replacefiles(command)
                     if modified_command is not None:
                         command = modified_command
-                        self.composite_logger.log_debug("Retrying with modified command to replace files: {0}".format(str(command)))
+                        self.composite_logger.log_debug("[ZPM] Retrying with modified command to replace files: {0}".format(str(command)))
                         continue
 
                 self.log_errors_on_invoke(command, out, code)
@@ -155,11 +155,11 @@ class ZypperPackageManager(PackageManager):
 
                 # Retriable error code, so check number of retries and wait then retry if applicable; otherwise, raise error after max retries
                 if i < self.package_manager_max_retries:
-                    self.composite_logger.log_warning("Exception on package manager invoke. [Exception={0}] [RetryCount={1}]".format(error_msg, str(i)))
+                    self.composite_logger.log_warning("[ZPM] Exception on package manager invoke. [Exception={0}][RetryCount={1}]".format(error_msg, str(i)))
                     time.sleep(pow(2, i + 2))
                     continue
                 else:
-                    error_msg = "Unable to invoke package manager (retries exhausted) [{0}] [RetryCount={1}]".format(error_msg, str(i))
+                    error_msg = "Unable to invoke package manager (retries exhausted) [{0}][RetryCount={1}]".format(error_msg, str(i))
                     self.status_handler.add_error_to_status(error_msg, Constants.PatchOperationErrorCodes.PACKAGE_MANAGER_FAILURE)
                     if raise_on_exception:
                         raise Exception(error_msg, "[{0}]".format(Constants.ERROR_ADDED_TO_STATUS))
@@ -201,32 +201,32 @@ class ZypperPackageManager(PackageManager):
 
     def log_errors_on_invoke(self, command, out, code):
         """Logs verbose error messages if there is an error on invoke_package_manager"""
-        self.composite_logger.log_error("Package manager result: [Command={0}][Code={1}][Output={2}]".format(command, code, out))
+        self.composite_logger.log_error("[ZPM] Invoked package manager. [Command={0}][Code={1}][Output={2}]".format(command, code, out))
         self.log_process_tree_if_exists(out)
         self.telemetry_writer.write_execution_error(command, code, out)
 
     def log_success_on_invoke(self, code, out):
         """Logs verbose success messages on invoke_package_manager"""
         self.composite_logger.log_verbose("\n\n==[SUCCESS]===============================================================")
-        self.composite_logger.log_debug("Package manager result: [Code={0}][Output={1}]".format(code, out))
+        self.composite_logger.log_debug("[ZPM] Invoked package manager. [Code={0}][Output={1}]".format(code, out))
         self.composite_logger.log_verbose("==========================================================================\n\n")
 
     def log_process_tree_if_exists(self, out):
         """Logs the process tree based on locking PID in output, if there is a process tree to be found"""
         process_tree = self.get_process_tree_from_pid_in_output(out)
         if process_tree is not None:
-            self.composite_logger.log_warning(" - Process tree for the pid in output: \n{0}".format(str(process_tree)))
+            self.composite_logger.log_verbose("[ZPM]  > Process tree for the pid in output: \n{0}".format(str(process_tree)))
 
     def set_lock_timeout_and_backup_original(self):
         """Saves the env var ZYPP_LOCK_TIMEOUT and sets it to 5"""
         self.zypp_lock_timeout_backup = self.env_layer.get_env_var('ZYPP_LOCK_TIMEOUT')
-        self.composite_logger.log_debug("Original value of ZYPP_LOCK_TIMEOUT env var: {0}".format(str(self.zypp_lock_timeout_backup)))
+        self.composite_logger.log_debug("[ZPM] Original value of ZYPP_LOCK_TIMEOUT env var: {0}".format(str(self.zypp_lock_timeout_backup)))
         self.env_layer.set_env_var('ZYPP_LOCK_TIMEOUT', 5)
 
     def restore_original_lock_timeout(self):
         """Restores the original value of the env var ZYPP_LOCK_TIMEOUT, if any was saved"""
         if self.zypp_lock_timeout_backup is None:
-            self.composite_logger.log_debug("Attempted to restore original lock timeout when none was saved")
+            self.composite_logger.log_debug("[ZPM] Attempted to restore original lock timeout when none was saved")
 
         self.env_layer.set_env_var('ZYPP_LOCK_TIMEOUT', self.zypp_lock_timeout_backup)
         self.zypp_lock_timeout_backup = None
@@ -285,7 +285,7 @@ class ZypperPackageManager(PackageManager):
         """Get all missing updates"""
         self.composite_logger.log_debug("\nDiscovering all packages...")
         if cached and not len(self.all_updates_cached) == 0:
-            self.composite_logger.log_debug(" - Returning cached package data.")
+            self.composite_logger.log_debug("[ZPM] > Returning cached package data.")
             return self.all_updates_cached, self.all_update_versions_cached  # allows for high performance reuse in areas of the code explicitly aware of the cache
 
         out = self.invoke_package_manager(self.zypper_check)
@@ -310,7 +310,7 @@ class ZypperPackageManager(PackageManager):
             if package in packages_from_patch_data:
                 security_packages.append(package)
                 security_package_versions.append(all_package_versions[index])
-                self.composite_logger.log_debug(" - " + str(package) + " [" + str(all_package_versions[index]) + "]")
+                self.composite_logger.log_debug("[ZPM] > " + str(package) + " [" + str(all_package_versions[index]) + "]")
 
         self.composite_logger.log_debug("Discovered " + str(len(security_packages)) + " 'security' package entries.\n")
         return security_packages, security_package_versions
@@ -327,8 +327,8 @@ class ZypperPackageManager(PackageManager):
 
         # SPECIAL CONDITION IF ZYPPER UPDATE IS DETECTED - UNAVOIDABLE SECURITY UPDATE(S) WILL BE INSTALLED AND THE RUN REPEATED FOR 'OTHER".
         if self.get_package_manager_setting(Constants.PACKAGE_MGR_SETTING_REPEAT_PATCH_OPERATION, True):
-            self.composite_logger.log_warning("Important: Zypper-related security updates are necessary to continue - those will be installed first.")
-            self.composite_logger.log_warning("Temporarily skipping 'other' package entry discovery due to Zypper-related security updates.\n")
+            self.composite_logger.log_warning("[ZPM] Important: Zypper-related security updates are necessary to continue - those will be installed first.")
+            self.composite_logger.log_warning("[ZPM] Temporarily skipping 'other' package entry discovery due to Zypper-related security updates.\n")
             return self.get_security_updates()  # TO DO: in some cases, some misc security updates may sneak in - filter this (to do item)
             # also for above: also note that simply force updating only zypper does not solve the issue - tried
 
@@ -339,7 +339,7 @@ class ZypperPackageManager(PackageManager):
             if package not in packages_from_patch_data:
                 other_packages.append(package)
                 other_package_versions.append(all_package_versions[index])
-                self.composite_logger.log_verbose(" - " + str(package) + " [" + str(all_package_versions[index]) + "]")
+                self.composite_logger.log_verbose("[ZPM]  - " + str(package) + " [" + str(all_package_versions[index]) + "]")
 
         self.composite_logger.log_debug("Discovered " + str(len(other_packages)) + " 'other' package entries.\n")
         return other_packages, other_package_versions
@@ -372,9 +372,9 @@ class ZypperPackageManager(PackageManager):
                 packages.append(package)
                 version = line_split[4].strip()
                 versions.append(version)
-                self.composite_logger.log_verbose(" - Applicable line: " + line + ". Package: " + package + ". Version: " + version + ".")
+                self.composite_logger.log_verbose("[ZPM] > Applicable line: " + line + ". Package: " + package + ". Version: " + version + ".")
             else:
-                self.composite_logger.log_verbose(" - Inapplicable line: " + line)
+                self.composite_logger.log_verbose("[ZPM] > Inapplicable line: " + line)
 
         return packages, versions
 
@@ -389,19 +389,19 @@ class ZypperPackageManager(PackageManager):
             if not parser_seeing_packages_flag:
                 if 'package is going to be installed' in line or 'package is going to be upgraded' in line or \
                         'packages are going to be installed:' in line or 'packages are going to be upgraded:' in line:
-                    self.composite_logger.log_verbose(" - Start marker line: " + line)
+                    self.composite_logger.log_verbose("[ZPM] > Start marker line: " + line)
                     parser_seeing_packages_flag = True  # Start -- Next line contains information we need
                 else:
-                    self.composite_logger.log_verbose(" - Inapplicable line: " + line)
+                    self.composite_logger.log_verbose("[ZPM] > Inapplicable line: " + line)
                 continue
 
             if not line or line.isspace():
-                self.composite_logger.log_verbose(" - End marker line: " + line)
+                self.composite_logger.log_verbose("[ZPM] > End marker line: " + line)
                 parser_seeing_packages_flag = False
                 continue  # End -- We're past a package information block
 
             line_parts = line.strip().split(' ')
-            self.composite_logger.log_verbose(" - Package list line: " + line)
+            self.composite_logger.log_verbose("[ZPM] > Package list line: " + line)
             for line_part in line_parts:
                 packages.append(line_part)
                 self.composite_logger.log_verbose("    - Package: " + line_part)
@@ -433,12 +433,12 @@ class ZypperPackageManager(PackageManager):
         installed_package_versions = self.get_all_available_versions_of_package_ex(package_name, include_installed=True, include_available=False)
         for version in installed_package_versions:
             if version == package_version:
-                self.composite_logger.log_debug(" - Installed version match found for: " + str(package_name) + "(" + str(package_version) + ")")
+                self.composite_logger.log_debug("[ZPM] > Installed version match found for: " + str(package_name) + "(" + str(package_version) + ")")
                 return True
             else:
-                self.composite_logger.log_verbose(" - Did not match: " + str(version))
+                self.composite_logger.log_verbose("[ZPM] > Did not match: " + str(version))
 
-        self.composite_logger.log_debug(" - Installed version match NOT found for: " + str(package_name) + "(" + str(package_version) + ")")
+        self.composite_logger.log_debug("[ZPM] > Installed version match NOT found for: " + str(package_name) + "(" + str(package_version) + ")")
         return False
 
     def get_all_available_versions_of_package_ex(self, package_name, include_installed=False, include_available=True):
@@ -459,19 +459,19 @@ class ZypperPackageManager(PackageManager):
         for line in lines:
             if not packages_list_flag:  # keep going until the packages list starts
                 if not all(word in line for word in ["S", "Name", "Type", "Version", "Arch", "Repository"]):
-                    self.composite_logger.log_verbose(" - Inapplicable line: " + str(line))
+                    self.composite_logger.log_verbose("[ZPM] > Inapplicable line: " + str(line))
                     continue
                 else:
-                    self.composite_logger.log_verbose(" - Package list started: " + str(line))
+                    self.composite_logger.log_verbose("[ZPM] > Package list started: " + str(line))
                     packages_list_flag = True
                     continue
 
             package_details = line.split(' |')
             if len(package_details) != 6:
-                self.composite_logger.log_verbose(" - Inapplicable line: " + str(line))
+                self.composite_logger.log_verbose("[ZPM] > Inapplicable line: " + str(line))
                 continue
             else:
-                self.composite_logger.log_verbose(" - Applicable line: " + str(line))
+                self.composite_logger.log_verbose("[ZPM] > Applicable line: " + str(line))
                 details_status = str(package_details[0].strip())
                 details_name = str(package_details[1].strip())
                 details_type = str(package_details[2].strip())
@@ -521,14 +521,14 @@ class ZypperPackageManager(PackageManager):
 
         for line in lines:
             if line.find(" going to be ") < 0:
-                self.composite_logger.log_verbose(" - Inapplicable line: " + str(line))
+                self.composite_logger.log_verbose("[ZPM] > Inapplicable line: " + str(line))
                 continue
 
             updates_line = lines[lines.index(line) + 1]
             dependent_package_names = re.split(r'\s+', updates_line)
             for dependent_package_name in dependent_package_names:
                 if len(dependent_package_name) != 0 and dependent_package_name not in packages:
-                    self.composite_logger.log_verbose(" - Dependency detected: " + dependent_package_name)
+                    self.composite_logger.log_verbose("[ZPM] > Dependency detected: " + dependent_package_name)
                     dependencies.append(dependent_package_name)
 
         return dependencies
@@ -565,7 +565,7 @@ class ZypperPackageManager(PackageManager):
                 return Constants.UNKNOWN_PACKAGE_SIZE
             return pkg_list[0]
         except Exception as error:
-            self.composite_logger.log_debug(" - Could not get package size from output: " + repr(error))
+            self.composite_logger.log_debug("[ZPM] > Could not get package size from output: " + repr(error))
             return Constants.UNKNOWN_PACKAGE_SIZE
     # endregion
 
@@ -578,10 +578,10 @@ class ZypperPackageManager(PackageManager):
 
     def get_current_auto_os_patch_state(self):
         """ Gets the current auto OS update patch state on the machine """
-        self.composite_logger.log("Fetching the current automatic OS patch state on the machine...")
+        self.composite_logger.log_debug("[ZPM] Fetching the current automatic OS patch state on the machine...")
 
         current_auto_os_patch_state_for_yast2_online_update_configuration = self.__get_current_auto_os_patch_state_for_yast2_online_update_configuration()
-        self.composite_logger.log("OS patch state per auto OS update service: [yast2-online-update-configuration={0}]".format(str(current_auto_os_patch_state_for_yast2_online_update_configuration)))
+        self.composite_logger.log_debug("[ZPM] OS patch state per auto OS update service: [yast2-online-update-configuration={0}]".format(str(current_auto_os_patch_state_for_yast2_online_update_configuration)))
 
         current_auto_os_patch_state = current_auto_os_patch_state_for_yast2_online_update_configuration
         self.composite_logger.log_debug("Overall Auto OS Patch State based on all auto OS update service states [OverallAutoOSPatchState={0}]".format(str(current_auto_os_patch_state)))
@@ -651,7 +651,7 @@ class ZypperPackageManager(PackageManager):
     def disable_auto_os_update(self):
         """ Disables auto OS updates on the machine only if they are enable_on_reboot and logs the default settings the machine comes with """
         try:
-            self.composite_logger.log("Disabling auto OS updates in all identified services...")
+            self.composite_logger.log_debug("[ZPM] Disabling auto OS updates in all identified services...")
             self.disable_auto_os_update_for_yast_online_update_configuration()
             self.composite_logger.log_debug("Completed attempt to disable auto OS updates")
 
@@ -661,7 +661,7 @@ class ZypperPackageManager(PackageManager):
 
     def disable_auto_os_update_for_yast_online_update_configuration(self):
         """ Disables auto OS updates, using yast online, and logs the default settings the machine comes with """
-        self.composite_logger.log("Disabling auto OS updates using yast online update configuration")
+        self.composite_logger.log_debug("[ZPM] Disabling auto OS updates using yast online update configuration")
         self.__init_auto_update_for_yast_online_update_configuration()
 
         self.backup_image_default_patch_configuration_if_not_exists()
@@ -673,7 +673,7 @@ class ZypperPackageManager(PackageManager):
         self.composite_logger.log_debug("Preemptively disabling auto OS updates using yum-cron")
         self.update_os_patch_configuration_sub_setting(self.apply_updates_identifier_text, "false", self.auto_update_config_pattern_match_text)
 
-        self.composite_logger.log("Successfully disabled auto OS updates using yast2-online-update-configuration")
+        self.composite_logger.log_debug("[ZPM] Successfully disabled auto OS updates using yast2-online-update-configuration")
 
     def backup_image_default_patch_configuration_if_not_exists(self):
         """ Records the default system settings for auto OS updates within patch extension artifacts for future reference.
@@ -775,7 +775,7 @@ class ZypperPackageManager(PackageManager):
         try:
             pending_file_exists = os.path.isfile(self.REBOOT_PENDING_FILE_PATH)  # not intended for zypper, but supporting as back-compat
             pending_processes_exist = self.do_processes_require_restart()
-            self.composite_logger.log_debug(" - Reboot required debug flags (zypper): " + str(pending_file_exists) + ", " + str(pending_processes_exist) + ".")
+            self.composite_logger.log_debug("[ZPM] > Reboot required debug flags (zypper): " + str(pending_file_exists) + ", " + str(pending_processes_exist) + ".")
             return pending_file_exists or pending_processes_exist
         except Exception as error:
             self.composite_logger.log_error('Error while checking for reboot pending (zypper): ' + repr(error))
@@ -792,23 +792,23 @@ class ZypperPackageManager(PackageManager):
         for line in lines:
             if not process_list_flag:  # keep going until the process list starts
                 if not all(word in line for word in ["PID", "PPID", "UID", "User", "Command", "Service"]):
-                    self.composite_logger.log_verbose(" - Inapplicable line: " + str(line))
+                    self.composite_logger.log_verbose("[ZPM] > Inapplicable line: " + str(line))
                     continue
                 else:
-                    self.composite_logger.log_verbose(" - Process list started: " + str(line))
+                    self.composite_logger.log_verbose("[ZPM] > Process list started: " + str(line))
                     process_list_flag = True
                     continue
 
             process_details = line.split(' |')
             if len(process_details) < 6:
-                self.composite_logger.log_verbose(" - Inapplicable line: " + str(line))
+                self.composite_logger.log_verbose("[ZPM] > Inapplicable line: " + str(line))
                 continue
             else:
-                self.composite_logger.log_verbose(" - Applicable line: " + str(line))
+                self.composite_logger.log_verbose("[ZPM] > Applicable line: " + str(line))
                 process_count += 1
                 process_list_verbose += process_details[4].strip() + " (" + process_details[0].strip() + "), "  # process name and id
 
-        self.composite_logger.log(" - Processes requiring restart (" + str(process_count) + "): [" + process_list_verbose + "<eol>]")
+        self.composite_logger.log_debug("[ZPM] - Processes requiring restart (" + str(process_count) + "): [" + process_list_verbose + "<eol>]")
         return process_count != 0  # True if there were any
     # endregion Reboot Management
 

--- a/src/core/src/package_managers/ZypperPackageManager.py
+++ b/src/core/src/package_managers/ZypperPackageManager.py
@@ -701,7 +701,7 @@ class ZypperPackageManager(PackageManager):
             # verify if existing backup is valid if not, write to backup
             is_backup_valid = self.is_image_default_patch_configuration_backup_valid(image_default_patch_configuration_backup)
             if is_backup_valid:
-                self.composite_logger.log_debug("Since extension has a valid backup, no need to log the current settings again. [Default Auto OS update settings={0}] [File path={1}]"
+                self.composite_logger.log_verbose("Since extension has a valid backup, no need to log the current settings again. [Default Auto OS update settings={0}] [File path={1}]"
                                                 .format(str(image_default_patch_configuration_backup), self.image_default_patch_configuration_backup_path))
             else:
                 self.composite_logger.log_debug("Since the backup is invalid, will add a new backup with the current auto OS update settings")
@@ -794,19 +794,19 @@ class ZypperPackageManager(PackageManager):
         for line in lines:
             if not process_list_flag:  # keep going until the process list starts
                 if not all(word in line for word in ["PID", "PPID", "UID", "User", "Command", "Service"]):
-                    self.composite_logger.log_debug(" - Inapplicable line: " + str(line))
+                    self.composite_logger.log_verbose(" - Inapplicable line: " + str(line))
                     continue
                 else:
-                    self.composite_logger.log_debug(" - Process list started: " + str(line))
+                    self.composite_logger.log_verbose(" - Process list started: " + str(line))
                     process_list_flag = True
                     continue
 
             process_details = line.split(' |')
             if len(process_details) < 6:
-                self.composite_logger.log_debug(" - Inapplicable line: " + str(line))
+                self.composite_logger.log_verbose(" - Inapplicable line: " + str(line))
                 continue
             else:
-                self.composite_logger.log_debug(" - Applicable line: " + str(line))
+                self.composite_logger.log_verbose(" - Applicable line: " + str(line))
                 process_count += 1
                 process_list_verbose += process_details[4].strip() + " (" + process_details[0].strip() + "), "  # process name and id
 

--- a/src/core/src/package_managers/ZypperPackageManager.py
+++ b/src/core/src/package_managers/ZypperPackageManager.py
@@ -283,19 +283,19 @@ class ZypperPackageManager(PackageManager):
     # region Classification-based (incl. All) update check
     def get_all_updates(self, cached=False):
         """Get all missing updates"""
-        self.composite_logger.log_debug("\nDiscovering all packages...")
+        self.composite_logger.log_debug("[ZPM] Discovering all packages...")
         if cached and not len(self.all_updates_cached) == 0:
             self.composite_logger.log_debug("[ZPM] > Returning cached package data.")
             return self.all_updates_cached, self.all_update_versions_cached  # allows for high performance reuse in areas of the code explicitly aware of the cache
 
         out = self.invoke_package_manager(self.zypper_check)
         self.all_updates_cached, self.all_update_versions_cached = self.extract_packages_and_versions(out)
-        self.composite_logger.log_debug("Discovered " + str(len(self.all_updates_cached)) + " package entries.")
+        self.composite_logger.log_debug("[ZPM] Discovered " + str(len(self.all_updates_cached)) + " package entries.")
         return self.all_updates_cached, self.all_update_versions_cached
 
     def get_security_updates(self):
         """Get missing security updates"""
-        self.composite_logger.log_debug("\nDiscovering 'security' packages...")
+        self.composite_logger.log_debug("[ZPM] Discovering 'security' packages...")
         security_packages = []
         security_package_versions = []
 
@@ -312,12 +312,12 @@ class ZypperPackageManager(PackageManager):
                 security_package_versions.append(all_package_versions[index])
                 self.composite_logger.log_debug("[ZPM] > " + str(package) + " [" + str(all_package_versions[index]) + "]")
 
-        self.composite_logger.log_debug("Discovered " + str(len(security_packages)) + " 'security' package entries.\n")
+        self.composite_logger.log_debug("[ZPM] Discovered " + str(len(security_packages)) + " 'security' package entries.\n")
         return security_packages, security_package_versions
 
     def get_other_updates(self):
         """Get missing other updates"""
-        self.composite_logger.log_debug("\nDiscovering 'other' packages...")
+        self.composite_logger.log_debug("[ZPM] Discovering 'other' packages...")
         other_packages = []
         other_package_versions = []
 
@@ -341,7 +341,7 @@ class ZypperPackageManager(PackageManager):
                 other_package_versions.append(all_package_versions[index])
                 self.composite_logger.log_verbose("[ZPM]  - " + str(package) + " [" + str(all_package_versions[index]) + "]")
 
-        self.composite_logger.log_debug("Discovered " + str(len(other_packages)) + " 'other' package entries.\n")
+        self.composite_logger.log_debug("[ZPM] Discovered " + str(len(other_packages)) + " 'other' package entries.\n")
         return other_packages, other_package_versions
 
     def set_max_patch_publish_date(self, max_patch_publish_date=str()):
@@ -380,7 +380,7 @@ class ZypperPackageManager(PackageManager):
 
     def extract_packages_from_patch_data(self, output):
         """Returns packages (sometimes with version information embedded) from patch data"""
-        self.composite_logger.log_debug("\nExtracting package entries from security patch data...")
+        self.composite_logger.log_debug("[ZPM] Extracting package entries from security patch data...")
         packages = []
         parser_seeing_packages_flag = False
 
@@ -406,7 +406,7 @@ class ZypperPackageManager(PackageManager):
                 packages.append(line_part)
                 self.composite_logger.log_verbose("    - Package: " + line_part)
 
-        self.composite_logger.log_debug("\nExtracted " + str(len(packages)) + " prospective package entries from security patch data.\n")
+        self.composite_logger.log_verbose("[ZPM] Extracted " + str(len(packages)) + " prospective package entries from security patch data.\n")
         return packages
     # endregion
     # endregion
@@ -429,7 +429,7 @@ class ZypperPackageManager(PackageManager):
 
     def is_package_version_installed(self, package_name, package_version):
         """ Returns true if the specific package version is installed """
-        self.composite_logger.log_verbose("\nCHECKING PACKAGE INSTALL STATUS FOR: " + str(package_name) + "(" + str(package_version) + ")")
+        self.composite_logger.log_verbose("[ZPM] Checking package installation status. [Package={0}][Version={1}]".format(str(package_name), str(package_version)))
         installed_package_versions = self.get_all_available_versions_of_package_ex(package_name, include_installed=True, include_available=False)
         for version in installed_package_versions:
             if version == package_version:
@@ -450,7 +450,7 @@ class ZypperPackageManager(PackageManager):
 
         package_versions = []
 
-        self.composite_logger.log_verbose("\nGetting all available versions of package '" + package_name + "' [Installed=" + str(include_installed) + ", Available=" + str(include_available) + "]...")
+        self.composite_logger.log_verbose("[ZPM] Getting all available versions of package '" + package_name + "' [Installed=" + str(include_installed) + ", Available=" + str(include_available) + "]...")
         cmd = self.single_package_check_versions.replace('<PACKAGE-NAME>', package_name)
         output = self.invoke_package_manager(cmd)
         lines = output.strip().split('\n')
@@ -478,16 +478,16 @@ class ZypperPackageManager(PackageManager):
                 details_version = str(package_details[3].strip())
 
                 if details_name != package_name:
-                    self.composite_logger.log_verbose("    - Excluding as package name doesn't match exactly: " + details_name)
+                    self.composite_logger.log_verbose("[ZPM]    > Excluding as package name doesn't match exactly: " + details_name)
                     continue
                 if details_type == "srcpackage":
-                    self.composite_logger.log_verbose("    - Excluding as package is of type 'srcpackage'.")
+                    self.composite_logger.log_verbose("[ZPM]    > Excluding as package is of type 'srcpackage'.")
                     continue
                 if (details_status == "i" or details_status == "i+") and not include_installed:  # exclude installed as (include_installed not selected)
-                    self.composite_logger.log_verbose("    - Excluding as package version is installed: " + details_version)
+                    self.composite_logger.log_verbose("[ZPM]    > Excluding as package version is installed: " + details_version)
                     continue
                 if (details_status != "i" and details_status != "i+") and not include_available:  # exclude available as (include_available not selected)
-                    self.composite_logger.log_verbose("    - Excluding as package version is available: " + details_version)
+                    self.composite_logger.log_verbose("[ZPM]    > Excluding as package version is available: " + details_version)
                     continue
 
                 package_versions.append(details_version)
@@ -540,7 +540,7 @@ class ZypperPackageManager(PackageManager):
                 package_names += ' '
             package_names += package
 
-        self.composite_logger.log_debug("\nRESOLVING DEPENDENCIES USING COMMAND:: " + str(self.single_package_upgrade_simulation_cmd + package_names))
+        self.composite_logger.log_verbose("[ZPM] RESOLVING DEPENDENCIES USING COMMAND: " + str(self.single_package_upgrade_simulation_cmd + package_names))
 
         output = self.invoke_package_manager(self.single_package_upgrade_simulation_cmd + package_names)
         dependencies = self.extract_dependencies(output, packages)
@@ -629,7 +629,7 @@ class ZypperPackageManager(PackageManager):
                 return is_service_installed, apply_updates_value
 
             is_service_installed = True
-            self.composite_logger.log_debug("Checking if auto updates are currently enabled...")
+            self.composite_logger.log_debug("[ZPM] Checking if auto updates are currently enabled...")
             image_default_patch_configuration = self.env_layer.file_system.read_with_retry(self.os_patch_configuration_settings_file_path, raise_if_not_found=False)
             if image_default_patch_configuration is not None:
                 settings = image_default_patch_configuration.strip().split('\n')
@@ -639,9 +639,9 @@ class ZypperPackageManager(PackageManager):
                         apply_updates_value = match.group(1)
 
             if apply_updates_value == "":
-                self.composite_logger.log_debug("Machine did not have any value set for [Setting={0}]".format(str(self.apply_updates_identifier_text)))
+                self.composite_logger.log_debug("[ZPM] Machine did not have any value set for [Setting={0}]".format(str(self.apply_updates_identifier_text)))
             else:
-                self.composite_logger.log_verbose("Current value set for [{0}={1}]".format(str(self.apply_updates_identifier_text), str(apply_updates_value)))
+                self.composite_logger.log_verbose("[ZPM] Current value set for [{0}={1}]".format(str(self.apply_updates_identifier_text), str(apply_updates_value)))
 
             return is_service_installed, apply_updates_value
 
@@ -653,7 +653,7 @@ class ZypperPackageManager(PackageManager):
         try:
             self.composite_logger.log_debug("[ZPM] Disabling auto OS updates in all identified services...")
             self.disable_auto_os_update_for_yast_online_update_configuration()
-            self.composite_logger.log_debug("Completed attempt to disable auto OS updates")
+            self.composite_logger.log_debug("[ZPM] Completed attempt to disable auto OS updates")
 
         except Exception as error:
             self.composite_logger.log_error("Could not disable auto OS updates. [Error={0}]".format(repr(error)))
@@ -667,13 +667,13 @@ class ZypperPackageManager(PackageManager):
         self.backup_image_default_patch_configuration_if_not_exists()
         # check if file exists, if not do nothing
         if not os.path.exists(self.os_patch_configuration_settings_file_path):
-            self.composite_logger.log_debug("Cannot disable auto updates using yast2-online-update-configuration because the configuration file does not exist, indicating the service is not installed")
+            self.composite_logger.log_debug("[ZPM] Cannot disable auto updates using yast2-online-update-configuration because the configuration file does not exist, indicating the service is not installed")
             return
 
-        self.composite_logger.log_debug("Preemptively disabling auto OS updates using yum-cron")
+        self.composite_logger.log_debug("[ZPM] Preemptively disabling auto OS updates using yum-cron")
         self.update_os_patch_configuration_sub_setting(self.apply_updates_identifier_text, "false", self.auto_update_config_pattern_match_text)
 
-        self.composite_logger.log_debug("[ZPM] Successfully disabled auto OS updates using yast2-online-update-configuration")
+        self.composite_logger.log_debug("[ZPM] [ZPM] Successfully disabled auto OS updates using yast2-online-update-configuration")
 
     def backup_image_default_patch_configuration_if_not_exists(self):
         """ Records the default system settings for auto OS updates within patch extension artifacts for future reference.
@@ -699,11 +699,11 @@ class ZypperPackageManager(PackageManager):
             # verify if existing backup is valid if not, write to backup
             is_backup_valid = self.is_image_default_patch_configuration_backup_valid(image_default_patch_configuration_backup)
             if is_backup_valid:
-                self.composite_logger.log_verbose("Since extension has a valid backup, no need to log the current settings again. [Default Auto OS update settings={0}] [File path={1}]"
+                self.composite_logger.log_verbose("[ZPM] Since extension has a valid backup, no need to log the current settings again. [Default Auto OS update settings={0}] [File path={1}]"
                                                 .format(str(image_default_patch_configuration_backup), self.image_default_patch_configuration_backup_path))
             else:
-                self.composite_logger.log_debug("Since the backup is invalid, will add a new backup with the current auto OS update settings")
-                self.composite_logger.log_debug("Fetching current auto OS update settings for [AutoOSUpdateService={0}]".format(str(self.current_auto_os_update_service)))
+                self.composite_logger.log_debug("[ZPM] Since the backup is invalid, will add a new backup with the current auto OS update settings")
+                self.composite_logger.log_debug("[ZPM] Fetching current auto OS update settings for [AutoOSUpdateService={0}]".format(str(self.current_auto_os_update_service)))
                 is_service_installed, apply_updates_value = self.__get_current_auto_os_updates_setting_on_machine()
 
                 backup_image_default_patch_configuration_json_to_add = {
@@ -715,7 +715,7 @@ class ZypperPackageManager(PackageManager):
 
                 image_default_patch_configuration_backup.update(backup_image_default_patch_configuration_json_to_add)
 
-                self.composite_logger.log_debug("Logging default system configuration settings for auto OS updates. [Settings={0}] [Log file path={1}]"
+                self.composite_logger.log_debug("[ZPM] Logging default system configuration settings for auto OS updates. [Settings={0}] [Log file path={1}]"
                                                 .format(str(image_default_patch_configuration_backup), self.image_default_patch_configuration_backup_path))
                 self.env_layer.file_system.write_with_retry(self.image_default_patch_configuration_backup_path, '{0}'.format(json.dumps(image_default_patch_configuration_backup)), mode='w+')
         except Exception as error:
@@ -733,16 +733,16 @@ class ZypperPackageManager(PackageManager):
     def is_backup_valid_for_yast_online_update_configuration(self, image_default_patch_configuration_backup):
         if self.ZypperAutoOSUpdateServices.YAST2_ONLINE_UPDATE_CONFIGURATION in image_default_patch_configuration_backup \
                 and self.apply_updates_identifier_text in image_default_patch_configuration_backup[self.ZypperAutoOSUpdateServices.YAST2_ONLINE_UPDATE_CONFIGURATION]:
-            self.composite_logger.log_debug("Extension has a valid backup for default yum-cron configuration settings")
+            self.composite_logger.log_debug("[ZPM] Extension has a valid backup for default yum-cron configuration settings")
             return True
         else:
-            self.composite_logger.log_debug("Extension does not have a valid backup for default yum-cron configuration settings")
+            self.composite_logger.log_debug("[ZPM] Extension does not have a valid backup for default yum-cron configuration settings")
             return False
 
     def update_os_patch_configuration_sub_setting(self, patch_configuration_sub_setting, value="false", config_pattern_match_text=""):
         """ Updates (or adds if it doesn't exist) the given patch_configuration_sub_setting with the given value in os_patch_configuration_settings_file """
         try:
-            self.composite_logger.log_debug("Updating system configuration settings for auto OS updates. [Patch Configuration Sub Setting={0}] [Value={1}]".format(str(patch_configuration_sub_setting), value))
+            self.composite_logger.log_debug("[ZPM] Updating system configuration settings for auto OS updates. [Patch Configuration Sub Setting={0}] [Value={1}]".format(str(patch_configuration_sub_setting), value))
             os_patch_configuration_settings = self.env_layer.file_system.read_with_retry(self.os_patch_configuration_settings_file_path)
             patch_configuration_sub_setting_to_update = patch_configuration_sub_setting + '="' + value + '"'
             patch_configuration_sub_setting_found_in_file = False
@@ -763,8 +763,8 @@ class ZypperPackageManager(PackageManager):
 
             self.env_layer.file_system.write_with_retry(self.os_patch_configuration_settings_file_path, '{0}'.format(updated_patch_configuration_sub_setting.lstrip()), mode='w+')
         except Exception as error:
-            error_msg = "Error occurred while updating system configuration settings for auto OS updates. [Patch Configuration={0}] [Error={1}]".format(str(patch_configuration_sub_setting), repr(error))
-            self.composite_logger.log_error(error_msg)
+            error_msg = "Error occurred while updating system configuration settings for auto OS updates. [PatchConfig={0}][Error={1}]".format(str(patch_configuration_sub_setting), repr(error))
+            self.composite_logger.log_error("[ZPM] " + error_msg)
             self.status_handler.add_error_to_status(error_msg, Constants.PatchOperationErrorCodes.DEFAULT_ERROR)
             raise
     # endregion
@@ -775,14 +775,14 @@ class ZypperPackageManager(PackageManager):
         try:
             pending_file_exists = os.path.isfile(self.REBOOT_PENDING_FILE_PATH)  # not intended for zypper, but supporting as back-compat
             pending_processes_exist = self.do_processes_require_restart()
-            self.composite_logger.log_debug("[ZPM] > Reboot required debug flags (zypper): " + str(pending_file_exists) + ", " + str(pending_processes_exist) + ".")
+            self.composite_logger.log_debug("[ZPM] > Reboot required debug flags (zypper): [FileExists={0}][ProcessesExist={1}]".format(str(pending_file_exists), str(pending_processes_exist)))
             return pending_file_exists or pending_processes_exist
         except Exception as error:
-            self.composite_logger.log_error('Error while checking for reboot pending (zypper): ' + repr(error))
+            self.composite_logger.log_error("[ZPM] Error while checking for reboot pending (zypper). [Error={0}]".format(repr(error)))
             return True  # defaults for safety
 
     def do_processes_require_restart(self):
-        """Signals whether processes require a restart due to updates"""
+        """ Signals whether processes require a restart due to updates """
         output = self.invoke_package_manager(self.zypper_ps)
         lines = output.strip().split('\n')
 
@@ -808,7 +808,7 @@ class ZypperPackageManager(PackageManager):
                 process_count += 1
                 process_list_verbose += process_details[4].strip() + " (" + process_details[0].strip() + "), "  # process name and id
 
-        self.composite_logger.log_debug("[ZPM] - Processes requiring restart (" + str(process_count) + "): [" + process_list_verbose + "<eol>]")
+        self.composite_logger.log_debug("[ZPM] > Processes requiring restart (" + str(process_count) + "): [" + process_list_verbose + "<eol>]")
         return process_count != 0  # True if there were any
     # endregion Reboot Management
 


### PR DESCRIPTION
This PR makes no functional changes to the code beyond:
- more clarity in logging origin through tagging with source file acronyms. 
- deprioritizing some logs (debug to verbose) that are in years-old highly stable code paths.

This is similar to code that's already gone in for Apt.