### PR TITLE
Fix excessive disk logging

### DIFF
--- a/src/core/src/local_loggers/FileLogger.py
+++ b/src/core/src/local_loggers/FileLogger.py
@@ -40,7 +40,7 @@ class FileLogger(object):
     def write(self, message, fail_silently=True):
         try:
             if len(message) > self.max_msg_size:
-                message = self.__truncate_message(message=message, max_size=self.max_msg_size)
+                message = message[:self.max_msg_size]
             if self.log_file_handle is not None:
                 self.log_file_handle.write(message)
         except Exception as error:
@@ -54,7 +54,7 @@ class FileLogger(object):
         """ A best-effort attempt to write out errors where writing to the primary log file was interrupted"""
         try:
             if len(message) > self.max_msg_size:
-                message = self.__truncate_message(message=message, max_size=self.max_msg_size)
+                message = message[:self.max_msg_size]
             with self.env_layer.file_system.open(self.log_failure_log_file, 'a+') as fail_log:
                 timestamp = self.env_layer.datetime.timestamp()
                 fail_log.write("\n" + timestamp + "> " + message)
@@ -72,15 +72,4 @@ class FileLogger(object):
                 self.write(str(message_at_close))
             self.log_file_handle.close()
             self.log_file_handle = None     # Not having this can cause 'I/O exception on closed file' exceptions
-
-    def __truncate_message(self, message, max_size):
-        # type(str, int) -> str
-        """ Truncate message to a max size in bytes (32MB) at a safe point (end of the line avoid json serialization error) """
-        truncated_message = message[:max_size]
-        last_newline_index = truncated_message.rfind("\n")
-
-        if last_newline_index != -1:
-            return truncated_message[:last_newline_index + 1]
-
-        return truncated_message
 

--- a/src/core/src/local_loggers/FileLogger.py
+++ b/src/core/src/local_loggers/FileLogger.py
@@ -68,14 +68,14 @@ class FileLogger(object):
             if message_at_close is not None:
                 self.write(str(message_at_close))
             self.log_file_handle.close()
-            self.log_file_handle = None     # Not having this can cause 'I/O exception on closed file' exceptions
+            self.log_file_handle = None  # Reset to prevent 'I/O exception on closed file' exceptions
 
-    def truncate_message(self, message, max_size = 4 * 1024 * 1024):
-        """ Truncate message to a max size in bytes (4MB) at a safe point (end of line) to avoid excessively disk logging """
+    def truncate_message(self, message, max_size=32 * 1024 * 1024):
+        """ Truncate message to a max size in bytes (32MB) at a safe point (end of line) to avoid excessively disk logging """
         if len(message) > max_size:
             truncated_message = message[:max_size]
             last_newline_index = truncated_message.rfind("\n")
-            
+
             if last_newline_index != -1:
                 return truncated_message[:last_newline_index + 1]
             else:

--- a/src/core/src/local_loggers/FileLogger.py
+++ b/src/core/src/local_loggers/FileLogger.py
@@ -68,7 +68,7 @@ class FileLogger(object):
             if message_at_close is not None:
                 self.write(str(message_at_close))
             self.log_file_handle.close()
-            self.log_file_handle = None  # Reset to prevent 'I/O exception on closed file' exceptions
+            self.log_file_handle = None     # Not having this can cause 'I/O exception on closed file' exceptions
 
     def truncate_message(self, message, max_size=32 * 1024 * 1024):
         """ Truncate message to a max size in bytes (32MB) at a safe point (end of line) to avoid excessively disk logging """

--- a/src/core/tests/Test_FileLogger.py
+++ b/src/core/tests/Test_FileLogger.py
@@ -1,0 +1,97 @@
+# Copyright 2025 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires Python 2.7+
+import unittest
+from core.src.local_loggers.FileLogger import FileLogger
+
+
+class MockFileHandle:
+    def __init__(self, raise_on_write=False):
+        self.raise_on_write = raise_on_write
+        self.contents = ""
+        self.closed = False
+    
+    def write(self, message):
+        if self.raise_on_write:
+            raise Exception("Mock write exception")
+        self.contents += message
+    
+    def flush(self):
+        pass
+
+    def close(self):
+        self.closed = True
+
+    def fileno(self):
+        return 1
+
+
+class MockFileSystem:
+    def open(self, file_path, mode):
+        return MockFileHandle()
+
+
+class MockEnvLayer:
+    def __init__(self):
+        self.file_system = MockFileSystem()
+        self.datetime = self
+    
+    def timestampe(self):
+        return "2025-01-01T00:00:00Z"
+
+
+class TestFileLogger(unittest.TestCase):
+    def setUp(self):
+        self.mock_env_layer = MockEnvLayer()
+        self.log_file = "test.log"
+        self.file_logger = FileLogger(self.mock_env_layer, self.log_file)
+    
+    def test_write(self):
+        message = "Test message"
+        self.file_logger.write(message)
+        self.assertEqual(self.file_logger.log_file_handle.contents, message)
+
+    def test_no_truncation(self):
+        message = "No truncation"
+        result = self.file_logger.truncate_message(message)
+        self.assertEqual(result, message)
+    
+    def test_write_truncated_message(self):
+        message = "A" * (32 * 1024 * 1024 - 10) + "\nExtra line.\n"  # 32MB - 10 bytes to include newlines
+        truncate_message = self.file_logger.truncate_message(message)
+        self.file_logger.write(message)
+        self.assertTrue(truncate_message.endswith("\n"))
+        self.assertTrue(len(truncate_message) < (32 * 1024 * 1024 + 1))
+        self.assertIn(truncate_message, self.file_logger.log_file_handle.contents)
+        self.assertNotIn(message, self.file_logger.log_file_handle.contents)
+
+    def test_write_silent_failure(self):
+        self.file_logger.log_file_handle = MockFileHandle(raise_on_write=True)
+        try:
+            self.file_logger.write("Test message", fail_silently=True)
+        except Exception:
+            self.fail("raise an exception when fail_silently=True")
+
+    def test_write_non_silent_failure(self):
+        self.file_logger.log_file_handle = MockFileHandle(raise_on_write=True)
+
+        with self.assertRaises(Exception) as context:
+            self.file_logger.write("test message", fail_silently=False)
+
+        self.assertIn("Fatal exception trying to write to log file", str(context.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/core/tests/Test_FileLogger.py
+++ b/src/core/tests/Test_FileLogger.py
@@ -97,15 +97,6 @@ class TestFileLogger(unittest.TestCase):
         self.file_logger.write(message)
         self.assertEqual(len(self.file_logger.log_file_handle.contents), max_msg_size)
 
-    def test_write_message_with_newline(self):
-        """ Test FileLogger truncate_message() truncation apply with newline """
-        max_msg_size = 32 * 1024 * 1024
-        message = "A" * (32 * 1024 * 1024 - 10) + "\nExtra line.\n"  # 32MB with newlines
-        self.file_logger.write(message)
-        self.assertTrue(self.file_logger.log_file_handle.contents.endswith("\n"))
-        self.assertTrue(len(self.file_logger.log_file_handle.contents), max_msg_size)
-        self.assertNotIn(message, self.file_logger.log_file_handle.contents)
-
     def test_write_false_silent_failure(self):
         """ Test FileLogger write(), throws exception raise_on_write is true """
         self.file_logger.log_file_handle = MockFileHandle(raise_on_write=True)


### PR DESCRIPTION
[x] pr to address bug item 29588036: Prevent excessive logging to disk in runway OS-error conditions
[x] add truncation logic to handle runway logging to disk on machines when there's error, especially network issue. the truncation will cut the message at a safe point at newline and max log content size in byte is set at 32MB to prevent disk space exhaustion on machine
[x] add unit tests