### PR TITLE
Feature: Adding support for Azure Linux 2.0 in Tdnf Package Manager

### DIFF
--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -198,6 +198,7 @@ class Constants(object):
     SUSE = 'SUSE'
     CENTOS = 'CentOS'
     AZURE_LINUX = 'Microsoft Azure Linux'
+    COMMON_BASE_LINUX_MARINER = 'Common Base Linux Mariner'
 
     # Package Managers
     APT = 'apt'

--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -197,8 +197,7 @@ class Constants(object):
     RED_HAT = 'Red Hat'
     SUSE = 'SUSE'
     CENTOS = 'CentOS'
-    AZURE_LINUX = 'Microsoft Azure Linux'
-    COMMON_BASE_LINUX_MARINER = 'Common Base Linux Mariner'
+    AZURE_LINUX = ['Microsoft Azure Linux', 'Common Base Linux Mariner']
 
     # Package Managers
     APT = 'apt'

--- a/src/core/src/bootstrap/EnvLayer.py
+++ b/src/core/src/bootstrap/EnvLayer.py
@@ -60,12 +60,15 @@ class EnvLayer(object):
         # Constant paths
         self.etc_environment_file_path = "/etc/environment"
 
+    @staticmethod
+    def is_distro_azure_linux(distro_name):
+        return any(x in distro_name for x in Constants.AZURE_LINUX)
+
     def get_package_manager(self):
         """ Detects package manager type """
         ret = None
 
-        distro_name = self.platform.linux_distribution()[0]
-        if distro_name == Constants.AZURE_LINUX or distro_name == Constants.COMMON_BASE_LINUX_MARINER:
+        if self.is_distro_azure_linux(str(self.platform.linux_distribution())):
             code, out = self.run_command_output('which tdnf', False, False)
             if code == 0:
                 ret = Constants.TDNF

--- a/src/core/src/bootstrap/EnvLayer.py
+++ b/src/core/src/bootstrap/EnvLayer.py
@@ -64,7 +64,8 @@ class EnvLayer(object):
         """ Detects package manager type """
         ret = None
 
-        if self.platform.linux_distribution()[0] == Constants.AZURE_LINUX:
+        distro_name = self.platform.linux_distribution()[0]
+        if distro_name == Constants.AZURE_LINUX or distro_name == Constants.COMMON_BASE_LINUX_MARINER:
             code, out = self.run_command_output('which tdnf', False, False)
             if code == 0:
                 ret = Constants.TDNF

--- a/src/core/src/package_managers/TdnfPackageManager.py
+++ b/src/core/src/package_managers/TdnfPackageManager.py
@@ -76,8 +76,9 @@ class TdnfPackageManager(PackageManager):
 
         # if an Auto Patching request comes in on a Azure Linux machine with Security and/or Critical classifications selected, we need to install all patches, since classifications aren't available in Azure Linux repository
         installation_included_classifications = [] if execution_config.included_classifications_list is None else execution_config.included_classifications_list
+        linux_distribution = str(env_layer.platform.linux_distribution())
         if execution_config.health_store_id is not str() and execution_config.operation.lower() == Constants.INSTALLATION.lower() \
-                and Constants.AZURE_LINUX in str(env_layer.platform.linux_distribution()) \
+                and (Constants.AZURE_LINUX in linux_distribution or Constants.COMMON_BASE_LINUX_MARINER in linux_distribution) \
                 and 'Critical' in installation_included_classifications and 'Security' in installation_included_classifications:
             self.composite_logger.log_debug("Updating classifications list to install all patches for the Auto Patching request since classification based patching is not available on Azure Linux machines")
             execution_config.included_classifications_list = [Constants.PackageClassification.CRITICAL, Constants.PackageClassification.SECURITY, Constants.PackageClassification.OTHER]

--- a/src/core/src/package_managers/TdnfPackageManager.py
+++ b/src/core/src/package_managers/TdnfPackageManager.py
@@ -76,9 +76,8 @@ class TdnfPackageManager(PackageManager):
 
         # if an Auto Patching request comes in on a Azure Linux machine with Security and/or Critical classifications selected, we need to install all patches, since classifications aren't available in Azure Linux repository
         installation_included_classifications = [] if execution_config.included_classifications_list is None else execution_config.included_classifications_list
-        linux_distribution = str(env_layer.platform.linux_distribution())
         if execution_config.health_store_id is not str() and execution_config.operation.lower() == Constants.INSTALLATION.lower() \
-                and (Constants.AZURE_LINUX in linux_distribution or Constants.COMMON_BASE_LINUX_MARINER in linux_distribution) \
+                and (env_layer.is_distro_azure_linux(str(env_layer.platform.linux_distribution()))) \
                 and 'Critical' in installation_included_classifications and 'Security' in installation_included_classifications:
             self.composite_logger.log_debug("Updating classifications list to install all patches for the Auto Patching request since classification based patching is not available on Azure Linux machines")
             execution_config.included_classifications_list = [Constants.PackageClassification.CRITICAL, Constants.PackageClassification.SECURITY, Constants.PackageClassification.OTHER]

--- a/src/core/tests/Test_EnvLayer.py
+++ b/src/core/tests/Test_EnvLayer.py
@@ -33,8 +33,11 @@ class TestExecutionConfig(unittest.TestCase):
     def mock_linux_distribution(self):
         return ['test', 'test', 'test']
 
-    def mock_linux_distribution_to_return_azure_linux(self):
+    def mock_linux_distribution_to_return_azure_linux_3(self):
         return ['Microsoft Azure Linux', '3.0', '']
+
+    def mock_linux_distribution_to_return_azure_linux_2(self):
+        return ['Common Base Linux Mariner', '2.0', '']
 
     def mock_run_command_for_apt(self, cmd, no_output=False, chk_err=False):
         if cmd.find("which apt-get") > -1:
@@ -66,8 +69,9 @@ class TestExecutionConfig(unittest.TestCase):
 
         test_input_output_table = [
             [self.mock_run_command_for_apt, self.mock_linux_distribution, Constants.APT],
-            [self.mock_run_command_for_tdnf, self.mock_linux_distribution_to_return_azure_linux, Constants.TDNF],
-            [self.mock_run_command_for_yum, self.mock_linux_distribution_to_return_azure_linux, None],  # check for Azure Linux machine which does not have tdnf
+            [self.mock_run_command_for_tdnf, self.mock_linux_distribution_to_return_azure_linux_3, Constants.TDNF],
+            [self.mock_run_command_for_yum, self.mock_linux_distribution_to_return_azure_linux_3, None],  # check for Azure Linux machine which does not have tdnf
+            [self.mock_run_command_for_tdnf, self.mock_linux_distribution_to_return_azure_linux_2, Constants.TDNF],
             [self.mock_run_command_for_yum, self.mock_linux_distribution, Constants.YUM],
             [self.mock_run_command_for_zypper, self.mock_linux_distribution, Constants.ZYPPER],
         ]


### PR DESCRIPTION
Expanding Tdnf Package Manager to support Azure Linux 2.0

Inn VM Test Logs:
[x] Azure Linux 2.0 (Common Base Linux): 
&nbsp;&nbsp;&nbsp;&nbsp; - [4.core.log](https://github.com/user-attachments/files/19806437/4.core.log)
&nbsp;&nbsp;&nbsp;&nbsp; - [4.status.txt](https://github.com/user-attachments/files/19806471/4.status.txt)
[x] Pre-Existing Azure Linux 3.0 code compatibility test 
&nbsp;&nbsp;&nbsp;&nbsp; - [1.core.log](https://github.com/user-attachments/files/19806490/1.core.log)
&nbsp;&nbsp;&nbsp;&nbsp; - [1.status.txt](https://github.com/user-attachments/files/19806492/1.status.txt)
