### PR TITLE
Remove a comma the end of the tombstone_name to fix json deserialization 

### DIFF
--- a/src/core/src/service_interfaces/StatusHandler.py
+++ b/src/core/src/service_interfaces/StatusHandler.py
@@ -1139,7 +1139,7 @@ class StatusHandler(object):
             Patch Name: 20 additional updates of classification <classification_name> reported.
             Classification: [Critical, Security, Other]
         """
-        tombstone_name = str(patches_count_by_classification) + ' additional updates of classification ' + classification_name + ' reported',
+        tombstone_name = str(patches_count_by_classification) + ' additional updates of classification ' + classification_name + ' reported'
         return {
             'patchId': 'Truncated_patch_list_id',
             'name': tombstone_name,

--- a/src/core/tests/Test_StatusHandlerTruncation.py
+++ b/src/core/tests/Test_StatusHandlerTruncation.py
@@ -855,7 +855,7 @@ class TestStatusHandlerTruncation(unittest.TestCase):
         truncated_substatus_msg = self.__get_message_json_from_substatus(truncated_substatus_file_data)
         self.assertEqual(truncated_substatus_msg['patches'][-1]['patchId'], "Truncated_patch_list_id")
         self.assertEqual(truncated_substatus_msg['patches'][-1]['classifications'], ['Other'])
-        self.assertTrue("additional updates of classification" in truncated_substatus_msg['patches'][-1]['name'][0])
+        self.assertTrue("additional updates of classification" in truncated_substatus_msg['patches'][-1]['name'])
 
         if tombstone_count >= 2:
             self.assertEqual(truncated_substatus_msg['patches'][-2]['patchId'], "Truncated_patch_list_id")


### PR DESCRIPTION
[x] the extra comma at the end of tombstone_name is causing json deserialization error, this extra comma is creating a tuple/list when tombstone is output in status file, so during json deserialization step of the data it will be unable to deserialize the tuple since it's supposed to be a string
[x] prior code change:
![image](https://github.com/user-attachments/assets/a3410daa-dd73-4b18-8f69-a8a7b2458e12)
[x] post code change:
<img width="547" alt="image" src="https://github.com/user-attachments/assets/0a882402-b02c-4822-b46b-71ca87dccce5" />
[x]
![image](https://github.com/user-attachments/assets/95db0d2b-b9f6-45f8-90dd-87edc4a2ff99)
