### PR TITLE
Bugfix: Optional parameter use in run_command_output & legacy return_code

### DIFF
--- a/src/core/src/bootstrap/EnvLayer.py
+++ b/src/core/src/bootstrap/EnvLayer.py
@@ -135,8 +135,9 @@ class EnvLayer(object):
             print("Error occurred while getting environment variable [Variable={0}][Exception={1}]".format(str(var_name), repr(error)))
             if raise_if_not_success:
                 raise
+            return None
 
-    def run_command_output(self, cmd, no_output, chk_err=True):
+    def run_command_output(self, cmd, no_output=False, chk_err=True):
         # type: (str, bool, bool) -> (int, any)
         """ Wrapper for subprocess.check_output. Execute 'cmd'. Returns return code and STDOUT, trapping expected exceptions. Reports exceptions to Error if chk_err parameter is True """
 
@@ -185,7 +186,7 @@ class EnvLayer(object):
             output = subprocess.check_output(no_output, cmd, stderr=subprocess.STDOUT, shell=True)
         except subprocess.CalledProcessError as e:
             if chk_err:
-                print("Error: CalledProcessError. [Code={0}][Command={1}][Result={2}]".format(str(e.returncode), e.cmd, self.__convert_process_output_to_ascii(e.output[:-1])), file=sys.stdout)
+                print("Error: CalledProcessError. [Code={0}][Command={1}][Result={2}]".format(str(e.return_code), e.cmd, self.__convert_process_output_to_ascii(e.output[:-1])), file=sys.stdout)
             if no_output:
                 return e.return_code, None
             else:

--- a/src/extension/src/EnvLayer.py
+++ b/src/extension/src/EnvLayer.py
@@ -97,7 +97,7 @@ class EnvLayer(object):
                 no_output, cmd, stderr=subprocess.STDOUT, shell=True)
         except subprocess.CalledProcessError as e:
             if chk_err:
-                print("Error: CalledProcessError.  Error Code is: " + str(e.returncode), file=sys.stdout)
+                print("Error: CalledProcessError.  Error Code is: " + str(e.return_code), file=sys.stdout)
                 print("Error: CalledProcessError.  Command string was: " + e.cmd, file=sys.stdout)
                 print("Error: CalledProcessError.  Command result was: " + self.__convert_process_output_to_ascii(e.output[:-1]), file=sys.stdout)
             if no_output:


### PR DESCRIPTION
Handling an issue caught in Canary on auto-assessment code paths:
_ERROR:Error: TypeError("run_command_output() missing 1 required positional argument: 'no_output'")_

In reviewing this closer, there is also a historical bug in run_command_output CalledProcessError usage where the shadowed class entity (returncode) is used instead of the correct attribute (return_code) in an error log path. 