### PR TITLE
Bugfix: Fix yum output parsing to avoid false reboot detection

### DIFF
--- a/src/core/src/package_managers/YumPackageManager.py
+++ b/src/core/src/package_managers/YumPackageManager.py
@@ -1062,7 +1062,7 @@ class YumPackageManager(PackageManager):
                     continue
 
             process_details = re.split(r'\s+', line.strip())
-            if len(process_details) < 7:
+            if len(process_details) < 7 or line.find("packages excluded") >= 0:
                 self.composite_logger.log_verbose("[YPM] > Inapplicable line: " + str(line))
                 continue
             else:


### PR DESCRIPTION
The leading number (`62`) was incorrectly interpreted as a process ID, which
resulted in false positives during reboot-required checks and incorrect update
status reporting in Azure Update Manager.


### References
- Incident 447902558  
- ADO Bug: [AzGPS][Linux][Guest][Arc][AWS][CRI] Yum incorrectly parsing data for reboot check in AWS  
- Related Arc fix: PR 8873077 (format validation for reboot check)

---

### Impact
- Prevents false reboot detection caused by yum informational output
- Improves accuracy of update status and counters reported by AUM
- No functional change for valid yum process parsing