### PR TITLE
Bugfix: Unit tests broken in Python 3.12

### DIFF
--- a/src/core/tests/Test_CoreMain.py
+++ b/src/core/tests/Test_CoreMain.py
@@ -1004,8 +1004,8 @@ class TestCoreMain(unittest.TestCase):
         CoreMain(argument_composer.get_composed_arguments())
 
         # check values of health_store_id and maintenance_run_id
-        self.assertEquals(runtime.execution_config.health_store_id, None)
-        self.assertEquals(runtime.execution_config.maintenance_run_id, None)
+        self.assertEqual(runtime.execution_config.health_store_id, None)
+        self.assertEqual(runtime.execution_config.maintenance_run_id, None)
 
         # check telemetry events
         self.__check_telemetry_events(runtime)

--- a/src/core/tests/Test_UbuntuProClient.py
+++ b/src/core/tests/Test_UbuntuProClient.py
@@ -404,6 +404,5 @@ class TestUbuntuProClient(unittest.TestCase):
         package_manager.ubuntu_pro_client.get_ubuntu_pro_client_updates = backup_get_ubuntu_pro_client_updates
         obj.mock_unimport_uaclient_update_module()
 
-
 if __name__ == '__main__':
     unittest.main()

--- a/src/core/tests/Test_UbuntuProClient.py
+++ b/src/core/tests/Test_UbuntuProClient.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 #
 # Requires Python 2.7+
-import imp
 import sys
 import types
 import unittest
+if sys.version_info[0] < 3:
+    import imp
 
 from core.src.bootstrap.Constants import Constants
 from core.tests.library.ArgumentComposer import ArgumentComposer
@@ -66,7 +67,10 @@ class MockVersionResult(MockSystemModules):
             mock_method = getattr(self, method_name)
             setattr(sys.modules['uaclient.api.u.pro.version.v1'], mock_name, mock_method)
         else:
-            version_module = imp.new_module('version_module')
+            if sys.version_info[0] < 3:
+                version_module = imp.new_module('version_module')
+            else:
+                version_module = types.ModuleType('version_module')
             mock_method = getattr(self, method_name)
             setattr(version_module, mock_name, mock_method)
             self.assign_sys_modules_with_mock_module('uaclient.api.u.pro.version.v1', version_module)
@@ -403,6 +407,7 @@ class TestUbuntuProClient(unittest.TestCase):
 
         package_manager.ubuntu_pro_client.get_ubuntu_pro_client_updates = backup_get_ubuntu_pro_client_updates
         obj.mock_unimport_uaclient_update_module()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/core/tests/Test_UbuntuProClient.py
+++ b/src/core/tests/Test_UbuntuProClient.py
@@ -93,7 +93,8 @@ class MockRebootRequiredResult(MockSystemModules):
             sys.modules['uaclient.api.u.pro.security.status.reboot_required.v1'] = types.ModuleType('reboot_module')
             mock_method = getattr(self, method_name)
             setattr(sys.modules['uaclient.api.u.pro.security.status.reboot_required.v1'], mock_name, mock_method)
-        else:
+        else:  # Python 2 only
+            import imp
             reboot_module = imp.new_module('reboot_module')
             mock_method = getattr(self, method_name)
             setattr(reboot_module, mock_name, mock_method)
@@ -113,7 +114,7 @@ class UpdateInfo:
 
 class MockUpdatesResult(MockSystemModules):
 
-    def __init__(self, updates = []):
+    def __init__(self, updates=[]):
         self.updates = updates
 
     def mock_update_list_with_all_update_types(self):
@@ -138,6 +139,7 @@ class MockUpdatesResult(MockSystemModules):
             mock_method = getattr(self, method_name)
             setattr(sys.modules['uaclient.api.u.pro.packages.updates.v1'], mock_name, mock_method)
         else:
+            import imp
             update_module = imp.new_module('update_module')
             mock_method = getattr(self, method_name)
             setattr(update_module, mock_name, mock_method)

--- a/src/core/tests/Test_UbuntuProClient.py
+++ b/src/core/tests/Test_UbuntuProClient.py
@@ -16,6 +16,8 @@
 import sys
 import types
 import unittest
+if sys.version_info < (3, 12):
+    import imp
 
 from core.src.bootstrap.Constants import Constants
 from core.tests.library.ArgumentComposer import ArgumentComposer
@@ -64,8 +66,7 @@ class MockVersionResult(MockSystemModules):
             sys.modules['uaclient.api.u.pro.version.v1'] = types.ModuleType('version_module')
             mock_method = getattr(self, method_name)
             setattr(sys.modules['uaclient.api.u.pro.version.v1'], mock_name, mock_method)
-        else:   # Python 2 only
-            import imp
+        else:
             version_module = imp.new_module('version_module')
             mock_method = getattr(self, method_name)
             setattr(version_module, mock_name, mock_method)
@@ -93,8 +94,7 @@ class MockRebootRequiredResult(MockSystemModules):
             sys.modules['uaclient.api.u.pro.security.status.reboot_required.v1'] = types.ModuleType('reboot_module')
             mock_method = getattr(self, method_name)
             setattr(sys.modules['uaclient.api.u.pro.security.status.reboot_required.v1'], mock_name, mock_method)
-        else:  # Python 2 only
-            import imp
+        else:
             reboot_module = imp.new_module('reboot_module')
             mock_method = getattr(self, method_name)
             setattr(reboot_module, mock_name, mock_method)
@@ -139,7 +139,6 @@ class MockUpdatesResult(MockSystemModules):
             mock_method = getattr(self, method_name)
             setattr(sys.modules['uaclient.api.u.pro.packages.updates.v1'], mock_name, mock_method)
         else:
-            import imp
             update_module = imp.new_module('update_module')
             mock_method = getattr(self, method_name)
             setattr(update_module, mock_name, mock_method)

--- a/src/core/tests/Test_UbuntuProClient.py
+++ b/src/core/tests/Test_UbuntuProClient.py
@@ -16,8 +16,6 @@
 import sys
 import types
 import unittest
-if sys.version_info[0] < 3:
-    import imp
 
 from core.src.bootstrap.Constants import Constants
 from core.tests.library.ArgumentComposer import ArgumentComposer
@@ -66,11 +64,9 @@ class MockVersionResult(MockSystemModules):
             sys.modules['uaclient.api.u.pro.version.v1'] = types.ModuleType('version_module')
             mock_method = getattr(self, method_name)
             setattr(sys.modules['uaclient.api.u.pro.version.v1'], mock_name, mock_method)
-        else:
-            if sys.version_info[0] < 3:
-                version_module = imp.new_module('version_module')
-            else:
-                version_module = types.ModuleType('version_module')
+        else:   # Python 2 only
+            import imp
+            version_module = imp.new_module('version_module')
             mock_method = getattr(self, method_name)
             setattr(version_module, mock_name, mock_method)
             self.assign_sys_modules_with_mock_module('uaclient.api.u.pro.version.v1', version_module)

--- a/src/extension/tests/Test_ExtEnvHandler.py
+++ b/src/extension/tests/Test_ExtEnvHandler.py
@@ -233,7 +233,7 @@ class TestExtEnvHandler(unittest.TestCase):
         temp_folder_path = ext_env_handler.get_temp_folder()
 
         # validate path
-        self.assertEquals(temp_folder_path, ext_env_handler.temp_folder)
+        self.assertEqual(temp_folder_path, ext_env_handler.temp_folder)
 
         shutil.rmtree(test_dir)
 


### PR DESCRIPTION
Includes fixes for unit tests found non-functional in Python 3.12 when testing other code.

- assertEquals -> assertEqual
- imp module replaced with alternate for Python 3 compatibility
