### PR TITLE
[AzL3Tdnf] Renaming TdnfPackageManager to AzL3PackageManager

### DIFF
--- a/src/core/src/bootstrap/ConfigurationFactory.py
+++ b/src/core/src/bootstrap/ConfigurationFactory.py
@@ -37,7 +37,7 @@ from core.src.local_loggers.FileLogger import FileLogger
 from core.src.local_loggers.CompositeLogger import CompositeLogger
 
 from core.src.package_managers.AptitudePackageManager import AptitudePackageManager
-from core.src.package_managers.TdnfPackageManager import TdnfPackageManager
+from core.src.package_managers.AzL3TdnfPackageManager import AzL3TdnfPackageManager
 from core.src.package_managers.YumPackageManager import YumPackageManager
 from core.src.package_managers.ZypperPackageManager import ZypperPackageManager
 
@@ -70,17 +70,17 @@ class ConfigurationFactory(object):
 
         self.configurations = {
             'apt_prod_config':    self.new_prod_configuration(Constants.APT, AptitudePackageManager),
-            'tdnf_prod_config': self.new_prod_configuration(Constants.TDNF, TdnfPackageManager),
+            'tdnf_prod_config': self.new_prod_configuration(Constants.TDNF, AzL3TdnfPackageManager),
             'yum_prod_config':    self.new_prod_configuration(Constants.YUM, YumPackageManager),
             'zypper_prod_config': self.new_prod_configuration(Constants.ZYPPER, ZypperPackageManager),
 
             'apt_dev_config':     self.new_dev_configuration(Constants.APT, AptitudePackageManager),
-            'tdnf_dev_config': self.new_dev_configuration(Constants.TDNF, TdnfPackageManager),
+            'tdnf_dev_config': self.new_dev_configuration(Constants.TDNF, AzL3TdnfPackageManager),
             'yum_dev_config':     self.new_dev_configuration(Constants.YUM, YumPackageManager),
             'zypper_dev_config':  self.new_dev_configuration(Constants.ZYPPER, ZypperPackageManager),
 
             'apt_test_config':    self.new_test_configuration(Constants.APT, AptitudePackageManager),
-            'tdnf_test_config': self.new_test_configuration(Constants.TDNF, TdnfPackageManager),
+            'tdnf_test_config': self.new_test_configuration(Constants.TDNF, AzL3TdnfPackageManager),
             'yum_test_config':    self.new_test_configuration(Constants.YUM, YumPackageManager),
             'zypper_test_config': self.new_test_configuration(Constants.ZYPPER, ZypperPackageManager)
         }

--- a/src/core/tests/Test_AzL3TdnfPackageManager.py
+++ b/src/core/tests/Test_AzL3TdnfPackageManager.py
@@ -30,7 +30,7 @@ from core.tests.library.RuntimeCompositor import RuntimeCompositor
 from core.src.external_dependencies import distro
 
 
-class TestTdnfPackageManager(unittest.TestCase):
+class TestAzL3TdnfPackageManager(unittest.TestCase):
     def setUp(self):
         self.runtime = RuntimeCompositor(ArgumentComposer().get_composed_arguments(), True, Constants.TDNF)
         self.container = self.runtime.container


### PR DESCRIPTION
This is a simple renaming of TdnfPackageManager to AzL3PackageManager. Will be followed up by separating generic TdnfPackageManager implementations from Azure Linux 3 specific ones: https://github.com/Azure/LinuxPatchExtension/pull/331