### PR TITLE
Updating extension version to 1.6.65

### DIFF
--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -31,7 +31,7 @@ class Constants(object):
     UNKNOWN = "Unknown"
 
     # Extension version (todo: move to a different file)
-    EXT_VERSION = "1.6.64"
+    EXT_VERSION = "1.6.65"
 
     # Runtime environments
     TEST = 'Test'

--- a/src/extension/src/Constants.py
+++ b/src/extension/src/Constants.py
@@ -28,7 +28,7 @@ class Constants(object):
                         yield item
 
     # Extension version (todo: move to a different file)
-    EXT_VERSION = "1.6.64"
+    EXT_VERSION = "1.6.65"
 
     # Runtime environments
     TEST = 'Test'

--- a/src/extension/src/manifest.xml
+++ b/src/extension/src/manifest.xml
@@ -2,7 +2,7 @@
 <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure">
   <ProviderNameSpace>Microsoft.CPlat.Core</ProviderNameSpace>
   <Type>LinuxPatchExtension</Type>
-  <Version>1.6.64</Version>
+  <Version>1.6.65</Version>
   <Label>Microsoft Azure VM InGuest Patch Extension for Linux Virtual Machines</Label>
   <HostingResources>VmRole</HostingResources>
   <MediaLink></MediaLink>


### PR DESCRIPTION
Release contains
- Explicitly blocking AzLinux 4 and RHEL10 support until code is fully ready : [https://github.com/Azure/LinuxPatchExtension/pull/344]