### PR TITLE
Engg. hygiene: Explicit Codecov workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: Workflow for Codecov
+permissions:
+  contents: read
 on:
   push:
     branches: [master]


### PR DESCRIPTION
Potential fix for [https://github.com/Azure/LinuxPatchExtension/security/code-scanning/1](https://github.com/Azure/LinuxPatchExtension/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's actions, it primarily needs read access to repository contents and write access to pull requests (if applicable). For uploading coverage reports, no additional permissions are required as the `codecov-action` uses the `CODECOV_TOKEN` secret.

The `permissions` block will be added at the root level to apply to all jobs in the workflow. If any job requires different permissions, we can override them within the specific job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
