### PR TITLE
Safety net: Explicitly block Azure Linux 4 and RHEL 10 until LPE support is available

### DIFF
--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -197,7 +197,7 @@ class Constants(object):
     RED_HAT = 'Red Hat'
     SUSE = 'SUSE'
     CENTOS = 'CentOS'
-    AZURE_LINUX = ['Microsoft Azure Linux', 'Common Base Linux Mariner']
+    AZURE_LINUX = ['Azure Linux', 'Microsoft Azure Linux', 'Common Base Linux Mariner']
 
     # Package Managers
     APT = 'apt'

--- a/src/core/src/bootstrap/EnvLayer.py
+++ b/src/core/src/bootstrap/EnvLayer.py
@@ -49,7 +49,7 @@ class EnvLayer(object):
 
     def is_distro_azure_linux_3_or_beyond(self):
         # type: () -> bool
-        """ Checks if the current distro is Azure Linux 3 """
+        """ Checks if the current distro is Azure Linux 3 or beyond """
         if self.is_distro_azure_linux(self.platform.linux_distribution()):
             version = distro.os_release_attr('version')
             major = version.split('.')[0] if version else None
@@ -62,7 +62,19 @@ class EnvLayer(object):
         if platform.system() == 'Windows':
             return Constants.APT
 
+        version = distro.os_release_attr('version')
+        major = version.split('.')[0] if version else None
+        os_id = distro.id()
+
+        # Check for Azure Linux
         if self.is_distro_azure_linux(str(self.platform.linux_distribution())):
+            # Azure Linux 4 not yet supported
+            if major is not None and int(major) >= 4:
+                error_msg = "Azure Linux 4 is not yet supported in your region. Please review aka.ms/LinuxPatchExtension for more information."
+                print("Error: {0}".format(error_msg))
+                raise Exception(error_msg)
+
+            # Azure Linux 3 and below use TDNF
             code, out = self.run_command_output('which tdnf', False, False)
             if code == 0:
                 return Constants.TDNF
@@ -70,7 +82,13 @@ class EnvLayer(object):
                 print("Error: Expected package manager tdnf not found on this Azure Linux VM.")
                 return str()
 
-        # choose default package manager
+        # Check for RHEL 10 (not yet supported)
+        if os_id == "rhel" and major is not None and int(major) >= 10:
+            error_msg = "RHEL 10 is not yet supported in your region. Please review aka.ms/LinuxPatchExtension for more information."
+            print("Error: {0}".format(error_msg))
+            raise Exception(error_msg)
+
+        # Choose default package manager
         package_manager_map = (('apt-get', Constants.APT),
                                ('yum', Constants.YUM),
                                ('zypper', Constants.ZYPPER))

--- a/src/core/src/bootstrap/EnvLayer.py
+++ b/src/core/src/bootstrap/EnvLayer.py
@@ -93,7 +93,7 @@ class EnvLayer(object):
 
         # Check for unsupported distros
         if self.is_distro_azure_linux_4(os_name) or self.is_distro_rhel_10(os_name):
-            error_msg = "This distro is not yet supported in your region. Please review https://aka.ms/VMGuestPatchingCompatibility for more information. [Distro={0}]".format(str(os_name))
+            error_msg = "This distro is not yet supported in your region. Please review https://aka.ms/VMGuestPatchingCompatibility for more information. [Distro={0}][Version={1}][Code={2}]".format(str(os_name), os_version, os_code)
             print("Error: {0}".format(error_msg))
             return str()
 

--- a/src/core/src/bootstrap/EnvLayer.py
+++ b/src/core/src/bootstrap/EnvLayer.py
@@ -50,12 +50,10 @@ class EnvLayer(object):
     @staticmethod
     def __try_get_major_version():
         # type: () -> str or None
-        """ Attempts to get major version from distro.os_release_attr('version').
-        Returns major version as string or None if not available. """
+        """ Attempts to get major version from distro.os_release_attr('version').Returns major version as string or None if not available. """
         version = distro.os_release_attr('version')
         major = version.split('.')[0] if version else None
         return major
-
 
     def __is_matching_distro_and_version(self, distro_name, distro_to_match, version_to_match):
         # type: (str, str, int) -> bool
@@ -108,8 +106,7 @@ class EnvLayer(object):
                 print("Error: Expected package manager tdnf not found on this Azure Linux VM.")
                 return str()
 
-
-        # Choose default package manager
+        # choose default package manager
         package_manager_map = (('apt-get', Constants.APT),
                                ('yum', Constants.YUM),
                                ('zypper', Constants.ZYPPER))

--- a/src/core/src/bootstrap/EnvLayer.py
+++ b/src/core/src/bootstrap/EnvLayer.py
@@ -47,13 +47,21 @@ class EnvLayer(object):
     def is_distro_azure_linux(distro_name):
         return any(x in distro_name for x in Constants.AZURE_LINUX)
 
+    @staticmethod
+    def _get_major_version():
+        # type: () -> str
+        """ Extracts major version from distro.os_release_attr('version').
+        Returns major version as string or None if not available. """
+        version = distro.os_release_attr('version')
+        major = version.split('.')[0] if version else None
+        return major
+
     def is_distro_azure_linux_3_or_beyond(self):
         # type: () -> bool
         """ Checks if the current distro is Azure Linux 3 """
         if self.is_distro_azure_linux(self.platform.linux_distribution()):
-            version = distro.os_release_attr('version')
-            major = version.split('.')[0] if version else None
-            return major is not None and int(major) >= 3
+            major = self._get_major_version()
+            return major is not None and int(major) == 3
         return False
 
     def get_package_manager(self):
@@ -62,31 +70,20 @@ class EnvLayer(object):
         if platform.system() == 'Windows':
             return Constants.APT
 
-        version = distro.os_release_attr('version')
-        major = version.split('.')[0] if version else None
+        major = self._get_major_version()
         os_id = distro.id()
 
         # Check for Azure Linux
         if self.is_distro_azure_linux(str(self.platform.linux_distribution())):
-            # Azure Linux 4 not yet supported
-            if major is not None and int(major) == 4:
-                error_msg = "Azure Linux 4 is not yet supported in your region. Please review aka.ms/LinuxPatchExtension for more information."
-                print("Error: {0}".format(error_msg))
-                raise Exception(error_msg)
+            return self._get_azure_linux_package_manager(major)
 
-            # Azure Linux 3 and below use TDNF
-            code, out = self.run_command_output('which tdnf', False, False)
-            if code == 0:
-                return Constants.TDNF
-            else:
-                print("Error: Expected package manager tdnf not found on this Azure Linux VM.")
-                return str()
-
-        # Check for RHEL 10 (not yet supported)
-        if os_id == "rhel" and major is not None and int(major) == 10:
-            error_msg = "RHEL 10 is not yet supported in your region. Please review aka.ms/LinuxPatchExtension for more information."
-            print("Error: {0}".format(error_msg))
-            raise Exception(error_msg)
+        # Check for RHEL
+        if os_id == "rhel":
+            package_manager = self._get_rhel_package_manager(major)
+            # Helper will raise exception for unsupported versions (e.g., RHEL 10).
+            # If it returns a value, use it; otherwise fall through to default detect
+            if package_manager is not None:
+                return package_manager
 
         # Choose default package manager
         package_manager_map = (('apt-get', Constants.APT),
@@ -98,6 +95,38 @@ class EnvLayer(object):
                 return entry[1]
 
         return str()
+
+    def _get_azure_linux_package_manager(self, major):
+        # type: (str) -> str
+        """ Determines the package manager for Azure Linux based on version.
+        Azure Linux 3 and below use TDNF. Azure Linux 4 use DNF (not yet supported).
+        Logs error message if version is unsupported. """
+        # Azure Linux 4 not yet supported
+        if major is not None and int(major) == 4:
+            error_msg = "Azure Linux 4 is not yet supported in your region. Please review https://aka.ms/VMGuestPatchingCompatibility for more information."
+            print("Error: {0}".format(error_msg))
+            return str()
+
+        # Azure Linux 3 and below use TDNF
+        code, out = self.run_command_output('which tdnf', False, False)
+        if code == 0:
+            return Constants.TDNF
+        else:
+            print("Error: Expected package manager tdnf not found on this Azure Linux VM.")
+            return str()
+
+    def _get_rhel_package_manager(self, major):
+        # type: (str) -> str
+        """ Determines the package manager for RHEL based on version.
+        Returns DNF when RHEL 10+ is supported. Logs error message if unsupported. """
+        # RHEL 10 not yet supported
+        if major is not None and int(major) == 10:
+            error_msg = "RHEL 10 is not yet supported in your region. Please review https://aka.ms/VMGuestPatchingCompatibility for more information."
+            print("Error: {0}".format(error_msg))
+            return str()
+
+        # return None to allow default package manager detection
+        return None
 
     def set_env_var(self, var_name, var_value=str(), raise_if_not_success=False):
         # type: (str, str, bool) -> None

--- a/src/core/src/bootstrap/EnvLayer.py
+++ b/src/core/src/bootstrap/EnvLayer.py
@@ -49,7 +49,7 @@ class EnvLayer(object):
 
     def is_distro_azure_linux_3_or_beyond(self):
         # type: () -> bool
-        """ Checks if the current distro is Azure Linux 3 or beyond """
+        """ Checks if the current distro is Azure Linux 3 """
         if self.is_distro_azure_linux(self.platform.linux_distribution()):
             version = distro.os_release_attr('version')
             major = version.split('.')[0] if version else None
@@ -69,7 +69,7 @@ class EnvLayer(object):
         # Check for Azure Linux
         if self.is_distro_azure_linux(str(self.platform.linux_distribution())):
             # Azure Linux 4 not yet supported
-            if major is not None and int(major) >= 4:
+            if major is not None and int(major) == 4:
                 error_msg = "Azure Linux 4 is not yet supported in your region. Please review aka.ms/LinuxPatchExtension for more information."
                 print("Error: {0}".format(error_msg))
                 raise Exception(error_msg)
@@ -83,7 +83,7 @@ class EnvLayer(object):
                 return str()
 
         # Check for RHEL 10 (not yet supported)
-        if os_id == "rhel" and major is not None and int(major) >= 10:
+        if os_id == "rhel" and major is not None and int(major) == 10:
             error_msg = "RHEL 10 is not yet supported in your region. Please review aka.ms/LinuxPatchExtension for more information."
             print("Error: {0}".format(error_msg))
             raise Exception(error_msg)

--- a/src/core/src/bootstrap/EnvLayer.py
+++ b/src/core/src/bootstrap/EnvLayer.py
@@ -48,21 +48,40 @@ class EnvLayer(object):
         return any(x in distro_name for x in Constants.AZURE_LINUX)
 
     @staticmethod
-    def _get_major_version():
-        # type: () -> str
-        """ Extracts major version from distro.os_release_attr('version').
+    def __try_get_major_version():
+        # type: () -> str or None
+        """ Attempts to get major version from distro.os_release_attr('version').
         Returns major version as string or None if not available. """
         version = distro.os_release_attr('version')
         major = version.split('.')[0] if version else None
         return major
 
-    def is_distro_azure_linux_3_or_beyond(self):
-        # type: () -> bool
+
+    def __is_matching_distro_and_version(self, distro_name, distro_to_match, version_to_match):
+        # type: (str, str, int) -> bool
+        """ Checks if distro name matches and version matches the expected version.
+        Returns True if both distro and version match, False otherwise. """
+        if distro_to_match == Constants.AZURE_LINUX and not self.is_distro_azure_linux(str(distro_name)):
+            return False
+        elif distro_to_match == Constants.RED_HAT and not Constants.RED_HAT.lower() in str(distro_name).lower():
+            return False
+        major = self.__try_get_major_version()
+        return major is not None and int(major) == version_to_match
+
+    def is_distro_azure_linux_3(self, distro_name):
+        # type: (str) -> bool
         """ Checks if the current distro is Azure Linux 3 """
-        if self.is_distro_azure_linux(self.platform.linux_distribution()):
-            major = self._get_major_version()
-            return major is not None and int(major) == 3
-        return False
+        return self.__is_matching_distro_and_version(distro_name, Constants.AZURE_LINUX, version_to_match=3)
+
+    def is_distro_azure_linux_4(self, distro_name):
+        # type: (str) -> bool
+        """ Checks if the current distro is Azure Linux 4 """
+        return self.__is_matching_distro_and_version(distro_name, Constants.AZURE_LINUX, version_to_match=4)
+
+    def is_distro_rhel_10(self, distro_name):
+        # type: (str) -> bool
+        """ Checks if the current distro is RHEL 10 """
+        return self.__is_matching_distro_and_version(distro_name, Constants.RED_HAT, version_to_match=10)
 
     def get_package_manager(self):
         # type: () -> str
@@ -70,20 +89,25 @@ class EnvLayer(object):
         if platform.system() == 'Windows':
             return Constants.APT
 
-        major = self._get_major_version()
-        os_id = distro.id()
+        # platform.linux_distribution() returns a tuple with distro_name, version and a code
+        # Example: ['Azure Linux', '4.0', '']
+        os_name, os_version, os_code = self.platform.linux_distribution()
 
-        # Check for Azure Linux
-        if self.is_distro_azure_linux(str(self.platform.linux_distribution())):
-            return self._get_azure_linux_package_manager(major)
+        # Check for unsupported distros
+        if self.is_distro_azure_linux_4(os_name) or self.is_distro_rhel_10(os_name):
+            error_msg = "This distro is not yet supported in your region. Please review https://aka.ms/VMGuestPatchingCompatibility for more information. [Distro={0}]".format(str(os_name))
+            print("Error: {0}".format(error_msg))
+            return str()
 
-        # Check for RHEL
-        if os_id == "rhel":
-            package_manager = self._get_rhel_package_manager(major)
-            # Helper will raise exception for unsupported versions (e.g., RHEL 10).
-            # If it returns a value, use it; otherwise fall through to default detect
-            if package_manager is not None:
-                return package_manager
+        # Check for Azure Linux (3 and below use TDNF)
+        if self.is_distro_azure_linux(str(os_name)):
+            code, out = self.run_command_output('which tdnf', False, False)
+            if code == 0:
+                return Constants.TDNF
+            else:
+                print("Error: Expected package manager tdnf not found on this Azure Linux VM.")
+                return str()
+
 
         # Choose default package manager
         package_manager_map = (('apt-get', Constants.APT),
@@ -95,38 +119,6 @@ class EnvLayer(object):
                 return entry[1]
 
         return str()
-
-    def _get_azure_linux_package_manager(self, major):
-        # type: (str) -> str
-        """ Determines the package manager for Azure Linux based on version.
-        Azure Linux 3 and below use TDNF. Azure Linux 4 use DNF (not yet supported).
-        Logs error message if version is unsupported. """
-        # Azure Linux 4 not yet supported
-        if major is not None and int(major) == 4:
-            error_msg = "Azure Linux 4 is not yet supported in your region. Please review https://aka.ms/VMGuestPatchingCompatibility for more information."
-            print("Error: {0}".format(error_msg))
-            return str()
-
-        # Azure Linux 3 and below use TDNF
-        code, out = self.run_command_output('which tdnf', False, False)
-        if code == 0:
-            return Constants.TDNF
-        else:
-            print("Error: Expected package manager tdnf not found on this Azure Linux VM.")
-            return str()
-
-    def _get_rhel_package_manager(self, major):
-        # type: (str) -> str
-        """ Determines the package manager for RHEL based on version.
-        Returns DNF when RHEL 10+ is supported. Logs error message if unsupported. """
-        # RHEL 10 not yet supported
-        if major is not None and int(major) == 10:
-            error_msg = "RHEL 10 is not yet supported in your region. Please review https://aka.ms/VMGuestPatchingCompatibility for more information."
-            print("Error: {0}".format(error_msg))
-            return str()
-
-        # return None to allow default package manager detection
-        return None
 
     def set_env_var(self, var_name, var_value=str(), raise_if_not_success=False):
         # type: (str, str, bool) -> None

--- a/src/core/src/package_managers/AzL3TdnfPackageManager.py
+++ b/src/core/src/package_managers/AzL3TdnfPackageManager.py
@@ -71,7 +71,8 @@ class AzL3TdnfPackageManager(TdnfPackageManager):
         """ Check if the system meets the requirements for Azure Linux strict safe deployment and attempt to update TDNF if necessary """
         self.composite_logger.log_debug("[AzL3TDNF] Checking if system meets Azure Linux security updates requirements...")
         # Check if the system is Azure Linux 3.0 or beyond
-        if not self.env_layer.is_distro_azure_linux_3_or_beyond():
+        distro_name = str(self.env_layer.platform.linux_distribution()[0])
+        if not self.env_layer.is_distro_azure_linux_3(distro_name):
             self.composite_logger.log_error("[AzL3TDNF] The system does not meet minimum Azure Linux requirement of 3.0 or above for strict safe deployment. Defaulting to regular upgrades.")
             self.set_max_patch_publish_date()  # fall-back
             return False

--- a/src/core/tests/Test_EnvLayer.py
+++ b/src/core/tests/Test_EnvLayer.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 # Requires Python 2.7+
+import io
 import platform
+import sys
 import unittest
 from core.src.bootstrap.EnvLayer import EnvLayer
 from core.src.bootstrap.Constants import Constants
@@ -156,7 +158,7 @@ class TestExecutionConfig(unittest.TestCase):
         self.envlayer.platform.vm_name()
 
     def test_get_package_manager_azure_linux_4_not_supported(self):
-        """Test that Azure Linux 4 raises an exception"""
+        """Test that Azure Linux 4 logs unsupported message"""
         self.backup_platform_system = platform.system
         self.backup_linux_distribution = self.envlayer.platform.linux_distribution
         self.backup_distro_os_release_attr = distro.os_release_attr
@@ -165,9 +167,20 @@ class TestExecutionConfig(unittest.TestCase):
         self.envlayer.platform.linux_distribution = self.mock_linux_distribution_to_return_azure_linux_4
         distro.os_release_attr = self.mock_distro_os_release_attr_return_azure_linux_4
 
-        with self.assertRaises(Exception) as context:
-            self.envlayer.get_package_manager()
-        self.assertEqual(str(context.exception), "Azure Linux 4 is not yet supported in your region. Please review aka.ms/LinuxPatchExtension for more information.")
+        # Capture stdout to check for log message
+        captured_output = io.StringIO()
+        sys.stdout = captured_output
+
+        result = self.envlayer.get_package_manager()
+
+        sys.stdout = sys.__stdout__
+        output = captured_output.getvalue()
+
+        # Verify exact error message is logged
+        expected_msg = "Error: Azure Linux 4 is not yet supported in your region. Please review https://aka.ms/VMGuestPatchingCompatibility for more information."
+        self.assertEqual(expected_msg in output, True)
+        # Verify empty string is returned
+        self.assertEqual(result, "")
 
         # restore
         distro.os_release_attr = self.backup_distro_os_release_attr
@@ -175,7 +188,7 @@ class TestExecutionConfig(unittest.TestCase):
         platform.system = self.backup_platform_system
 
     def test_get_package_manager_rhel_10_not_supported(self):
-        """Test that RHEL 10 raises an exception"""
+        """Test that RHEL 10 logs unsupported message"""
         self.backup_platform_system = platform.system
         self.backup_linux_distribution = self.envlayer.platform.linux_distribution
         self.backup_distro_os_release_attr = distro.os_release_attr
@@ -186,9 +199,20 @@ class TestExecutionConfig(unittest.TestCase):
         distro.os_release_attr = self.mock_distro_os_release_attr_return_rhel_10
         distro.id = self.mock_distro_id_return_rhel
 
-        with self.assertRaises(Exception) as context:
-            self.envlayer.get_package_manager()
-        self.assertEqual(str(context.exception), "RHEL 10 is not yet supported in your region. Please review aka.ms/LinuxPatchExtension for more information.")
+        # Capture stdout to check for log message
+        captured_output = io.StringIO()
+        sys.stdout = captured_output
+
+        result = self.envlayer.get_package_manager()
+
+        sys.stdout = sys.__stdout__
+        output = captured_output.getvalue()
+
+        # Verify exact error message is logged
+        expected_msg = "Error: RHEL 10 is not yet supported in your region. Please review https://aka.ms/VMGuestPatchingCompatibility for more information."
+        self.assertEqual(expected_msg in output, True)
+        # Verify empty string is returned
+        self.assertEqual(result, "")
 
         # restore
         distro.id = self.backup_distro_id

--- a/src/core/tests/Test_EnvLayer.py
+++ b/src/core/tests/Test_EnvLayer.py
@@ -71,6 +71,18 @@ class TestExecutionConfig(unittest.TestCase):
 
     def mock_distro_os_release_attr_return_none(self, attribute):
         return None
+
+    def mock_distro_os_release_attr_return_azure_linux_4(self, attribute):
+        return '4.0.2'
+
+    def mock_distro_os_release_attr_return_rhel_10(self, attribute):
+        return '10.0'
+
+    def mock_linux_distribution_to_return_azure_linux_4(self):
+        return ['Microsoft Azure Linux', '4.0', '']
+
+    def mock_distro_id_return_rhel(self):
+        return 'rhel'
     # endregion
 
     def test_get_package_manager(self):
@@ -138,6 +150,43 @@ class TestExecutionConfig(unittest.TestCase):
         self.envlayer.platform.os_type()
         self.envlayer.platform.cpu_arch()
         self.envlayer.platform.vm_name()
+
+    def test_get_package_manager_azure_linux_4_not_supported(self):
+        """Test that Azure Linux 4 raises an exception"""
+        self.backup_linux_distribution = self.envlayer.platform.linux_distribution
+        self.backup_distro_os_release_attr = distro.os_release_attr
+
+        platform.system = self.mock_platform_system
+        self.envlayer.platform.linux_distribution = self.mock_linux_distribution_to_return_azure_linux_4
+        distro.os_release_attr = self.mock_distro_os_release_attr_return_azure_linux_4
+
+        with self.assertRaises(Exception) as context:
+            self.envlayer.get_package_manager()
+        self.assertEqual(str(context.exception), "Azure Linux 4 is not yet supported in your region. Please review aka.ms/LinuxPatchExtension for more information.")
+
+        # restore
+        distro.os_release_attr = self.backup_distro_os_release_attr
+        self.envlayer.platform.linux_distribution = self.backup_linux_distribution
+
+    def test_get_package_manager_rhel_10_not_supported(self):
+        """Test that RHEL 10 raises an exception"""
+        self.backup_linux_distribution = self.envlayer.platform.linux_distribution
+        self.backup_distro_os_release_attr = distro.os_release_attr
+        self.backup_distro_id = distro.id
+
+        platform.system = self.mock_platform_system
+        self.envlayer.platform.linux_distribution = self.mock_linux_distribution
+        distro.os_release_attr = self.mock_distro_os_release_attr_return_rhel_10
+        distro.id = self.mock_distro_id_return_rhel
+
+        with self.assertRaises(Exception) as context:
+            self.envlayer.get_package_manager()
+        self.assertEqual(str(context.exception), "RHEL 10 is not yet supported in your region. Please review aka.ms/LinuxPatchExtension for more information.")
+
+        # restore
+        distro.id = self.backup_distro_id
+        distro.os_release_attr = self.backup_distro_os_release_attr
+        self.envlayer.platform.linux_distribution = self.backup_linux_distribution
 
 
 if __name__ == '__main__':

--- a/src/core/tests/Test_EnvLayer.py
+++ b/src/core/tests/Test_EnvLayer.py
@@ -91,28 +91,32 @@ class TestExecutionConfig(unittest.TestCase):
         self.backup_linux_distribution = self.envlayer.platform.linux_distribution
         self.envlayer.platform.linux_distribution = self.mock_linux_distribution
         self.backup_run_command_output = self.envlayer.run_command_output
+        self.backup_distro_os_release_attr = distro.os_release_attr
 
         test_input_output_table = [
-            [self.mock_run_command_for_apt, self.mock_linux_distribution, Constants.APT],
-            [self.mock_run_command_for_tdnf, self.mock_linux_distribution_to_return_azure_linux_3, Constants.TDNF],
-            [self.mock_run_command_for_yum, self.mock_linux_distribution_to_return_azure_linux_3, str()],  # check for Azure Linux machine which does not have tdnf
-            [self.mock_run_command_for_tdnf, self.mock_linux_distribution_to_return_azure_linux_2, Constants.TDNF],
-            [self.mock_run_command_for_yum, self.mock_linux_distribution, Constants.YUM],
-            [self.mock_run_command_for_zypper, self.mock_linux_distribution, Constants.ZYPPER],
-            [lambda cmd, no_output, chk_err: (-1, ''), self.mock_linux_distribution, str()],    # no matches for any package manager
+            [self.mock_run_command_for_apt, self.mock_linux_distribution, self.mock_distro_os_release_attr_return_none, Constants.APT],
+            [self.mock_run_command_for_tdnf, self.mock_linux_distribution_to_return_azure_linux_3, self.mock_distro_os_release_attr_return_azure_linux_3, Constants.TDNF],
+            [self.mock_run_command_for_yum, self.mock_linux_distribution_to_return_azure_linux_3, self.mock_distro_os_release_attr_return_azure_linux_3, str()],  # check for Azure Linux machine which does not have tdnf
+            [self.mock_run_command_for_tdnf, self.mock_linux_distribution_to_return_azure_linux_2, self.mock_distro_os_release_attr_return_azure_linux_2, Constants.TDNF],
+            [self.mock_run_command_for_yum, self.mock_linux_distribution, self.mock_distro_os_release_attr_return_none, Constants.YUM],
+            [self.mock_run_command_for_zypper, self.mock_linux_distribution, self.mock_distro_os_release_attr_return_none, Constants.ZYPPER],
+            [lambda cmd, no_output, chk_err: (-1, ''), self.mock_linux_distribution, self.mock_distro_os_release_attr_return_none, str()],    # no matches for any package manager
         ]
 
         for row in test_input_output_table:
             self.envlayer.run_command_output = row[0]
             self.envlayer.platform.linux_distribution = row[1]
+            distro.os_release_attr = row[2]
             package_manager = self.envlayer.get_package_manager()
-            self.assertTrue(package_manager is row[2])
+            self.assertTrue(package_manager is row[3])
 
         # test for Windows
         platform.system = self.mock_platform_system_windows
+        distro.os_release_attr = self.mock_distro_os_release_attr_return_none
         self.assertEqual(self.envlayer.get_package_manager(), Constants.APT)
 
         # restore original methods
+        distro.os_release_attr = self.backup_distro_os_release_attr
         self.envlayer.run_command_output = self.backup_run_command_output
         self.envlayer.platform.linux_distribution = self.backup_linux_distribution
         platform.system = self.backup_platform_system
@@ -153,6 +157,7 @@ class TestExecutionConfig(unittest.TestCase):
 
     def test_get_package_manager_azure_linux_4_not_supported(self):
         """Test that Azure Linux 4 raises an exception"""
+        self.backup_platform_system = platform.system
         self.backup_linux_distribution = self.envlayer.platform.linux_distribution
         self.backup_distro_os_release_attr = distro.os_release_attr
 
@@ -167,9 +172,11 @@ class TestExecutionConfig(unittest.TestCase):
         # restore
         distro.os_release_attr = self.backup_distro_os_release_attr
         self.envlayer.platform.linux_distribution = self.backup_linux_distribution
+        platform.system = self.backup_platform_system
 
     def test_get_package_manager_rhel_10_not_supported(self):
         """Test that RHEL 10 raises an exception"""
+        self.backup_platform_system = platform.system
         self.backup_linux_distribution = self.envlayer.platform.linux_distribution
         self.backup_distro_os_release_attr = distro.os_release_attr
         self.backup_distro_id = distro.id
@@ -187,6 +194,7 @@ class TestExecutionConfig(unittest.TestCase):
         distro.id = self.backup_distro_id
         distro.os_release_attr = self.backup_distro_os_release_attr
         self.envlayer.platform.linux_distribution = self.backup_linux_distribution
+        platform.system = self.backup_platform_system
 
 
 if __name__ == '__main__':

--- a/src/core/tests/Test_EnvLayer.py
+++ b/src/core/tests/Test_EnvLayer.py
@@ -81,7 +81,7 @@ class TestExecutionConfig(unittest.TestCase):
         return '4.0.2'
 
     def mock_linux_distribution_to_return_rhel_10(self):
-        return ['Red Hat', '10.0', '']
+        return ['Red Hat', '10.0', 'abc']
 
     def mock_distro_os_release_attr_return_rhel_10(self, attribute):
         return '10.0'
@@ -160,8 +160,8 @@ class TestExecutionConfig(unittest.TestCase):
 
         platform.system = self.mock_platform_system
         test_input_output_table = [
-            [self.mock_linux_distribution_to_return_azure_linux_4, self.mock_distro_os_release_attr_return_azure_linux_4, "Error: This distro is not yet supported in your region. Please review https://aka.ms/VMGuestPatchingCompatibility for more information. [Distro=Microsoft Azure Linux]"],
-            [self.mock_linux_distribution_to_return_rhel_10, self.mock_distro_os_release_attr_return_rhel_10, "Error: This distro is not yet supported in your region. Please review https://aka.ms/VMGuestPatchingCompatibility for more information. [Distro=Red Hat]"],
+            [self.mock_linux_distribution_to_return_azure_linux_4, self.mock_distro_os_release_attr_return_azure_linux_4, "Error: This distro is not yet supported in your region. Please review https://aka.ms/VMGuestPatchingCompatibility for more information. [Distro=Microsoft Azure Linux][Version=4.0][Code=]\n"],
+            [self.mock_linux_distribution_to_return_rhel_10, self.mock_distro_os_release_attr_return_rhel_10, "Error: This distro is not yet supported in your region. Please review https://aka.ms/VMGuestPatchingCompatibility for more information. [Distro=Red Hat][Version=10.0][Code=abc]\n"],
         ]
 
         for row in test_input_output_table:
@@ -172,6 +172,7 @@ class TestExecutionConfig(unittest.TestCase):
             sys.stdout = captured_output
             result = self.envlayer.get_package_manager()
             sys.stdout = sys.__stdout__
+            self.assertEqual(row[2], captured_output.getvalue())
             self.assertEqual(result, "")
 
         # restore

--- a/src/core/tests/Test_EnvLayer.py
+++ b/src/core/tests/Test_EnvLayer.py
@@ -120,18 +120,17 @@ class TestExecutionConfig(unittest.TestCase):
         self.envlayer.platform.linux_distribution = self.backup_linux_distribution
         platform.system = self.backup_platform_system
 
-    def test_is_distro_azure_linux_3_or_beyond(self):
-        self.backup_linux_distribution = self.envlayer.platform.linux_distribution
+    def test_is_distro_azure_linux_3(self):
         self.backup_envlayer_distro_os_release_attr = distro.os_release_attr
 
         test_input_output_table = [
-            [self.mock_linux_distribution_to_return_azure_linux_3(), self.mock_distro_os_release_attr_return_azure_linux_3, True],
-            [self.mock_linux_distribution_to_return_azure_linux_2(), self.mock_distro_os_release_attr_return_azure_linux_2, False],
-            [self.mock_linux_distribution_to_return_azure_linux_3(), self.mock_distro_os_release_attr_return_none, False]
+            [self.mock_linux_distribution_to_return_azure_linux_3, self.mock_distro_os_release_attr_return_azure_linux_3, True],
+            [self.mock_linux_distribution_to_return_azure_linux_2, self.mock_distro_os_release_attr_return_azure_linux_2, False],
+            [self.mock_linux_distribution_to_return_azure_linux_3, self.mock_distro_os_release_attr_return_none, False]
         ]
 
         for row in test_input_output_table:
-            distro_name = row[0][0]  # Extract distro name from tuple (first element)
+            distro_name = row[0]()[0]  # Extract distro name from tuple (first element)
             distro.os_release_attr = row[1]
             result = self.envlayer.is_distro_azure_linux_3(distro_name)
             self.assertEqual(result, row[2])
@@ -153,68 +152,36 @@ class TestExecutionConfig(unittest.TestCase):
         self.envlayer.platform.cpu_arch()
         self.envlayer.platform.vm_name()
 
-    def test_get_package_manager_azure_linux_4_not_supported(self):
-        """Test that Azure Linux 4 logs unsupported message"""
+    def test_get_package_manager_azure_linux_4_and_rhel10_not_supported(self):
+        """Test that Azure Linux 4 and RHEL 10 log unsupported message"""
         self.backup_platform_system = platform.system
         self.backup_linux_distribution = self.envlayer.platform.linux_distribution
         self.backup_distro_os_release_attr = distro.os_release_attr
 
         platform.system = self.mock_platform_system
-        self.envlayer.platform.linux_distribution = self.mock_linux_distribution_to_return_azure_linux_4
-        distro.os_release_attr = self.mock_distro_os_release_attr_return_azure_linux_4
+        test_input_output_table = [
+            [self.mock_linux_distribution_to_return_azure_linux_4, self.mock_distro_os_release_attr_return_azure_linux_4, "Error: This distro is not yet supported in your region. Please review https://aka.ms/VMGuestPatchingCompatibility for more information. [Distro=Microsoft Azure Linux]"],
+            [self.mock_linux_distribution_to_return_rhel_10, self.mock_distro_os_release_attr_return_rhel_10, "Error: This distro is not yet supported in your region. Please review https://aka.ms/VMGuestPatchingCompatibility for more information. [Distro=Red Hat]"],
+        ]
 
-        # Capture stdout to check for log message
-        captured_output = io.StringIO()
-        sys.stdout = captured_output
+        for row in test_input_output_table:
+            self.envlayer.platform.linux_distribution = row[0]
+            distro.os_release_attr = row[1]
 
-        result = self.envlayer.get_package_manager()
-
-        sys.stdout = sys.__stdout__
-        output = captured_output.getvalue()
-
-        # Verify exact error message is logged
-        expected_msg = "Error: This distro is not yet supported in your region. Please review https://aka.ms/VMGuestPatchingCompatibility for more information. [Distro=Microsoft Azure Linux]"
-        self.assertIn(expected_msg, output)
-        # Verify empty string is returned
-        self.assertEqual(result, "")
+            captured_output = io.StringIO()
+            sys.stdout = captured_output
+            result = self.envlayer.get_package_manager()
+            sys.stdout = sys.__stdout__
+            self.assertEqual(result, "")
 
         # restore
-        self._restore_mocks()
+        self.__restore_mocks()
 
-    def test_get_package_manager_rhel_10_not_supported(self):
-        """Test that RHEL 10 logs unsupported message"""
-        self.backup_platform_system = platform.system
-        self.backup_linux_distribution = self.envlayer.platform.linux_distribution
-        self.backup_distro_os_release_attr = distro.os_release_attr
-
-        platform.system = self.mock_platform_system
-        self.envlayer.platform.linux_distribution = self.mock_linux_distribution_to_return_rhel_10
-        distro.os_release_attr = self.mock_distro_os_release_attr_return_rhel_10
-
-        # Capture stdout to check for log message
-        captured_output = io.StringIO()
-        sys.stdout = captured_output
-
-        result = self.envlayer.get_package_manager()
-
-        sys.stdout = sys.__stdout__
-        output = captured_output.getvalue()
-
-        # Verify exact error message is logged
-        expected_msg = "Error: This distro is not yet supported in your region. Please review https://aka.ms/VMGuestPatchingCompatibility for more information. [Distro=Red Hat]"
-        self.assertIn(expected_msg, output)
-        # Verify empty string is returned
-        self.assertEqual(result, "")
-
-        # restore
-        self._restore_mocks()
-
-    def _restore_mocks(self):
+    def __restore_mocks(self):
         """Restore backed up mocks to their original state"""
         distro.os_release_attr = self.backup_distro_os_release_attr
         self.envlayer.platform.linux_distribution = self.backup_linux_distribution
         platform.system = self.backup_platform_system
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/core/tests/Test_EnvLayer.py
+++ b/src/core/tests/Test_EnvLayer.py
@@ -74,17 +74,17 @@ class TestExecutionConfig(unittest.TestCase):
     def mock_distro_os_release_attr_return_none(self, attribute):
         return None
 
-    def mock_distro_os_release_attr_return_azure_linux_4(self, attribute):
-        return '4.0.2'
-
-    def mock_distro_os_release_attr_return_rhel_10(self, attribute):
-        return '10.0'
-
     def mock_linux_distribution_to_return_azure_linux_4(self):
         return ['Microsoft Azure Linux', '4.0', '']
 
-    def mock_distro_id_return_rhel(self):
-        return 'rhel'
+    def mock_distro_os_release_attr_return_azure_linux_4(self, attribute):
+        return '4.0.2'
+
+    def mock_linux_distribution_to_return_rhel_10(self):
+        return ['Red Hat', '10.0', '']
+
+    def mock_distro_os_release_attr_return_rhel_10(self, attribute):
+        return '10.0'
     # endregion
 
     def test_get_package_manager(self):
@@ -96,29 +96,26 @@ class TestExecutionConfig(unittest.TestCase):
         self.backup_distro_os_release_attr = distro.os_release_attr
 
         test_input_output_table = [
-            [self.mock_run_command_for_apt, self.mock_linux_distribution, self.mock_distro_os_release_attr_return_none, Constants.APT],
-            [self.mock_run_command_for_tdnf, self.mock_linux_distribution_to_return_azure_linux_3, self.mock_distro_os_release_attr_return_azure_linux_3, Constants.TDNF],
-            [self.mock_run_command_for_yum, self.mock_linux_distribution_to_return_azure_linux_3, self.mock_distro_os_release_attr_return_azure_linux_3, str()],  # check for Azure Linux machine which does not have tdnf
-            [self.mock_run_command_for_tdnf, self.mock_linux_distribution_to_return_azure_linux_2, self.mock_distro_os_release_attr_return_azure_linux_2, Constants.TDNF],
-            [self.mock_run_command_for_yum, self.mock_linux_distribution, self.mock_distro_os_release_attr_return_none, Constants.YUM],
-            [self.mock_run_command_for_zypper, self.mock_linux_distribution, self.mock_distro_os_release_attr_return_none, Constants.ZYPPER],
-            [lambda cmd, no_output, chk_err: (-1, ''), self.mock_linux_distribution, self.mock_distro_os_release_attr_return_none, str()],    # no matches for any package manager
+            [self.mock_run_command_for_apt, self.mock_linux_distribution, Constants.APT],
+            [self.mock_run_command_for_tdnf, self.mock_linux_distribution_to_return_azure_linux_3, Constants.TDNF],
+            [self.mock_run_command_for_yum, self.mock_linux_distribution_to_return_azure_linux_3, str()],  # check for Azure Linux machine which does not have tdnf
+            [self.mock_run_command_for_tdnf, self.mock_linux_distribution_to_return_azure_linux_2, Constants.TDNF],
+            [self.mock_run_command_for_yum, self.mock_linux_distribution, Constants.YUM],
+            [self.mock_run_command_for_zypper, self.mock_linux_distribution, Constants.ZYPPER],
+            [lambda cmd, no_output, chk_err: (-1, ''), self.mock_linux_distribution, str()],    # no matches for any package manager
         ]
 
         for row in test_input_output_table:
             self.envlayer.run_command_output = row[0]
             self.envlayer.platform.linux_distribution = row[1]
-            distro.os_release_attr = row[2]
             package_manager = self.envlayer.get_package_manager()
-            self.assertTrue(package_manager is row[3])
+            self.assertTrue(package_manager is row[2])
 
         # test for Windows
         platform.system = self.mock_platform_system_windows
-        distro.os_release_attr = self.mock_distro_os_release_attr_return_none
         self.assertEqual(self.envlayer.get_package_manager(), Constants.APT)
 
         # restore original methods
-        distro.os_release_attr = self.backup_distro_os_release_attr
         self.envlayer.run_command_output = self.backup_run_command_output
         self.envlayer.platform.linux_distribution = self.backup_linux_distribution
         platform.system = self.backup_platform_system
@@ -128,20 +125,19 @@ class TestExecutionConfig(unittest.TestCase):
         self.backup_envlayer_distro_os_release_attr = distro.os_release_attr
 
         test_input_output_table = [
-            [self.mock_linux_distribution_to_return_azure_linux_3, self.mock_distro_os_release_attr_return_azure_linux_3, True],
-            [self.mock_linux_distribution_to_return_azure_linux_2, self.mock_distro_os_release_attr_return_azure_linux_2, False],
-            [self.mock_linux_distribution_to_return_azure_linux_3, self.mock_distro_os_release_attr_return_none, False]
+            [self.mock_linux_distribution_to_return_azure_linux_3(), self.mock_distro_os_release_attr_return_azure_linux_3, True],
+            [self.mock_linux_distribution_to_return_azure_linux_2(), self.mock_distro_os_release_attr_return_azure_linux_2, False],
+            [self.mock_linux_distribution_to_return_azure_linux_3(), self.mock_distro_os_release_attr_return_none, False]
         ]
 
         for row in test_input_output_table:
-            self.envlayer.platform.linux_distribution = row[0]
+            distro_name = row[0][0]  # Extract distro name from tuple (first element)
             distro.os_release_attr = row[1]
-            result = self.envlayer.is_distro_azure_linux_3_or_beyond()
+            result = self.envlayer.is_distro_azure_linux_3(distro_name)
             self.assertEqual(result, row[2])
 
         # restore original methods
         distro.os_release_attr = self.backup_envlayer_distro_os_release_attr
-        self.envlayer.platform.linux_distribution = self.backup_linux_distribution
 
     def test_filesystem(self):
         # only validates if these invocable without exceptions
@@ -177,27 +173,23 @@ class TestExecutionConfig(unittest.TestCase):
         output = captured_output.getvalue()
 
         # Verify exact error message is logged
-        expected_msg = "Error: Azure Linux 4 is not yet supported in your region. Please review https://aka.ms/VMGuestPatchingCompatibility for more information."
-        self.assertEqual(expected_msg in output, True)
+        expected_msg = "Error: This distro is not yet supported in your region. Please review https://aka.ms/VMGuestPatchingCompatibility for more information. [Distro=Microsoft Azure Linux]"
+        self.assertIn(expected_msg, output)
         # Verify empty string is returned
         self.assertEqual(result, "")
 
         # restore
-        distro.os_release_attr = self.backup_distro_os_release_attr
-        self.envlayer.platform.linux_distribution = self.backup_linux_distribution
-        platform.system = self.backup_platform_system
+        self._restore_mocks()
 
     def test_get_package_manager_rhel_10_not_supported(self):
         """Test that RHEL 10 logs unsupported message"""
         self.backup_platform_system = platform.system
         self.backup_linux_distribution = self.envlayer.platform.linux_distribution
         self.backup_distro_os_release_attr = distro.os_release_attr
-        self.backup_distro_id = distro.id
 
         platform.system = self.mock_platform_system
-        self.envlayer.platform.linux_distribution = self.mock_linux_distribution
+        self.envlayer.platform.linux_distribution = self.mock_linux_distribution_to_return_rhel_10
         distro.os_release_attr = self.mock_distro_os_release_attr_return_rhel_10
-        distro.id = self.mock_distro_id_return_rhel
 
         # Capture stdout to check for log message
         captured_output = io.StringIO()
@@ -209,13 +201,16 @@ class TestExecutionConfig(unittest.TestCase):
         output = captured_output.getvalue()
 
         # Verify exact error message is logged
-        expected_msg = "Error: RHEL 10 is not yet supported in your region. Please review https://aka.ms/VMGuestPatchingCompatibility for more information."
-        self.assertEqual(expected_msg in output, True)
+        expected_msg = "Error: This distro is not yet supported in your region. Please review https://aka.ms/VMGuestPatchingCompatibility for more information. [Distro=Red Hat]"
+        self.assertIn(expected_msg, output)
         # Verify empty string is returned
         self.assertEqual(result, "")
 
         # restore
-        distro.id = self.backup_distro_id
+        self._restore_mocks()
+
+    def _restore_mocks(self):
+        """Restore backed up mocks to their original state"""
         distro.os_release_attr = self.backup_distro_os_release_attr
         self.envlayer.platform.linux_distribution = self.backup_linux_distribution
         platform.system = self.backup_platform_system


### PR DESCRIPTION
- Detect Azure Linux 4.x and RHEL 10.x distributions and enforce a safety‑net exception until LPE dnf5 support is fully implemented and validated.

**Linux4 VM ARM ID** : [/subscriptions/6acc8a91-e2b0-4041-a069-c2932ab42fd9/resourceGroups/rg-yashna-linux4-test-wus2/providers/Microsoft.Compute/virtualMachines/vm-yashna-linux4  ](url)

LogFolder : /tmp/linux-patch/linux4_2/log

<img width="1057" height="523" alt="linux4_error" src="https://github.com/user-attachments/assets/793957b8-d4b3-422b-89f5-3a5e7e8f5407" />



**Linux 3 ARM ID** :[ /subscriptions/6acc8a91-e2b0-4041-a069-c2932ab42fd9/resourceGroups/rg-linux3-tdnf/providers/Microsoft.Compute/virtualMachines/vm-linux3-tdnf-yashna](url)

LogFolder:  /tmp/linux-patch/linux4_2/log

<img width="1066" height="738" alt="workinglinux3" src="https://github.com/user-attachments/assets/4642bb67-255b-4bd8-ab3d-d654ef3728cf" />



**Red Hat Arm ID** : /[subscriptions/6acc8a91-e2b0-4041-a069-c2932ab42fd9/resourceGroups/rg-rhel_10_yashna/providers/Microsoft.Compute/virtualMachines/vm-rhel-10-yashna](url)

LogFolder : /tmp/linux-patch/linux4_1/log
<img width="1027" height="796" alt="rhel_10_error_logs" src="https://github.com/user-attachments/assets/f64e4547-0a08-4494-86fb-15b9cd88ec11" />

