### PR TITLE
Feature: [Ubuntu, non-CVM] Updating UEFI and kek certificates during default patching

### DIFF
--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -299,6 +299,13 @@ class Constants(object):
     STATUS_ERROR_MSG_SIZE_LIMIT_IN_CHARACTERS = 128
     STATUS_ERROR_LIMIT = 5
 
+    # Boot Certificates to update
+    class Certificates(EnumBackport):
+        KEK = "KEK"
+        DB = "DB"
+
+    LATEST_CERTIFICATE_TIMESTAMP = "2023"
+
     class PatchOperationTopLevelErrorCode(EnumBackport):
         SUCCESS = 0
         ERROR = 1
@@ -312,6 +319,7 @@ class Constants(object):
         NEWER_OPERATION_SUPERSEDED = "NEWER_OPERATION_SUPERSEDED"
         UA_ESM_REQUIRED = "UA_ESM_REQUIRED"
         TRUNCATION = "PACKAGE_LIST_TRUNCATED"
+        CERTIFICATE_UPDATE = "CERTIFICATE_UPDATE"
 
     ERROR_ADDED_TO_STATUS = "Error_added_to_status"
 

--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -58,6 +58,7 @@ class Constants(object):
 
     class AzGPSPaths(EnumBackport):
         EULA_SETTINGS = "/var/lib/azure/linuxpatchextension/patch.eula.settings"
+        UEFI_SETTINGS = "/var/lib/azure/linuxpatchextension/patch.uefi.settings"
 
     class EnvSettings(EnumBackport):
         LOG_FOLDER = "logFolder"
@@ -85,6 +86,11 @@ class Constants(object):
     class EulaSettings(EnumBackport):
         ACCEPT_EULA_FOR_ALL_PATCHES = 'AcceptEULAForAllPatches'
         ACCEPTED_BY = 'AcceptedBy'
+        LAST_MODIFIED = 'LastModified'
+
+    class UEFISettings(EnumBackport):
+        ENABLE_UEFI_CERT_UPDATE = 'EnableUEFICertUpdate'
+        ENABLED_By = 'EnabledBy'
         LAST_MODIFIED = 'LastModified'
 
     TEMP_FOLDER_DIR_NAME = "tmp"

--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -96,6 +96,11 @@ class Constants(object):
     TEMP_FOLDER_DIR_NAME = "tmp"
     TEMP_FOLDER_CLEANUP_ARTIFACT_LIST = ["*.list", "azgps*"]
 
+    # Boot Certificates to update
+    class Certificates(EnumBackport):
+        KEK = "KEK"
+        DB = "DB"
+
     # File to save default settings for auto OS updates
     IMAGE_DEFAULT_PATCH_CONFIGURATION_BACKUP_PATH = "ImageDefaultPatchConfiguration.bak"
 
@@ -304,11 +309,6 @@ class Constants(object):
     # Settings for Error Objects logged in status file
     STATUS_ERROR_MSG_SIZE_LIMIT_IN_CHARACTERS = 128
     STATUS_ERROR_LIMIT = 5
-
-    # Boot Certificates to update
-    class Certificates(EnumBackport):
-        KEK = "KEK"
-        DB = "DB"
 
     LATEST_CERTIFICATE_TIMESTAMP = "2023"
 

--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -90,7 +90,7 @@ class Constants(object):
 
     class UEFISettings(EnumBackport):
         ENABLE_UEFI_CERT_UPDATE = 'EnableUEFICertUpdate'
-        ENABLED_By = 'EnabledBy'
+        ENABLED_BY = 'EnabledBy'
         LAST_MODIFIED = 'LastModified'
 
     TEMP_FOLDER_DIR_NAME = "tmp"

--- a/src/core/src/core_logic/ExecutionConfig.py
+++ b/src/core/src/core_logic/ExecutionConfig.py
@@ -92,6 +92,9 @@ class ExecutionConfig(object):
         # EULA config
         self.accept_package_eula = self.__is_eula_accepted_for_all_patches()
 
+        # UEFI config
+        self.enable_uefi_cert_update = self.__is_uefi_cert_update_enabled()
+
     def __transform_execution_config_for_auto_assessment(self):
         self.activity_id = str(uuid.uuid4())
         self.included_classifications_list = self.included_package_name_mask_list = self.excluded_package_name_mask_list = []
@@ -266,4 +269,43 @@ class ExecutionConfig(object):
         if settings_source is not None and setting_to_fetch is not None and setting_to_fetch in settings_source:
             return settings_source[setting_to_fetch]
         return None
+
+    def __is_uefi_cert_update_enabled(self):
+        # type: () -> bool
+        """ Reads customer provided config on UEFI cert update from disk and returns a boolean.
+        NOTE: This is a temporary solution implemented expressly for validating cert updates with partners and will be deprecated soon """
+        is_uefi_cert_update_enabled = False
+        try:
+            if os.path.exists(Constants.AzGPSPaths.UEFI_SETTINGS):
+                uefi_cert_update_settings = json.loads(self.env_layer.file_system.read_with_retry(Constants.AzGPSPaths.UEFI_CERT_UPDATE_SETTINGS) or 'null')
+                enable_uefi_cert_update = self.__fetch_specific_uefi_cert_update_setting(uefi_cert_update_settings, Constants.UEFISettings.ENABLE_UEFI_CERT_UPDATE)
+                enabled_by = self.__fetch_specific_uefi_cert_update_setting(uefi_cert_update_settings, Constants.UEFISettings.ENABLED_BY)
+                last_modified = self.__fetch_specific_uefi_cert_update_setting(uefi_cert_update_settings, Constants.UEFISettings.LAST_MODIFIED)
+                if enable_uefi_cert_update is not None and self.__is_truthy(enable_uefi_cert_update):
+                    is_uefi_cert_update_enabled = True
+                self.composite_logger.log_debug("UEFI cert update config values from disk: [EnableUefiCertUpdate={0}] [EnabledBy={1}] [LastModified={2}]. Computed value of [IsUefiCertUpdateEnabled={3}]"
+                                                .format(str(enable_uefi_cert_update), str(enabled_by), str(last_modified), str(is_uefi_cert_update_enabled)))
+            else:
+                self.composite_logger.log_debug("No UEFI cert update settings found on the VM. Computed value of [IsUefiCertUpdateEnabled={0}]".format(str(is_uefi_cert_update_enabled)))
+        except Exception as error:
+            self.composite_logger.log_debug("Error occurred while reading and parsing UEFI cert update settings. Not enabling UEFI cert update. Error=[{0}]".format(repr(error)))
+
+        return is_uefi_cert_update_enabled
+
+    @staticmethod
+    def __is_truthy(value):
+        # type: (any) -> bool
+        """Case-insensitive truthy evaluator for config values."""
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, int):
+            return value == 1
+
+        # Cross-version text types:
+        # py2 -> (str, unicode)
+        # py3 -> (str, str)
+        text_types = (str, type(u""))
+        if isinstance(value, text_types):
+            return value.strip().lower() in ("true", "1")
+        return False
 

--- a/src/core/src/core_logic/ExecutionConfig.py
+++ b/src/core/src/core_logic/ExecutionConfig.py
@@ -265,7 +265,7 @@ class ExecutionConfig(object):
 
     @staticmethod
     def __fetch_specific_azgps_setting(settings_source, setting_to_fetch):
-        """ Returns the specific setting value from eula_settings_source or None if not found """
+        """ Returns the specific setting value azgps settings source or None if not found """
         if settings_source is not None and setting_to_fetch is not None and setting_to_fetch in settings_source:
             return settings_source[setting_to_fetch]
         return None

--- a/src/core/src/core_logic/ExecutionConfig.py
+++ b/src/core/src/core_logic/ExecutionConfig.py
@@ -249,9 +249,9 @@ class ExecutionConfig(object):
         try:
             if os.path.exists(Constants.AzGPSPaths.EULA_SETTINGS):
                 eula_settings = json.loads(self.env_layer.file_system.read_with_retry(Constants.AzGPSPaths.EULA_SETTINGS) or 'null')
-                accept_eula_for_all_patches = self.__fetch_specific_eula_setting(eula_settings, Constants.EulaSettings.ACCEPT_EULA_FOR_ALL_PATCHES)
-                accepted_by = self.__fetch_specific_eula_setting(eula_settings, Constants.EulaSettings.ACCEPTED_BY)
-                last_modified = self.__fetch_specific_eula_setting(eula_settings, Constants.EulaSettings.LAST_MODIFIED)
+                accept_eula_for_all_patches = self.__fetch_specific_azgps_setting(eula_settings, Constants.EulaSettings.ACCEPT_EULA_FOR_ALL_PATCHES)
+                accepted_by = self.__fetch_specific_azgps_setting(eula_settings, Constants.EulaSettings.ACCEPTED_BY)
+                last_modified = self.__fetch_specific_azgps_setting(eula_settings, Constants.EulaSettings.LAST_MODIFIED)
                 if accept_eula_for_all_patches is not None and accept_eula_for_all_patches in [True, 'True', 'true', '1', 1]:
                     is_eula_accepted = True
                 self.composite_logger.log_debug("EULA config values from disk: [AcceptEULAForAllPatches={0}] [AcceptedBy={1}] [LastModified={2}]. Computed value of [IsEULAAccepted={3}]"
@@ -264,7 +264,7 @@ class ExecutionConfig(object):
         return is_eula_accepted
 
     @staticmethod
-    def __fetch_specific_eula_setting(settings_source, setting_to_fetch):
+    def __fetch_specific_azgps_setting(settings_source, setting_to_fetch):
         """ Returns the specific setting value from eula_settings_source or None if not found """
         if settings_source is not None and setting_to_fetch is not None and setting_to_fetch in settings_source:
             return settings_source[setting_to_fetch]
@@ -277,10 +277,10 @@ class ExecutionConfig(object):
         is_uefi_cert_update_enabled = False
         try:
             if os.path.exists(Constants.AzGPSPaths.UEFI_SETTINGS):
-                uefi_cert_update_settings = json.loads(self.env_layer.file_system.read_with_retry(Constants.AzGPSPaths.UEFI_CERT_UPDATE_SETTINGS) or 'null')
-                enable_uefi_cert_update = self.__fetch_specific_uefi_cert_update_setting(uefi_cert_update_settings, Constants.UEFISettings.ENABLE_UEFI_CERT_UPDATE)
-                enabled_by = self.__fetch_specific_uefi_cert_update_setting(uefi_cert_update_settings, Constants.UEFISettings.ENABLED_BY)
-                last_modified = self.__fetch_specific_uefi_cert_update_setting(uefi_cert_update_settings, Constants.UEFISettings.LAST_MODIFIED)
+                uefi_cert_update_settings = json.loads(self.env_layer.file_system.read_with_retry(Constants.AzGPSPaths.UEFI_SETTINGS) or 'null')
+                enable_uefi_cert_update = self.__fetch_specific_azgps_setting(uefi_cert_update_settings, Constants.UEFISettings.ENABLE_UEFI_CERT_UPDATE)
+                enabled_by = self.__fetch_specific_azgps_setting(uefi_cert_update_settings, Constants.UEFISettings.ENABLED_BY)
+                last_modified = self.__fetch_specific_azgps_setting(uefi_cert_update_settings, Constants.UEFISettings.LAST_MODIFIED)
                 if enable_uefi_cert_update is not None and self.__is_truthy(enable_uefi_cert_update):
                     is_uefi_cert_update_enabled = True
                 self.composite_logger.log_debug("UEFI cert update config values from disk: [EnableUefiCertUpdate={0}] [EnabledBy={1}] [LastModified={2}]. Computed value of [IsUefiCertUpdateEnabled={3}]"

--- a/src/core/src/core_logic/PatchInstaller.py
+++ b/src/core/src/core_logic/PatchInstaller.py
@@ -817,5 +817,5 @@ class PatchInstaller(object):
         # type: () -> bool
         """ Returns true if the patching run is a default patching run"""
         return (self.execution_config.health_store_id is not None and
-                self.execution_config.health_store_id is not str() and
+                self.execution_config.health_store_id != "" and
                 self.execution_config.operation.lower() == Constants.INSTALLATION.lower())

--- a/src/core/src/core_logic/PatchInstaller.py
+++ b/src/core/src/core_logic/PatchInstaller.py
@@ -816,4 +816,6 @@ class PatchInstaller(object):
     def __is_default_patching(self):
         # type: () -> bool
         """ Returns true if the patching run is a default patching run"""
-        return self.execution_config.health_store_id is not str() and self.execution_config.operation.lower() == Constants.INSTALLATION.lower()
+        return (self.execution_config.health_store_id is not None and
+                self.execution_config.health_store_id is not str() and
+                self.execution_config.operation.lower() == Constants.INSTALLATION.lower())

--- a/src/core/src/core_logic/PatchInstaller.py
+++ b/src/core/src/core_logic/PatchInstaller.py
@@ -77,8 +77,9 @@ class PatchInstaller(object):
                 self.composite_logger.log_debug("Attempting to reboot the machine prior to patch installation as there is a reboot pending...")
                 reboot_manager.start_reboot_if_required_and_time_available(maintenance_window.get_remaining_time_in_minutes(None, False))
 
-        # Update certs if available
-        self.try_update_certificates_for_default_patching()
+        # Update certificates if feature flag to update certs is set
+        if self.execution_config.enable_uefi_cert_update:
+            self.try_update_certificates_for_default_patching()
 
         if self.execution_config.max_patch_publish_date != str():
             self.package_manager.set_max_patch_publish_date(self.execution_config.max_patch_publish_date)

--- a/src/core/src/core_logic/PatchInstaller.py
+++ b/src/core/src/core_logic/PatchInstaller.py
@@ -78,7 +78,7 @@ class PatchInstaller(object):
                 reboot_manager.start_reboot_if_required_and_time_available(maintenance_window.get_remaining_time_in_minutes(None, False))
 
         # Update certs if available
-        self.package_manager.update_certs()
+        self.try_update_certificates_for_default_patching()
 
         if self.execution_config.max_patch_publish_date != str():
             self.package_manager.set_max_patch_publish_date(self.execution_config.max_patch_publish_date)
@@ -800,3 +800,19 @@ class PatchInstaller(object):
 
         return max_batch_size_for_packages
 
+    def try_update_certificates_for_default_patching(self):
+        # type: () -> None
+        """ Attempts to update certificates on the machine for default patching"""
+        if not self.__is_default_patching():
+            self.composite_logger.log_debug("Not updating certificates since this is not a default patching operation.")
+            return
+
+        try:
+            self.package_manager.update_certs()
+        except Exception as e:
+            self.composite_logger.log_warning("An error was encountered while attempting to update certificates. Continuing with patch installation... [Error: {0}]".format(str(e)))
+
+    def __is_default_patching(self):
+        # type: () -> bool
+        """ Returns true if the patching run is a default patching run"""
+        return self.execution_config.health_store_id is not str() and self.execution_config.operation.lower() == Constants.INSTALLATION.lower()

--- a/src/core/src/core_logic/PatchInstaller.py
+++ b/src/core/src/core_logic/PatchInstaller.py
@@ -77,6 +77,9 @@ class PatchInstaller(object):
                 self.composite_logger.log_debug("Attempting to reboot the machine prior to patch installation as there is a reboot pending...")
                 reboot_manager.start_reboot_if_required_and_time_available(maintenance_window.get_remaining_time_in_minutes(None, False))
 
+        # Update certs if available
+        self.package_manager.update_certs()
+
         if self.execution_config.max_patch_publish_date != str():
             self.package_manager.set_max_patch_publish_date(self.execution_config.max_patch_publish_date)
 

--- a/src/core/src/package_managers/AptitudePackageManager.py
+++ b/src/core/src/package_managers/AptitudePackageManager.py
@@ -91,13 +91,12 @@ class AptitudePackageManager(PackageManager):
         
         self.package_install_expected_avg_time_in_seconds = 90  # As per telemetry data, the average time to install package is around 81 seconds for apt.
 
-        # Update certificates in factory defaults
-        # self.check_mokutil_exists_cmd = "command -v mokutil"
+        # Update certificates in factory defaults NOTE: The proposed references are short-term as it will be moved out soon
         self.install_mokutil_cmd = "sudo apt-get install -y -qq mokutil"
         self.proposed_repo_file_path = "/etc/apt/sources.list.d/proposed.list"
         self.proposed_pin_file_path = "/etc/apt/preferences.d/proposed"
         self.add_proposed_repo_cmd = (
-            "bash -c 'echo \"deb http://archive.ubuntu.com/ubuntu/ "
+            "bash -c 'echo \"deb https://archive.ubuntu.com/ubuntu/ "
             "$( . /etc/os-release && echo $VERSION_CODENAME )-proposed restricted main multiverse universe\" "
             "| sudo tee {0}'").format(self.proposed_repo_file_path)
         self.create_proposed_pin_cmd = (
@@ -973,7 +972,7 @@ class AptitudePackageManager(PackageManager):
         cmd = self.install_mokutil_cmd
         self.composite_logger.log_verbose('[APM] Invoking install mokutil command [Command={0}]'.format(cmd))
         out, code = self.invoke_package_manager_advanced(cmd, raise_on_exception=False)
-        self.composite_logger.log_debug('[APM] Invoked install mokutil exists. [Command={0}][Code={1}][Output={2}]'.format(cmd, str(code), str(out)))
+        self.composite_logger.log_debug('[APM] Invoked install mokutil command. [Command={0}][Code={1}][Output={2}]'.format(cmd, str(code), str(out)))
         return code == 0
 
     def try_update_certs(self):
@@ -994,6 +993,9 @@ class AptitudePackageManager(PackageManager):
             self.__run_cert_shell_command(self.fwupd_refresh_cmd, "FwupdRefresh", raise_on_error=True)
             self.__run_cert_shell_command(self.fwupd_update_cmd, "FwupdUpdate", raise_on_error=True)
 
+            """ NOTE: They tooling used to update here is fwupd (firmware update manager). In this method of updating certs, the exact version of current certs is never pinned
+            or set/referred while installing. fwupd fetches and installs latest available certs. This is beneficial because our code doesn't become dated in the future
+            (if it was pinned to an old version) but adds the need to verify if the certs we intend to update were applied. Hence the validation on latest certs. """
             if self.are_latest_certs_present():
                 self.composite_logger.log("[APM][Certs] Cert update completed and verified.")
                 success = True

--- a/src/core/src/package_managers/AptitudePackageManager.py
+++ b/src/core/src/package_managers/AptitudePackageManager.py
@@ -1029,7 +1029,7 @@ class AptitudePackageManager(PackageManager):
                 raise Exception(msg, "[{0}]".format(Constants.ERROR_ADDED_TO_STATUS))
             return False, out
 
-        self.composite_logger.log_debug("[APM][UpdateCerts] Apt step succeeded. [Step={0}][Output={1}]".format(step_name, str(out)))
+        self.composite_logger.log_debug("[APM][UpdateCerts] Apt step succeeded. [Step={0}][Command={1}][Code={2}][Output={3}]".format(step_name,  str(command), str(code), str(out)))
         return True, out
 
     def __run_cert_shell_command(self, command, step_name, raise_on_error=False):
@@ -1043,7 +1043,7 @@ class AptitudePackageManager(PackageManager):
                 raise Exception(msg, "[{0}]".format(Constants.ERROR_ADDED_TO_STATUS))
             return False, out
 
-        self.composite_logger.log_debug("[APM][UpdateCerts] Shell step succeeded. [Step={0}][Output={1}]".format(step_name, str(out)))
+        self.composite_logger.log_debug("[APM][UpdateCerts] Shell step succeeded. [Step={0}][Command={1}][Code={2}][Output={3}]".format(step_name, str(command), str(code), str(out)))
         return True, out
     # endregion
 

--- a/src/core/src/package_managers/AptitudePackageManager.py
+++ b/src/core/src/package_managers/AptitudePackageManager.py
@@ -968,7 +968,6 @@ class AptitudePackageManager(PackageManager):
         return self.package_install_expected_avg_time_in_seconds
 
     # region Update certificates in factory defaults
-    @abstractmethod
     def try_install_mokutil(self):
         # type: () -> bool
         """ Attempts to install mokutil """
@@ -977,16 +976,6 @@ class AptitudePackageManager(PackageManager):
         out, code = self.invoke_package_manager_advanced(cmd, raise_on_exception=False)
         self.composite_logger.log_debug('[APM] Invoked install mokutil exists. [Command={0}][Code={1}][Output={2}]'.format(cmd, str(code), str(out)))
         return code == 0
-
-    @abstractmethod
-    def fetch_current_certs(self, cert_type, get_cert_status_cmd, raise_on_exception=False):
-        # """ Fetches the status of the certificates on the machine """
-        pass
-
-    @abstractmethod
-    def is_latest_cert_installed(self, status_code, status_output):
-        """ Checks if the latest certs are already installed on the machine based on mokutil output """
-        pass
 
     def try_update_certs(self):
         """ Attempts to update certificate status """
@@ -1032,10 +1021,6 @@ class AptitudePackageManager(PackageManager):
 
         return success
 
-    @abstractmethod
-    def are_latest_certs_present(self):
-        pass
-
     def __run_cert_apt_command(self, command, step_name, raise_on_error=False):
         """Run apt/dpkg commands through package-manager wrapper."""
         out, code = self.invoke_package_manager_advanced(command, raise_on_exception=False)
@@ -1067,6 +1052,5 @@ class AptitudePackageManager(PackageManager):
         self.composite_logger.log_debug(
             "[APM][UpdateCerts] Shell step succeeded. [Step={0}][Output={1}]".format(step_name, str(out)))
         return True, out
-
     # endregion
 

--- a/src/core/src/package_managers/AptitudePackageManager.py
+++ b/src/core/src/package_managers/AptitudePackageManager.py
@@ -20,6 +20,7 @@ import os
 import re
 import shutil
 import sys
+from abc import abstractmethod
 
 from core.src.package_managers.PackageManager import PackageManager
 from core.src.bootstrap.Constants import Constants
@@ -90,6 +91,28 @@ class AptitudePackageManager(PackageManager):
         self.ubuntu_pro_client_all_updates_versions_cached = []
         
         self.package_install_expected_avg_time_in_seconds = 90  # As per telemetry data, the average time to install package is around 81 seconds for apt.
+
+        # Update certificates in factory defaults
+        # self.check_mokutil_exists_cmd = "command -v mokutil"
+        self.install_mokutil_cmd = "sudo apt-get install -y -qq mokutil"
+        self.proposed_repo_file_path = "/etc/apt/sources.list.d/proposed.list"
+        self.proposed_pin_file_path = "/etc/apt/preferences.d/proposed"
+        self.add_proposed_repo_cmd = (
+            "bash -c 'echo \"deb http://archive.ubuntu.com/ubuntu/ "
+            "$( . /etc/os-release && echo $VERSION_CODENAME )-proposed restricted main multiverse universe\" "
+            "| sudo tee {0}'").format(self.proposed_repo_file_path)
+        self.create_proposed_pin_cmd = (
+            "bash -c 'cat << EOF | sudo tee {0}\n"
+            "Package: *\n"
+            "Pin: release a=$( . /etc/os-release && echo $VERSION_CODENAME )-proposed\n"
+            "Pin-Priority: 100\n"
+            "EOF'").format(self.proposed_pin_file_path)
+        self.remove_proposed_repo_cmd = "sudo rm -f {0}".format(self.proposed_repo_file_path)
+        self.remove_proposed_pin_cmd = "sudo rm -f {0}".format(self.proposed_pin_file_path)
+        self.apt_update_cmd = "sudo apt-get -q update"
+        self.install_fwupd_from_proposed_cmd = "bash -c 'sudo apt-get install -y -t $( . /etc/os-release && echo $VERSION_CODENAME )-proposed fwupd'"
+        self.fwupd_refresh_cmd = "sudo fwupdmgr refresh" # NOTE: This could be made generic in package manager, depending on what solution type is adopted for other distros
+        self.fwupd_update_cmd = "sudo fwupdmgr update -y"
 
     # region Sources Management
     def __get_custom_sources_to_spec(self, max_patch_published_date=str(), base_classification=str()):
@@ -943,4 +966,107 @@ class AptitudePackageManager(PackageManager):
 
     def get_package_install_expected_avg_time_in_seconds(self):
         return self.package_install_expected_avg_time_in_seconds
+
+    # region Update certificates in factory defaults
+    @abstractmethod
+    def try_install_mokutil(self):
+        # type: () -> bool
+        """ Attempts to install mokutil """
+        cmd = self.install_mokutil_cmd
+        self.composite_logger.log_verbose('[APM] Invoking install mokutil command [Command={0}]'.format(cmd))
+        out, code = self.invoke_package_manager_advanced(cmd, raise_on_exception=False)
+        self.composite_logger.log_debug('[APM] Invoked install mokutil exists. [Command={0}][Code={1}][Output={2}]'.format(cmd, str(code), str(out)))
+        return code == 0
+
+    @abstractmethod
+    def fetch_current_certs(self, cert_type, get_cert_status_cmd, raise_on_exception=False):
+        # """ Fetches the status of the certificates on the machine """
+        pass
+
+    @abstractmethod
+    def is_latest_cert_installed(self, status_code, status_output):
+        """ Checks if the latest certs are already installed on the machine based on mokutil output """
+        pass
+
+    def try_update_certs(self):
+        """ Attempts to update certificate status """
+        self.composite_logger.log("[APM][Certs] Starting cert update flow.")
+        if self.are_latest_certs_present():
+            self.composite_logger.log("[APM][Certs] Latest certs already present. Skipping.")
+            return True
+
+        success = False
+        try:
+            # shell/file steps
+            self.__run_cert_shell_command(self.add_proposed_repo_cmd, "AddProposedRepo", raise_on_error=True)
+            self.__run_cert_shell_command(self.create_proposed_pin_cmd, "CreateAptPin", raise_on_error=True)
+
+            # apt/package-manager steps
+            self.__run_cert_apt_command(self.apt_update_cmd, "AptUpdateAfterRepo", raise_on_error=True)
+            self.__run_cert_apt_command(self.install_fwupd_from_proposed_cmd, "InstallFwupdFromProposed", raise_on_error=True)
+
+            # shell fwupd steps
+            self.__run_cert_shell_command(self.fwupd_refresh_cmd, "FwupdRefresh", raise_on_error=True)
+            self.__run_cert_shell_command(self.fwupd_update_cmd, "FwupdUpdate", raise_on_error=True)
+
+            if self.are_latest_certs_present():
+                self.composite_logger.log("[APM][Certs] Cert update completed and verified.")
+                success = True
+            else:
+                msg = "[APM][Certs] Cert update commands completed but latest certs not detected."
+                self.composite_logger.log_error(msg)
+                self.status_handler.add_error_to_status(msg, Constants.PatchOperationErrorCodes.CERTIFICATE_UPDATE)
+
+        except Exception as error:
+            self.composite_logger.log_error(
+                "[APM][Certs] Exception during cert update flow. [Error={0}]".format(repr(error)))
+
+        finally:
+            # best-effort cleanup
+            self.__run_cert_shell_command(self.remove_proposed_pin_cmd, "CleanupAptPin", raise_on_error=False)
+            self.__run_cert_shell_command(self.remove_proposed_repo_cmd, "CleanupProposedRepo", raise_on_error=False)
+            self.__run_cert_apt_command(self.apt_update_cmd, "AptUpdateAfterCleanup", raise_on_error=False)
+
+        if success:
+            self.status_handler.set_reboot_pending(self.is_reboot_pending())
+
+        return success
+
+    @abstractmethod
+    def are_latest_certs_present(self):
+        pass
+
+    def __run_cert_apt_command(self, command, step_name, raise_on_error=False):
+        """Run apt/dpkg commands through package-manager wrapper."""
+        out, code = self.invoke_package_manager_advanced(command, raise_on_exception=False)
+        if code != self.apt_exitcode_ok:
+            msg = "[APM][UpdateCerts] Apt step failed. [Step={0}][Command={1}][Code={2}][Output={3}]".format(
+                step_name, str(command), str(code), str(out))
+            self.composite_logger.log_error(msg)
+            self.status_handler.add_error_to_status(msg, Constants.PatchOperationErrorCodes.CERTIFICATE_UPDATE)
+            if raise_on_error:
+                raise Exception(msg, "[{0}]".format(Constants.ERROR_ADDED_TO_STATUS))
+            return False, out
+
+        self.composite_logger.log_debug(
+            "[APM][UpdateCerts] Apt step succeeded. [Step={0}][Output={1}]".format(step_name, str(out)))
+        return True, out
+
+    def __run_cert_shell_command(self, command, step_name, raise_on_error=False):
+        """Run non-apt utility commands directly."""
+        code, out = self.env_layer.run_command_output(command, False, False)
+        if code != 0:
+            msg = "[APM][UpdateCerts] Shell step failed. [Step={0}][Command={1}][Code={2}][Output={3}]".format(
+                step_name, str(command), str(code), str(out))
+            self.composite_logger.log_error(msg)
+            self.status_handler.add_error_to_status(msg, Constants.PatchOperationErrorCodes.CERTIFICATE_UPDATE)
+            if raise_on_error:
+                raise Exception(msg, "[{0}]".format(Constants.ERROR_ADDED_TO_STATUS))
+            return False, out
+
+        self.composite_logger.log_debug(
+            "[APM][UpdateCerts] Shell step succeeded. [Step={0}][Output={1}]".format(step_name, str(out)))
+        return True, out
+
+    # endregion
 

--- a/src/core/src/package_managers/AptitudePackageManager.py
+++ b/src/core/src/package_managers/AptitudePackageManager.py
@@ -20,7 +20,6 @@ import os
 import re
 import shutil
 import sys
-from abc import abstractmethod
 
 from core.src.package_managers.PackageManager import PackageManager
 from core.src.bootstrap.Constants import Constants
@@ -986,15 +985,12 @@ class AptitudePackageManager(PackageManager):
 
         success = False
         try:
-            # shell/file steps
             self.__run_cert_shell_command(self.add_proposed_repo_cmd, "AddProposedRepo", raise_on_error=True)
-            self.__run_cert_shell_command(self.create_proposed_pin_cmd, "CreateAptPin", raise_on_error=True)
-
-            # apt/package-manager steps
             self.__run_cert_apt_command(self.apt_update_cmd, "AptUpdateAfterRepo", raise_on_error=True)
+            self.__run_cert_shell_command(self.create_proposed_pin_cmd, "CreateAptPin", raise_on_error=True)
             self.__run_cert_apt_command(self.install_fwupd_from_proposed_cmd, "InstallFwupdFromProposed", raise_on_error=True)
 
-            # shell fwupd steps
+            # shell fwupd commands to update certificates
             self.__run_cert_shell_command(self.fwupd_refresh_cmd, "FwupdRefresh", raise_on_error=True)
             self.__run_cert_shell_command(self.fwupd_update_cmd, "FwupdUpdate", raise_on_error=True)
 
@@ -1007,8 +1003,7 @@ class AptitudePackageManager(PackageManager):
                 self.status_handler.add_error_to_status(msg, Constants.PatchOperationErrorCodes.CERTIFICATE_UPDATE)
 
         except Exception as error:
-            self.composite_logger.log_error(
-                "[APM][Certs] Exception during cert update flow. [Error={0}]".format(repr(error)))
+            self.composite_logger.log_error("[APM][Certs] Exception during cert update flow. [Error={0}]".format(repr(error)))
 
         finally:
             # best-effort cleanup
@@ -1017,6 +1012,8 @@ class AptitudePackageManager(PackageManager):
             self.__run_cert_apt_command(self.apt_update_cmd, "AptUpdateAfterCleanup", raise_on_error=False)
 
         if success:
+            # Not explicitly rebooting the VM to honor the customer's reboot preference and to avoid unexpected reboots.
+            # Reboot will only be performed if it is required by the VM after cert update and if the customer has set reboot setting in patch configuration to 'Reboot if required'.
             self.status_handler.set_reboot_pending(self.is_reboot_pending())
 
         return success
@@ -1025,32 +1022,28 @@ class AptitudePackageManager(PackageManager):
         """Run apt/dpkg commands through package-manager wrapper."""
         out, code = self.invoke_package_manager_advanced(command, raise_on_exception=False)
         if code != self.apt_exitcode_ok:
-            msg = "[APM][UpdateCerts] Apt step failed. [Step={0}][Command={1}][Code={2}][Output={3}]".format(
-                step_name, str(command), str(code), str(out))
+            msg = "[APM][UpdateCerts] Apt step failed. [Step={0}][Command={1}][Code={2}][Output={3}]".format(step_name, str(command), str(code), str(out))
             self.composite_logger.log_error(msg)
             self.status_handler.add_error_to_status(msg, Constants.PatchOperationErrorCodes.CERTIFICATE_UPDATE)
             if raise_on_error:
                 raise Exception(msg, "[{0}]".format(Constants.ERROR_ADDED_TO_STATUS))
             return False, out
 
-        self.composite_logger.log_debug(
-            "[APM][UpdateCerts] Apt step succeeded. [Step={0}][Output={1}]".format(step_name, str(out)))
+        self.composite_logger.log_debug("[APM][UpdateCerts] Apt step succeeded. [Step={0}][Output={1}]".format(step_name, str(out)))
         return True, out
 
     def __run_cert_shell_command(self, command, step_name, raise_on_error=False):
         """Run non-apt utility commands directly."""
         code, out = self.env_layer.run_command_output(command, False, False)
         if code != 0:
-            msg = "[APM][UpdateCerts] Shell step failed. [Step={0}][Command={1}][Code={2}][Output={3}]".format(
-                step_name, str(command), str(code), str(out))
+            msg = "[APM][UpdateCerts] Shell step failed. [Step={0}][Command={1}][Code={2}][Output={3}]".format(step_name, str(command), str(code), str(out))
             self.composite_logger.log_error(msg)
             self.status_handler.add_error_to_status(msg, Constants.PatchOperationErrorCodes.CERTIFICATE_UPDATE)
             if raise_on_error:
                 raise Exception(msg, "[{0}]".format(Constants.ERROR_ADDED_TO_STATUS))
             return False, out
 
-        self.composite_logger.log_debug(
-            "[APM][UpdateCerts] Shell step succeeded. [Step={0}][Output={1}]".format(step_name, str(out)))
+        self.composite_logger.log_debug("[APM][UpdateCerts] Shell step succeeded. [Step={0}][Output={1}]".format(step_name, str(out)))
         return True, out
     # endregion
 

--- a/src/core/src/package_managers/PackageManager.py
+++ b/src/core/src/package_managers/PackageManager.py
@@ -56,7 +56,7 @@ class PackageManager(object):
 
         # Update certificates in factory defaults
         self.check_mokutil_exists_cmd = "command -v mokutil"
-        self.get_kek_cert_status_cmd = "mokutil --kek | grep 'CN='"  # todo: review if this should be changed to mokutil --kek 2>&1 | grep -oP 'CN=\K[^,]+' | sort -u | tr '\n' '; ' || echo "none"
+        self.get_kek_cert_status_cmd = "mokutil --kek | grep 'CN='"
         self.get_db_cert_status_cmd = "mokutil --db | grep 'CN='"
         self.mokutil_success_exit_code = 0
 

--- a/src/core/src/package_managers/PackageManager.py
+++ b/src/core/src/package_managers/PackageManager.py
@@ -500,11 +500,11 @@ class PackageManager(object):
     # region Update certificates in factory defaults
     def update_certs(self):
         # 1. Fetch and Log current certs on the VM NOTE: Common across distros
-        # ensure mokutil exists
-        # if not, install mokutil
-        # If success, fetch cert detail
-        # If not, throw exception and stop
-        # log output
+            # ensure mokutil exists
+            # if not, install mokutil
+            # If success, fetch cert detail
+            # If not, throw exception and stop
+            # log output
         # 2. If 2023 certs already exists, do nothing
         # 3. If not, perform all the steps to update certs
         # 4. Validate and log new certs were installed
@@ -518,10 +518,9 @@ class PackageManager(object):
         if is_mokutil_installed or try_install_mokutil_status:
             self.try_update_certs()
         else:
-            error_msg = "[PM][UpdateCerts] Mokutil is not installed or could not be installed. Cannot fetch current certs."
+            error_msg = "[PM][UpdateCerts] Mokutil is not installed and could not be installed. Cannot fetch current certs."
             self.composite_logger.log_error(error_msg)
-            self.status_handler.add_error_to_status(error_msg,
-                                                    Constants.PatchOperationErrorCodes.CERTIFICATE_UPDATE)
+            self.status_handler.add_error_to_status(error_msg, Constants.PatchOperationErrorCodes.CERTIFICATE_UPDATE)
             raise Exception(error_msg, "[{0}]".format(Constants.ERROR_ADDED_TO_STATUS))
 
     def is_mokutil_installed(self):
@@ -562,7 +561,7 @@ class PackageManager(object):
 
     def is_latest_cert_installed(self, status_code, status_output):
         # type: (int, str) -> bool
-        """ Checks if the latest certs are already installed on the machine based on mokutil output """
+        """ Checks if the latest certs (i.e. 2023 certs) are already installed on the machine based on mokutil output """
         if status_code != self.mokutil_success_exit_code:
             return False
 

--- a/src/core/src/package_managers/PackageManager.py
+++ b/src/core/src/package_managers/PackageManager.py
@@ -54,6 +54,12 @@ class PackageManager(object):
         # Primarily for debian-based but generalizing for back-compat on customer-driven scenarios
         self.REBOOT_PENDING_FILE_PATH = '/var/run/reboot-required'
 
+        # Update certificates in factory defaults
+        self.check_mokutil_exists_cmd = "command -v mokutil"
+        self.get_kek_cert_status_cmd = "mokutil --kek | grep 'CN='"  # todo: review if this should be changed to mokutil --kek 2>&1 | grep -oP 'CN=\K[^,]+' | sort -u | tr '\n' '; ' || echo "none"
+        self.get_db_cert_status_cmd = "mokutil --db | grep 'CN='"
+        self.mokutil_success_exit_code = 0
+
     __metaclass__ = ABCMeta  # For Python 3.0+, it changes to class Abstract(metaclass=ABCMeta)
 
     @abstractmethod
@@ -490,4 +496,86 @@ class PackageManager(object):
     def get_package_install_expected_avg_time_in_seconds(self):
         """Retrieves average time to install package in seconds."""
         pass
+
+    # region Update certificates in factory defaults
+    def update_certs(self):
+        # 1. Fetch and Log current certs on the VM NOTE: Common across distros
+        # ensure mokutil exists
+        # if not, install mokutil
+        # If success, fetch cert detail
+        # If not, throw exception and stop
+        # log output
+        # 2. If 2023 certs already exists, do nothing
+        # 3. If not, perform all the steps to update certs
+        # 4. Validate and log new certs were installed
+
+        self.composite_logger.log_verbose("[PM] Updating current certificates if needed...")
+        is_mokutil_installed = self.is_mokutil_installed()
+        try_install_mokutil_status = False
+        if not is_mokutil_installed:
+            try_install_mokutil_status = self.try_install_mokutil()
+
+        if is_mokutil_installed or try_install_mokutil_status:
+            self.try_update_certs()
+        else:
+            error_msg = "[PM][UpdateCerts] Mokutil is not installed or could not be installed. Cannot fetch current certs."
+            self.composite_logger.log_error(error_msg)
+            self.status_handler.add_error_to_status(error_msg,
+                                                    Constants.PatchOperationErrorCodes.CERTIFICATE_UPDATE)
+            raise Exception(error_msg, "[{0}]".format(Constants.ERROR_ADDED_TO_STATUS))
+
+    def is_mokutil_installed(self):
+        # type: () -> bool
+        """check if mokutil is installed"""
+        cmd = self.check_mokutil_exists_cmd
+        self.composite_logger.log_verbose('[PM] Invoking check mokutil exists command [Command={0}]'.format(cmd))
+        code, out = self.env_layer.run_command_output(cmd, False, False)
+        self.composite_logger.log_debug('[PM] Invoked check mokutil exists. [Command={0}][Code={1}][Output={2}]'.format(cmd, str(code), str(out)))
+        return code == 0
+
+    def are_latest_certs_present(self):
+        kek_code, kek_out = self.fetch_current_certs(Constants.Certificates.KEK, self.get_kek_cert_status_cmd, raise_on_exception=False)
+        db_code, db_out = self.fetch_current_certs(Constants.Certificates.DB, self.get_db_cert_status_cmd, raise_on_exception=False)
+        return self.is_latest_cert_installed(kek_code, kek_out) and self.is_latest_cert_installed(db_code, db_out)
+
+    def fetch_current_certs(self, cert_type, get_cert_status_cmd, raise_on_exception=False):
+        # type: (str, str, bool) -> (int, str)
+        """ Fetches the status of the certificates on the machine """
+        cmd = get_cert_status_cmd
+        self.composite_logger.log_verbose('[PM] Invoking mokutil to fetch certificate details [Certificate={0}][Command={1}]'.format(cert_type, cmd))
+        code, out = self.env_layer.run_command_output(cmd, False, False)
+
+        if code != self.mokutil_success_exit_code:
+            self.composite_logger.log_warning('[ERROR] Customer environment error. Error invoking mokutil to fetch certificate status. '
+                                              '[Certificate={0}][Command={1}][Code={2}][Output={3}]'.format(cert_type, cmd, str(code), str(out)))
+            error_msg = ("Customer environment error: Investigate and resolve unexpected return code ({0}) for certificate ({1}) on command: {2}"
+                         .format(str(code), cert_type, cmd))
+            self.status_handler.add_error_to_status(error_msg, Constants.PatchOperationErrorCodes.CERTIFICATE_UPDATE)
+            if raise_on_exception:
+                raise Exception(error_msg, "[{0}]".format(Constants.ERROR_ADDED_TO_STATUS))
+
+        else:
+            self.composite_logger.log_debug('[PM] Invoked mokutil to fetch certificate details. [Certificate={0}][Command={1}][Code={2}][Output={3}]'
+                                            .format(cert_type, cmd, str(code), str(out)))
+
+        return code, out
+
+    def is_latest_cert_installed(self, status_code, status_output):
+        # type: (int, str) -> bool
+        """ Checks if the latest certs are already installed on the machine based on mokutil output """
+        if status_code != self.mokutil_success_exit_code:
+            return False
+
+        return Constants.LATEST_CERTIFICATE_TIMESTAMP in status_output
+
+    @abstractmethod
+    def try_install_mokutil(self):
+        """ Attempts to install mokutil """
+        pass
+
+    @abstractmethod
+    def try_update_certs(self):
+        """ Attempts to update certificate status """
+        pass
+    # endregion
 

--- a/src/core/src/package_managers/PackageManager.py
+++ b/src/core/src/package_managers/PackageManager.py
@@ -498,6 +498,7 @@ class PackageManager(object):
         pass
 
     # region Update certificates in factory defaults
+    # TODO (Before removing in-VM feature flag): This update should not be done in CVMs in current form
     def update_certs(self):
         # 1. Fetch and Log current certs on the VM NOTE: Common across distros
             # ensure mokutil exists

--- a/src/core/src/package_managers/TdnfPackageManager.py
+++ b/src/core/src/package_managers/TdnfPackageManager.py
@@ -765,3 +765,33 @@ class TdnfPackageManager(PackageManager):
     def get_package_install_expected_avg_time_in_seconds(self):
         return self.package_install_expected_avg_time_in_seconds
 
+    # region Update certificates in factory defaults
+    @abstractmethod
+    def update_certs(self):
+        pass
+
+    @abstractmethod
+    def try_install_mokutil(self):
+        """ Attempts to install mokutil """
+        pass
+
+    @abstractmethod
+    def fetch_current_certs(self, cert_type, get_cert_status_cmd, raise_on_exception=False):
+        # """ Fetches the status of the certificates on the machine """
+        pass
+
+    @abstractmethod
+    def is_latest_cert_installed(self, status_code, status_output):
+        """ Checks if the latest certs are already installed on the machine based on mokutil output """
+        pass
+
+    @abstractmethod
+    def try_update_certs(self):
+        """ Attempts to update certificate status """
+        pass
+
+    @abstractmethod
+    def are_latest_certs_present(self):
+        pass
+    # endregion
+

--- a/src/core/src/package_managers/TdnfPackageManager.py
+++ b/src/core/src/package_managers/TdnfPackageManager.py
@@ -766,32 +766,12 @@ class TdnfPackageManager(PackageManager):
         return self.package_install_expected_avg_time_in_seconds
 
     # region Update certificates in factory defaults
-    @abstractmethod
-    def update_certs(self):
-        pass
-
-    @abstractmethod
     def try_install_mokutil(self):
         """ Attempts to install mokutil """
         pass
 
-    @abstractmethod
-    def fetch_current_certs(self, cert_type, get_cert_status_cmd, raise_on_exception=False):
-        # """ Fetches the status of the certificates on the machine """
-        pass
-
-    @abstractmethod
-    def is_latest_cert_installed(self, status_code, status_output):
-        """ Checks if the latest certs are already installed on the machine based on mokutil output """
-        pass
-
-    @abstractmethod
     def try_update_certs(self):
         """ Attempts to update certificate status """
-        pass
-
-    @abstractmethod
-    def are_latest_certs_present(self):
         pass
     # endregion
 

--- a/src/core/src/package_managers/YumPackageManager.py
+++ b/src/core/src/package_managers/YumPackageManager.py
@@ -18,6 +18,7 @@
 import json
 import os
 import re
+from abc import abstractmethod
 from core.src.package_managers.PackageManager import PackageManager
 from core.src.bootstrap.Constants import Constants
 
@@ -1120,4 +1121,34 @@ class YumPackageManager(PackageManager):
 
     def get_package_install_expected_avg_time_in_seconds(self):
         return self.package_install_expected_avg_time_in_seconds
+
+    # region Update certificates in factory defaults
+    @abstractmethod
+    def update_certs(self):
+        pass
+
+    @abstractmethod
+    def try_install_mokutil(self):
+        """ Attempts to install mokutil """
+        pass
+
+    @abstractmethod
+    def fetch_current_certs(self, cert_type, get_cert_status_cmd, raise_on_exception=False):
+        # """ Fetches the status of the certificates on the machine """
+        pass
+
+    @abstractmethod
+    def is_latest_cert_installed(self, status_code, status_output):
+        """ Checks if the latest certs are already installed on the machine based on mokutil output """
+        pass
+
+    @abstractmethod
+    def try_update_certs(self):
+        """ Attempts to update certificate status """
+        pass
+
+    @abstractmethod
+    def are_latest_certs_present(self):
+        pass
+    # endregion
 

--- a/src/core/src/package_managers/YumPackageManager.py
+++ b/src/core/src/package_managers/YumPackageManager.py
@@ -18,7 +18,7 @@
 import json
 import os
 import re
-from abc import abstractmethod
+
 from core.src.package_managers.PackageManager import PackageManager
 from core.src.bootstrap.Constants import Constants
 

--- a/src/core/src/package_managers/YumPackageManager.py
+++ b/src/core/src/package_managers/YumPackageManager.py
@@ -1123,32 +1123,12 @@ class YumPackageManager(PackageManager):
         return self.package_install_expected_avg_time_in_seconds
 
     # region Update certificates in factory defaults
-    @abstractmethod
-    def update_certs(self):
-        pass
-
-    @abstractmethod
     def try_install_mokutil(self):
         """ Attempts to install mokutil """
         pass
 
-    @abstractmethod
-    def fetch_current_certs(self, cert_type, get_cert_status_cmd, raise_on_exception=False):
-        # """ Fetches the status of the certificates on the machine """
-        pass
-
-    @abstractmethod
-    def is_latest_cert_installed(self, status_code, status_output):
-        """ Checks if the latest certs are already installed on the machine based on mokutil output """
-        pass
-
-    @abstractmethod
     def try_update_certs(self):
         """ Attempts to update certificate status """
-        pass
-
-    @abstractmethod
-    def are_latest_certs_present(self):
         pass
     # endregion
 

--- a/src/core/src/package_managers/ZypperPackageManager.py
+++ b/src/core/src/package_managers/ZypperPackageManager.py
@@ -875,32 +875,12 @@ class ZypperPackageManager(PackageManager):
         return self.package_install_expected_avg_time_in_seconds
 
     # region Update certificates in factory defaults
-    @abstractmethod
-    def update_certs(self):
-        pass
-
-    @abstractmethod
     def try_install_mokutil(self):
         """ Attempts to install mokutil """
         pass
 
-    @abstractmethod
-    def fetch_current_certs(self, cert_type, get_cert_status_cmd, raise_on_exception=False):
-        # """ Fetches the status of the certificates on the machine """
-        pass
-
-    @abstractmethod
-    def is_latest_cert_installed(self, status_code, status_output):
-        """ Checks if the latest certs are already installed on the machine based on mokutil output """
-        pass
-
-    @abstractmethod
     def try_update_certs(self):
         """ Attempts to update certificate status """
-        pass
-
-    @abstractmethod
-    def are_latest_certs_present(self):
         pass
     # endregion
 

--- a/src/core/src/package_managers/ZypperPackageManager.py
+++ b/src/core/src/package_managers/ZypperPackageManager.py
@@ -19,7 +19,7 @@ import json
 import os
 import re
 import time
-from abc import abstractmethod
+
 from core.src.package_managers.PackageManager import PackageManager
 from core.src.bootstrap.Constants import Constants
 

--- a/src/core/src/package_managers/ZypperPackageManager.py
+++ b/src/core/src/package_managers/ZypperPackageManager.py
@@ -19,6 +19,7 @@ import json
 import os
 import re
 import time
+from abc import abstractmethod
 from core.src.package_managers.PackageManager import PackageManager
 from core.src.bootstrap.Constants import Constants
 
@@ -872,4 +873,34 @@ class ZypperPackageManager(PackageManager):
 
     def get_package_install_expected_avg_time_in_seconds(self):
         return self.package_install_expected_avg_time_in_seconds
+
+    # region Update certificates in factory defaults
+    @abstractmethod
+    def update_certs(self):
+        pass
+
+    @abstractmethod
+    def try_install_mokutil(self):
+        """ Attempts to install mokutil """
+        pass
+
+    @abstractmethod
+    def fetch_current_certs(self, cert_type, get_cert_status_cmd, raise_on_exception=False):
+        # """ Fetches the status of the certificates on the machine """
+        pass
+
+    @abstractmethod
+    def is_latest_cert_installed(self, status_code, status_output):
+        """ Checks if the latest certs are already installed on the machine based on mokutil output """
+        pass
+
+    @abstractmethod
+    def try_update_certs(self):
+        """ Attempts to update certificate status """
+        pass
+
+    @abstractmethod
+    def are_latest_certs_present(self):
+        pass
+    # endregion
 

--- a/src/core/tests/Test_AptitudePackageManager.py
+++ b/src/core/tests/Test_AptitudePackageManager.py
@@ -77,6 +77,16 @@ class TestAptitudePackageManager(unittest.TestCase):
     def mock_is_reboot_pending_returns_bool_False(self):
         return False
 
+    def mock_fetch_current_certs_only_db_latest(self, cert_type, get_cert_status_cmd, raise_on_exception=False):
+        if cert_type == Constants.Certificates.KEK:
+            return 0, "CN=LegacyCert 2011"
+        return 0, "CN=LatestCert 2023"
+
+    def mock_fetch_current_certs_kek_latest_db_fails(self, cert_type, get_cert_status_cmd, raise_on_exception=False):
+        if cert_type == Constants.Certificates.KEK:
+            return 0, "CN=LatestCert 2023"
+        return 1, "mokutil error"
+
     def mock_are_latest_certs_present_with_different_output_across_multiple_attempts(self):
         """Mock the presence of latest certs with different output across multiple attempts."""
         self.latest_certs_check_attempts += 1
@@ -98,6 +108,9 @@ class TestAptitudePackageManager(unittest.TestCase):
             if self.latest_apt_update_cmd_attempt == 2:
                 return 1, "Error"
         return 0, ""
+
+    def mock_is_mokutil_installed_return_false(self):
+        return False
     # endregion Mocks
 
     # region Utility Functions
@@ -1104,6 +1117,29 @@ class TestAptitudePackageManager(unittest.TestCase):
         package_manager = self.container.get('package_manager')
         self.assertFalse(package_manager.try_install_mokutil())
 
+    def test_are_latest_certs_present_returns_true_when_both_kek_and_db_are_latest(self):
+        self.runtime.set_legacy_test_type('SuccessInstallPath')
+        package_manager = self.container.get('package_manager')
+        self.assertTrue(package_manager.are_latest_certs_present())
+
+    def test_are_latest_certs_present_returns_false_when_kek_is_not_latest(self):
+        package_manager = self.container.get('package_manager')
+        backup_fetch_current_certs = package_manager.fetch_current_certs
+
+        package_manager.fetch_current_certs = self.mock_fetch_current_certs_only_db_latest
+
+        self.assertFalse(package_manager.are_latest_certs_present())
+        package_manager.fetch_current_certs = backup_fetch_current_certs
+
+    def test_are_latest_certs_present_returns_false_when_db_fetch_fails(self):
+        package_manager = self.container.get('package_manager')
+        backup_fetch_current_certs = package_manager.fetch_current_certs
+
+        package_manager.fetch_current_certs = self.mock_fetch_current_certs_kek_latest_db_fails
+
+        self.assertFalse(package_manager.are_latest_certs_present())
+        package_manager.fetch_current_certs = backup_fetch_current_certs
+
     def test_try_update_certs_returns_true_when_latest_certs_already_present(self):
         self.runtime.set_legacy_test_type('SuccessInstallPath')
         package_manager = self.container.get('package_manager')
@@ -1182,6 +1218,49 @@ class TestAptitudePackageManager(unittest.TestCase):
         self.assertEqual(package_manager.status_handler.is_reboot_pending, previous_reboot_pending_status)
 
         package_manager.env_layer.run_command_output = backup_run_command_output
+
+    def test_update_certs_calls_try_update_when_mokutil_already_installed(self):
+        package_manager = self.container.get('package_manager')
+        backup_try_update_certs = package_manager.try_update_certs
+
+        calls = []
+        package_manager.try_update_certs = lambda: calls.append("try_update_certs")
+        package_manager.update_certs()
+
+        self.assertEqual(calls, ["try_update_certs"])
+        package_manager.try_update_certs = backup_try_update_certs
+
+    def test_update_certs_calls_try_update_when_mokutil_install_succeeds(self):
+        package_manager = self.container.get('package_manager')
+        backup_is_mokutil_installed = package_manager.is_mokutil_installed
+        backup_try_update_certs = package_manager.try_update_certs
+
+        calls = []
+        package_manager.is_mokutil_installed = self.mock_is_mokutil_installed_return_false
+        package_manager.try_update_certs = lambda: calls.append("try_update_certs")
+
+        package_manager.update_certs()
+        self.assertEqual(calls, ["try_update_certs"])
+
+        package_manager.is_mokutil_installed = backup_is_mokutil_installed
+        package_manager.try_update_certs = backup_try_update_certs
+
+    def test_update_certs_raises_when_mokutil_install_fails(self):
+        self.runtime.set_legacy_test_type('SadPath')
+        package_manager = self.container.get('package_manager')
+        backup_add_error_to_status = package_manager.status_handler.add_error_to_status
+
+        captured_errors = []
+        package_manager.status_handler.add_error_to_status = lambda error_msg, error_code=None: captured_errors.append((error_msg, error_code))
+
+        self.assertRaises(Exception, package_manager.update_certs)
+        self.assertEqual(len(captured_errors), 2)
+        self.assertTrue("Customer environment error:" in captured_errors[0][0])
+        self.assertEqual(captured_errors[0][1], Constants.PatchOperationErrorCodes.PACKAGE_MANAGER_FAILURE)
+        self.assertTrue("Mokutil is not installed and could not be installed" in captured_errors[1][0])
+        self.assertEqual(captured_errors[1][1], Constants.PatchOperationErrorCodes.CERTIFICATE_UPDATE)
+
+        package_manager.status_handler.add_error_to_status = backup_add_error_to_status
     # endregion
 
 

--- a/src/core/tests/Test_AptitudePackageManager.py
+++ b/src/core/tests/Test_AptitudePackageManager.py
@@ -71,7 +71,6 @@ class TestAptitudePackageManager(unittest.TestCase):
 
     def mock_get_security_updates_return_empty_list(self):
         return [], []
-
     # endregion Mocks
 
     # region Utility Functions
@@ -1067,6 +1066,30 @@ class TestAptitudePackageManager(unittest.TestCase):
         self.assertTrue(os.path.exists(Constants.AzGPSPaths.EULA_SETTINGS))
         self.assertEqual(exec_config.accept_package_eula, False)
         runtime.stop()
+
+    # region Update certs tests
+    def test_try_install_mokutil_success(self):
+        package_manager = self.container.get('package_manager')
+        self.assertTrue(package_manager.try_install_mokutil())
+
+    def test_try_install_mokutil_failure(self):
+        self.runtime.set_legacy_test_type('SadPath')
+        package_manager = self.container.get('package_manager')
+        self.assertFalse(package_manager.try_install_mokutil())
+
+    def test_try_update_certs_returns_true_when_latest_certs_already_present(self):
+        self.runtime.set_legacy_test_type('SuccessInstallPath')
+        package_manager = self.container.get('package_manager')
+
+        shell_calls = []
+        apt_calls = []
+        package_manager._AptitudePackageManager__run_cert_shell_command = lambda command, step_name, raise_on_error=False: shell_calls.append(step_name)
+        package_manager._AptitudePackageManager__run_cert_apt_command = lambda command, step_name, raise_on_error=False: apt_calls.append(step_name)
+
+        self.assertTrue(package_manager.try_update_certs())
+        self.assertEqual(shell_calls, [])
+        self.assertEqual(apt_calls, [])
+    # endregion
 
 
 if __name__ == '__main__':

--- a/src/core/tests/Test_AptitudePackageManager.py
+++ b/src/core/tests/Test_AptitudePackageManager.py
@@ -1255,9 +1255,9 @@ class TestAptitudePackageManager(unittest.TestCase):
 
         self.assertRaises(Exception, package_manager.update_certs)
         self.assertEqual(len(captured_errors), 2)
-        self.assertTrue("Customer environment error:" in captured_errors[0][0])
+        self.assertIn("Customer environment error:", captured_errors[0][0])
         self.assertEqual(captured_errors[0][1], Constants.PatchOperationErrorCodes.PACKAGE_MANAGER_FAILURE)
-        self.assertTrue("Mokutil is not installed and could not be installed" in captured_errors[1][0])
+        self.assertIn("Mokutil is not installed and could not be installed", captured_errors[1][0])
         self.assertEqual(captured_errors[1][1], Constants.PatchOperationErrorCodes.CERTIFICATE_UPDATE)
 
         package_manager.status_handler.add_error_to_status = backup_add_error_to_status

--- a/src/core/tests/Test_AptitudePackageManager.py
+++ b/src/core/tests/Test_AptitudePackageManager.py
@@ -37,6 +37,8 @@ class TestAptitudePackageManager(unittest.TestCase):
         self.argument_composer = ArgumentComposer().get_composed_arguments()
         self.runtime = RuntimeCompositor(self.argument_composer, True, Constants.APT)
         self.container = self.runtime.container
+        self.latest_certs_check_attempts = 0
+        self.latest_apt_update_cmd_attempt = 0
 
     def tearDown(self):
         self.runtime.stop()
@@ -71,6 +73,31 @@ class TestAptitudePackageManager(unittest.TestCase):
 
     def mock_get_security_updates_return_empty_list(self):
         return [], []
+
+    def mock_is_reboot_pending_returns_bool_False(self):
+        return False
+
+    def mock_are_latest_certs_present_with_different_output_across_multiple_attempts(self):
+        """Mock the presence of latest certs with different output across multiple attempts."""
+        self.latest_certs_check_attempts += 1
+
+        # Mock the first attempt to indicate certs are not present
+        if self.latest_certs_check_attempts == 1:
+            return False
+
+        return True
+
+    def mock_run_command_output_remove_proposed_pin_fails(self, cmd, no_output=False, chk_err=True):
+        if cmd.find(self.runtime.package_manager.remove_proposed_pin_cmd) > -1:
+            return 1, "Error"
+        return 0, ""
+
+    def mock_run_command_output_apt_update_cmd_fails(self, cmd, no_output=False, chk_err=True):
+        if cmd.find(self.runtime.package_manager.apt_update_cmd) > -1:
+            self.latest_apt_update_cmd_attempt +=1
+            if self.latest_apt_update_cmd_attempt == 2:
+                return 1, "Error"
+        return 0, ""
     # endregion Mocks
 
     # region Utility Functions
@@ -1089,6 +1116,72 @@ class TestAptitudePackageManager(unittest.TestCase):
         self.assertTrue(package_manager.try_update_certs())
         self.assertEqual(shell_calls, [])
         self.assertEqual(apt_calls, [])
+
+    def test_try_update_certs_success(self):
+        package_manager = self.container.get('package_manager')
+
+        backup_is_reboot_pending = package_manager.is_reboot_pending
+        backup_are_latest_certs_present = package_manager.are_latest_certs_present
+        package_manager.is_reboot_pending = self.mock_is_reboot_pending_returns_bool_False
+        package_manager.are_latest_certs_present = self.mock_are_latest_certs_present_with_different_output_across_multiple_attempts
+
+        self.assertTrue(package_manager.try_update_certs())
+        self.assertEqual(package_manager.status_handler.is_reboot_pending, False)
+
+        package_manager.is_reboot_pending = backup_is_reboot_pending
+        package_manager.are_latest_certs_present = backup_are_latest_certs_present
+
+    def test_try_update_certs_all_commands_succeed_but_certs_not_updated(self):
+        """ Test when all commands to update certs succeed but certs are still not updated,
+        which should return False and not change reboot pending status """
+        package_manager = self.container.get('package_manager')
+        previous_reboot_pending_status = package_manager.status_handler.is_reboot_pending
+        self.assertFalse(package_manager.try_update_certs())
+        self.assertEqual(package_manager.status_handler.is_reboot_pending, previous_reboot_pending_status)
+
+    def test_try_update_certs_shell_command_fail_raises_exception(self):
+        """ Test when a command to update certs fails, which should return False and not change reboot pending status"""
+        self.runtime.set_legacy_test_type('SadPath')
+        package_manager = self.container.get('package_manager')
+        previous_reboot_pending_status = package_manager.status_handler.is_reboot_pending
+        self.assertFalse(package_manager.try_update_certs())
+        self.assertEqual(package_manager.status_handler.is_reboot_pending, previous_reboot_pending_status)
+
+    def test_try_update_certs_apt_command_fail_raises_exception(self):
+        """ Test when a command to update certs fails, which should return False and not change reboot pending status"""
+        self.runtime.set_legacy_test_type('FailInstallPath')
+        package_manager = self.container.get('package_manager')
+        previous_reboot_pending_status = package_manager.status_handler.is_reboot_pending
+        self.assertFalse(package_manager.try_update_certs())
+        self.assertEqual(package_manager.status_handler.is_reboot_pending, previous_reboot_pending_status)
+
+    def test_try_update_certs_shell_command_fail_no_exception_raised(self):
+        """ Test when a command to update certs fails, which should return False and not change reboot pending status"""
+        self.runtime.set_legacy_test_type('HappyPath')
+        package_manager = self.container.get('package_manager')
+
+        backup_run_command_output = package_manager.env_layer.run_command_output
+        package_manager.env_layer.run_command_output = self.mock_run_command_output_remove_proposed_pin_fails
+
+        previous_reboot_pending_status = package_manager.status_handler.is_reboot_pending
+        self.assertFalse(package_manager.try_update_certs())
+        self.assertEqual(package_manager.status_handler.is_reboot_pending, previous_reboot_pending_status)
+
+        package_manager.env_layer.run_command_output = backup_run_command_output
+
+    def test_try_update_certs_apt_command_fail_no_exception_raised(self):
+        """ Test when a command to update certs fails, which should return False and not change reboot pending status"""
+        self.runtime.set_legacy_test_type('HappyPath')
+        package_manager = self.container.get('package_manager')
+
+        backup_run_command_output = package_manager.env_layer.run_command_output
+        package_manager.env_layer.run_command_output = self.mock_run_command_output_apt_update_cmd_fails
+
+        previous_reboot_pending_status = package_manager.status_handler.is_reboot_pending
+        self.assertFalse(package_manager.try_update_certs())
+        self.assertEqual(package_manager.status_handler.is_reboot_pending, previous_reboot_pending_status)
+
+        package_manager.env_layer.run_command_output = backup_run_command_output
     # endregion
 
 

--- a/src/core/tests/Test_EnvLayer.py
+++ b/src/core/tests/Test_EnvLayer.py
@@ -152,31 +152,31 @@ class TestExecutionConfig(unittest.TestCase):
         self.envlayer.platform.cpu_arch()
         self.envlayer.platform.vm_name()
 
-    def test_get_package_manager_azure_linux_4_and_rhel10_not_supported(self):
-        """Test that Azure Linux 4 and RHEL 10 log unsupported message"""
-        self.backup_platform_system = platform.system
-        self.backup_linux_distribution = self.envlayer.platform.linux_distribution
-        self.backup_distro_os_release_attr = distro.os_release_attr
-
-        platform.system = self.mock_platform_system
-        test_input_output_table = [
-            [self.mock_linux_distribution_to_return_azure_linux_4, self.mock_distro_os_release_attr_return_azure_linux_4, "Error: This distro is not yet supported in your region. Please review https://aka.ms/VMGuestPatchingCompatibility for more information. [Distro=Microsoft Azure Linux][Version=4.0][Code=]\n"],
-            [self.mock_linux_distribution_to_return_rhel_10, self.mock_distro_os_release_attr_return_rhel_10, "Error: This distro is not yet supported in your region. Please review https://aka.ms/VMGuestPatchingCompatibility for more information. [Distro=Red Hat][Version=10.0][Code=abc]\n"],
-        ]
-
-        for row in test_input_output_table:
-            self.envlayer.platform.linux_distribution = row[0]
-            distro.os_release_attr = row[1]
-
-            captured_output = io.StringIO()
-            sys.stdout = captured_output
-            result = self.envlayer.get_package_manager()
-            sys.stdout = sys.__stdout__
-            self.assertEqual(row[2], captured_output.getvalue())
-            self.assertEqual(result, "")
-
-        # restore
-        self.__restore_mocks()
+    # def test_get_package_manager_azure_linux_4_and_rhel10_not_supported(self):
+    #     """Test that Azure Linux 4 and RHEL 10 log unsupported message"""
+    #     self.backup_platform_system = platform.system
+    #     self.backup_linux_distribution = self.envlayer.platform.linux_distribution
+    #     self.backup_distro_os_release_attr = distro.os_release_attr
+    #
+    #     platform.system = self.mock_platform_system
+    #     test_input_output_table = [
+    #         [self.mock_linux_distribution_to_return_azure_linux_4, self.mock_distro_os_release_attr_return_azure_linux_4, "Error: This distro is not yet supported in your region. Please review https://aka.ms/VMGuestPatchingCompatibility for more information. [Distro=Microsoft Azure Linux][Version=4.0][Code=]\n"],
+    #         [self.mock_linux_distribution_to_return_rhel_10, self.mock_distro_os_release_attr_return_rhel_10, "Error: This distro is not yet supported in your region. Please review https://aka.ms/VMGuestPatchingCompatibility for more information. [Distro=Red Hat][Version=10.0][Code=abc]\n"],
+    #     ]
+    #
+    #     for row in test_input_output_table:
+    #         self.envlayer.platform.linux_distribution = row[0]
+    #         distro.os_release_attr = row[1]
+    #
+    #         captured_output = io.StringIO()
+    #         sys.stdout = captured_output
+    #         result = self.envlayer.get_package_manager()
+    #         sys.stdout = sys.__stdout__
+    #         self.assertEqual(row[2], captured_output.getvalue())
+    #         self.assertEqual(result, "")
+    #
+    #     # restore
+    #     self.__restore_mocks()
 
     def __restore_mocks(self):
         """Restore backed up mocks to their original state"""

--- a/src/core/tests/Test_ExecutionConfig.py
+++ b/src/core/tests/Test_ExecutionConfig.py
@@ -13,9 +13,12 @@
 # limitations under the License.
 #
 # Requires Python 2.7+
+import json
+import os
 import unittest
 
 from core.src.bootstrap.Constants import Constants
+from core.src.core_logic.ExecutionConfig import ExecutionConfig
 from core.tests.library.ArgumentComposer import ArgumentComposer
 from core.tests.library.RuntimeCompositor import RuntimeCompositor
 
@@ -26,6 +29,11 @@ class TestExecutionConfig(unittest.TestCase):
 
     def tearDown(self):
         pass
+
+    # region Mocks
+    def mock_read_with_retry_raise_exception(self):
+        raise Exception
+    # endregion
 
     def test_get_max_patch_publish_date(self):
         test_input_output_table = [
@@ -42,6 +50,149 @@ class TestExecutionConfig(unittest.TestCase):
         runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.YUM)
         for row in test_input_output_table:
             self.assertEqual(runtime.execution_config._ExecutionConfig__get_max_patch_publish_date(row[0]), row[1])
+        runtime.stop()
+
+    def test_uefi_config_when_file_does_not_exist(self):
+        # UEFI in-VM customer config does not exist
+        runtime, execution_config = self.__setup_and_init_execution_config(write_to_file=False, config="UEFI")
+        self.__assert_uefi_configs(execution_config=execution_config, expected_file_exists=False, expected_enable_uefi_cert_update=False)
+        self.__teardown(runtime)
+
+    def test_uefi_config_when_no_data_found_in_file(self):
+        # UEFI in-VM customer config file exists but the file has no data
+        uefi_settings = None
+        runtime, execution_config = self.__setup_and_init_execution_config(write_to_file=True, config="UEFI", config_settings=uefi_settings)
+        self.__assert_uefi_configs(execution_config=execution_config, expected_file_exists=True, expected_enable_uefi_cert_update=False)
+        self.__teardown(runtime)
+
+    def test_uefi_config_when_enable_uefi_cert_update_not_in_config(self):
+        # EnableUEFICertUpdate not set in config
+        uefi_settings = {
+            "EnabledBy": "TestSetup",
+            "LastModified": "2026-04-21"
+        }
+        runtime, execution_config = self.__setup_and_init_execution_config(write_to_file=True, config="UEFI", config_settings=uefi_settings)
+        self.__assert_uefi_configs(execution_config=execution_config, expected_file_exists=True, expected_enable_uefi_cert_update=False)
+        self.__teardown(runtime)
+
+    def test_uefi_config_when_enable_uefi_cert_update_not_set_as_boolean(self):
+        uefi_settings = {
+            "EnabledBy": "TestSetup",
+            "LastModified": "2026-04-21",
+            "EnableUEFICertUpdate": "test"
+        }
+        runtime, execution_config = self.__setup_and_init_execution_config(write_to_file=True, config="UEFI", config_settings=uefi_settings)
+        self.__assert_uefi_configs(execution_config=execution_config, expected_file_exists=True, expected_enable_uefi_cert_update=False)
+        self.__teardown(runtime)
+
+    def test_uefi_config_with_illformed_config(self):
+        uefi_settings = ["test unexpected config value"]
+        runtime, execution_config = self.__setup_and_init_execution_config(write_to_file=True, config="UEFI", config_settings=uefi_settings)
+        self.__assert_uefi_configs(execution_config=execution_config, expected_file_exists=True, expected_enable_uefi_cert_update=False)
+        self.__teardown(runtime)
+
+    def test_uefi_config_when_file_read_raises_exception(self):
+        uefi_settings = {
+            "EnabledBy": "TestSetup",
+            "LastModified": "2026-04-21",
+            "EnableUEFICertUpdate": "test"
+        }
+        runtime, execution_config = self.__setup_and_init_execution_config(write_to_file=True, config="UEFI", config_settings=uefi_settings)
+        self.backup_read_with_retry = runtime.env_layer.file_system.read_with_retry
+        runtime.env_layer.file_system.read_with_retry = self.mock_read_with_retry_raise_exception
+        exec_config = ExecutionConfig(runtime.env_layer, runtime.composite_logger, str(runtime.argv))
+        self.__assert_uefi_configs(execution_config=exec_config, expected_file_exists=True, expected_enable_uefi_cert_update=False)
+        runtime.env_layer.file_system.read_with_retry = self.backup_read_with_retry
+        self.__teardown(runtime)
+
+    def test_uefi_config_file_with_enable_uefi_cert_update_set_to_false(self):
+        # Tests UEFI cert update enable set with different non-true values
+
+        # Value set to boolean False
+        uefi_settings = {
+            "EnabledBy": "TestSetup",
+            "LastModified": "2026-04-21",
+            "EnableUEFICertUpdate": False
+        }
+        runtime, execution_config = self.__setup_and_init_execution_config(write_to_file=True, config="UEFI", config_settings=uefi_settings)
+        self.__assert_uefi_configs(execution_config=execution_config, expected_file_exists=True, expected_enable_uefi_cert_update=False)
+        self.__teardown(runtime)
+
+        # Value set to random string
+        uefi_settings = {
+            "EnabledBy": "TestSetup",
+            "LastModified": "2026-04-21",
+            "EnableUEFICertUpdate": "3"
+        }
+        runtime, execution_config = self.__setup_and_init_execution_config(write_to_file=True, config="UEFI", config_settings=uefi_settings)
+        self.__assert_uefi_configs(execution_config=execution_config, expected_file_exists=True, expected_enable_uefi_cert_update=False)
+        self.__teardown(runtime)
+
+    def test_uefi_config_file_with_enable_uefi_cert_update_set_to_true(self):
+        # Tests EnableUEFICertUpdate with all acceptable values of true
+
+        # Value set to boolean True
+        uefi_settings = {
+            "EnabledBy": "TestSetup",
+            "LastModified": "2026-04-21",
+            "EnableUEFICertUpdate": True
+        }
+        runtime, execution_config = self.__setup_and_init_execution_config(write_to_file=True, config="UEFI", config_settings=uefi_settings)
+        self.__assert_uefi_configs(execution_config=execution_config, expected_file_exists=True, expected_enable_uefi_cert_update=True)
+        self.__teardown(runtime)
+
+        # Value set to string "True"
+        uefi_settings["EnableUEFICertUpdate"] = "True"
+        runtime, execution_config = self.__setup_and_init_execution_config(write_to_file=True, config="UEFI", config_settings=uefi_settings)
+        self.__assert_uefi_configs(execution_config=execution_config, expected_file_exists=True, expected_enable_uefi_cert_update=True)
+        self.__teardown(runtime)
+
+        # Value set to string "true"
+        uefi_settings["EnableUEFICertUpdate"] = "true"
+        runtime, execution_config = self.__setup_and_init_execution_config(write_to_file=True, config="UEFI", config_settings=uefi_settings)
+        self.__assert_uefi_configs(execution_config=execution_config, expected_file_exists=True, expected_enable_uefi_cert_update=True)
+        self.__teardown(runtime)
+
+        # Value set to string "1"
+        uefi_settings["EnableUEFICertUpdate"] = "1"
+        runtime, execution_config = self.__setup_and_init_execution_config(write_to_file=True, config="UEFI", config_settings=uefi_settings)
+        self.__assert_uefi_configs(execution_config=execution_config, expected_file_exists=True, expected_enable_uefi_cert_update=True)
+        self.__teardown(runtime)
+
+        # Value set to 1
+        uefi_settings["EnableUEFICertUpdate"] = 1
+        runtime, execution_config = self.__setup_and_init_execution_config(write_to_file=True, config="UEFI", config_settings=uefi_settings)
+        self.__assert_uefi_configs(execution_config=execution_config, expected_file_exists=True, expected_enable_uefi_cert_update=True)
+        self.__teardown(runtime)
+
+    def __assert_uefi_configs(self, execution_config, expected_file_exists, expected_enable_uefi_cert_update):
+        self.assertEqual(os.path.exists(Constants.AzGPSPaths.UEFI_SETTINGS), expected_file_exists)
+        self.assertEqual(execution_config.enable_uefi_cert_update, expected_enable_uefi_cert_update)
+
+    def __setup_and_init_execution_config(self, write_to_file=False, config=None, config_settings=None):
+        argument_composer = ArgumentComposer()
+        config_file_path = None
+        if config is not None and config == "UEFI":
+            config_file_path = Constants.AzGPSPaths.UEFI_SETTINGS
+
+        if write_to_file:
+            self.__write_config_settings_to_file(config_settings, config_file_path=config_file_path)
+        runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, package_manager_name=Constants.APT)
+        container = runtime.container
+        execution_config = container.get('execution_config')
+        return runtime, execution_config
+
+    @staticmethod
+    def __write_config_settings_to_file(config_settings, config_file_path):
+        f = open(config_file_path, "w+")
+        f.write(json.dumps(config_settings))
+        f.close()
+
+    @staticmethod
+    def __teardown(runtime):
+        # remove the uefi settings file if it exists after the test
+        if os.path.exists(Constants.AzGPSPaths.UEFI_SETTINGS):
+            os.remove(Constants.AzGPSPaths.UEFI_SETTINGS)
         runtime.stop()
 
 

--- a/src/core/tests/Test_ExecutionConfig.py
+++ b/src/core/tests/Test_ExecutionConfig.py
@@ -214,9 +214,8 @@ class TestExecutionConfig(unittest.TestCase):
 
     @staticmethod
     def __write_config_settings_to_file(config_settings, config_file_path):
-        f = open(config_file_path, "w+")
-        f.write(json.dumps(config_settings))
-        f.close()
+        with open(config_file_path, "w+") as f:
+            f.write(json.dumps(config_settings))
 
     @staticmethod
     def __teardown(runtime):

--- a/src/core/tests/Test_ExecutionConfig.py
+++ b/src/core/tests/Test_ExecutionConfig.py
@@ -58,39 +58,6 @@ class TestExecutionConfig(unittest.TestCase):
         self.__assert_uefi_configs(execution_config=execution_config, expected_file_exists=False, expected_enable_uefi_cert_update=False)
         self.__teardown(runtime)
 
-    def test_uefi_config_when_no_data_found_in_file(self):
-        # UEFI in-VM customer config file exists but the file has no data
-        uefi_settings = None
-        runtime, execution_config = self.__setup_and_init_execution_config(write_to_file=True, config="UEFI", config_settings=uefi_settings)
-        self.__assert_uefi_configs(execution_config=execution_config, expected_file_exists=True, expected_enable_uefi_cert_update=False)
-        self.__teardown(runtime)
-
-    def test_uefi_config_when_enable_uefi_cert_update_not_in_config(self):
-        # EnableUEFICertUpdate not set in config
-        uefi_settings = {
-            "EnabledBy": "TestSetup",
-            "LastModified": "2026-04-21"
-        }
-        runtime, execution_config = self.__setup_and_init_execution_config(write_to_file=True, config="UEFI", config_settings=uefi_settings)
-        self.__assert_uefi_configs(execution_config=execution_config, expected_file_exists=True, expected_enable_uefi_cert_update=False)
-        self.__teardown(runtime)
-
-    def test_uefi_config_when_enable_uefi_cert_update_not_set_as_boolean(self):
-        uefi_settings = {
-            "EnabledBy": "TestSetup",
-            "LastModified": "2026-04-21",
-            "EnableUEFICertUpdate": "test"
-        }
-        runtime, execution_config = self.__setup_and_init_execution_config(write_to_file=True, config="UEFI", config_settings=uefi_settings)
-        self.__assert_uefi_configs(execution_config=execution_config, expected_file_exists=True, expected_enable_uefi_cert_update=False)
-        self.__teardown(runtime)
-
-    def test_uefi_config_with_illformed_config(self):
-        uefi_settings = ["test unexpected config value"]
-        runtime, execution_config = self.__setup_and_init_execution_config(write_to_file=True, config="UEFI", config_settings=uefi_settings)
-        self.__assert_uefi_configs(execution_config=execution_config, expected_file_exists=True, expected_enable_uefi_cert_update=False)
-        self.__teardown(runtime)
-
     def test_uefi_config_when_file_read_raises_exception(self):
         uefi_settings = {
             "EnabledBy": "TestSetup",
@@ -105,65 +72,128 @@ class TestExecutionConfig(unittest.TestCase):
         runtime.env_layer.file_system.read_with_retry = self.backup_read_with_retry
         self.__teardown(runtime)
 
-    def test_uefi_config_file_with_enable_uefi_cert_update_set_to_false(self):
-        # Tests UEFI cert update enable set with different non-true values
+    def test_uefi_config_file_with_enable_uefi_cert_update(self):
+        # Tests UEFI cert update enable set with different values based in uefi config
 
-        # Value set to boolean False
-        uefi_settings = {
+        # Use Case 1: No UEFI config found on VM
+        uefi_settings_update_cert_when_no_uefi_config = None
+        expected_file_status_when_no_uefi_config = True
+        expected_enable_uefi_when_no_uefi_config = False
+
+        # Use Case 2: UEFI settings are illformed
+        uefi_settings_update_cert_when_enable_not_in_config = {
+            "EnabledBy": "TestSetup",
+            "LastModified": "2026-04-21"
+        }
+        expected_file_status_when_enable_not_in_config = True
+        expected_enable_uefi_when_enable_not_in_config = False
+
+        # Use Case 3: UEFI settings are illformed
+        uefi_settings_update_cert_illformed_config = ["test unexpected config value"]
+        expected_file_status_when_illformed_config = True
+        expected_enable_uefi_when_illformed_config = False
+
+        # Use Case 4: Value set to boolean False
+        uefi_settings_update_cert_false = {
             "EnabledBy": "TestSetup",
             "LastModified": "2026-04-21",
             "EnableUEFICertUpdate": False
         }
-        runtime, execution_config = self.__setup_and_init_execution_config(write_to_file=True, config="UEFI", config_settings=uefi_settings)
-        self.__assert_uefi_configs(execution_config=execution_config, expected_file_exists=True, expected_enable_uefi_cert_update=False)
-        self.__teardown(runtime)
+        expected_file_status_when_update_cert_false = True
+        expected_enable_uefi_when_update_cert_false = False
 
-        # Value set to random string
-        uefi_settings = {
+        # Use Case 5: Value set to random string
+        uefi_settings_when_update_cert_is_str = {
             "EnabledBy": "TestSetup",
             "LastModified": "2026-04-21",
             "EnableUEFICertUpdate": "3"
         }
-        runtime, execution_config = self.__setup_and_init_execution_config(write_to_file=True, config="UEFI", config_settings=uefi_settings)
-        self.__assert_uefi_configs(execution_config=execution_config, expected_file_exists=True, expected_enable_uefi_cert_update=False)
-        self.__teardown(runtime)
+        expected_file_status_when_update_cert_is_str = True
+        expected_enable_uefi_when_update_cert_is_str = False
 
-    def test_uefi_config_file_with_enable_uefi_cert_update_set_to_true(self):
+        # Use Case 6: Value set to random string test 2
+        uefi_settings_when_update_cert_is_str_test2 = {
+            "EnabledBy": "TestSetup",
+            "LastModified": "2026-04-21",
+            "EnableUEFICertUpdate": "test"
+        }
+        expected_file_status_when_update_cert_is_str_test2 = True
+        expected_enable_uefi_when_update_cert_is_str_test2 = False
+
+        # Use Case 7: Value set to float
+        uefi_settings_when_update_cert_is_float = {
+            "EnabledBy": "TestSetup",
+            "LastModified": "2026-04-21",
+            "EnableUEFICertUpdate": 3.1
+        }
+        expected_file_status_when_update_cert_is_float = True
+        expected_enable_uefi_when_update_cert_is_float = False
+
         # Tests EnableUEFICertUpdate with all acceptable values of true
-
-        # Value set to boolean True
-        uefi_settings = {
+        # Use Case 8: Value set to boolean True
+        uefi_settings_when_update_cert_true = {
             "EnabledBy": "TestSetup",
             "LastModified": "2026-04-21",
             "EnableUEFICertUpdate": True
         }
-        runtime, execution_config = self.__setup_and_init_execution_config(write_to_file=True, config="UEFI", config_settings=uefi_settings)
-        self.__assert_uefi_configs(execution_config=execution_config, expected_file_exists=True, expected_enable_uefi_cert_update=True)
-        self.__teardown(runtime)
+        expected_file_status_when_update_cert_true = True
+        expected_enable_uefi_when_update_cert_true = True
 
-        # Value set to string "True"
-        uefi_settings["EnableUEFICertUpdate"] = "True"
-        runtime, execution_config = self.__setup_and_init_execution_config(write_to_file=True, config="UEFI", config_settings=uefi_settings)
-        self.__assert_uefi_configs(execution_config=execution_config, expected_file_exists=True, expected_enable_uefi_cert_update=True)
-        self.__teardown(runtime)
+        # Use Case 9: Value set to boolean True
+        uefi_settings_when_update_cert_true_str = {
+            "EnabledBy": "TestSetup",
+            "LastModified": "2026-04-21",
+            "EnableUEFICertUpdate": "True"
+        }
+        expected_file_status_when_update_cert_true_str = True
+        expected_enable_uefi_when_update_cert_true_str = True
 
-        # Value set to string "true"
-        uefi_settings["EnableUEFICertUpdate"] = "true"
-        runtime, execution_config = self.__setup_and_init_execution_config(write_to_file=True, config="UEFI", config_settings=uefi_settings)
-        self.__assert_uefi_configs(execution_config=execution_config, expected_file_exists=True, expected_enable_uefi_cert_update=True)
-        self.__teardown(runtime)
+        # Use Case 10: Value set to boolean True
+        uefi_settings_when_update_cert_true_str_lower_case = {
+            "EnabledBy": "TestSetup",
+            "LastModified": "2026-04-21",
+            "EnableUEFICertUpdate": "true"
+        }
+        expected_file_status_when_update_cert_true_str_lower_case = True
+        expected_enable_uefi_when_update_cert_true_str_lower_case = True
 
-        # Value set to string "1"
-        uefi_settings["EnableUEFICertUpdate"] = "1"
-        runtime, execution_config = self.__setup_and_init_execution_config(write_to_file=True, config="UEFI", config_settings=uefi_settings)
-        self.__assert_uefi_configs(execution_config=execution_config, expected_file_exists=True, expected_enable_uefi_cert_update=True)
-        self.__teardown(runtime)
+        # Use Case 11: Value set to boolean True
+        uefi_settings_when_update_cert_true_numericstr = {
+            "EnabledBy": "TestSetup",
+            "LastModified": "2026-04-21",
+            "EnableUEFICertUpdate": "1"
+        }
+        expected_file_status_when_update_cert_true_numericstr = True
+        expected_enable_uefi_when_update_cert_true_numericstr = True
 
-        # Value set to 1
-        uefi_settings["EnableUEFICertUpdate"] = 1
-        runtime, execution_config = self.__setup_and_init_execution_config(write_to_file=True, config="UEFI", config_settings=uefi_settings)
-        self.__assert_uefi_configs(execution_config=execution_config, expected_file_exists=True, expected_enable_uefi_cert_update=True)
-        self.__teardown(runtime)
+        # Use Case 12: Value set to boolean True
+        uefi_settings_when_update_cert_true_numeric = {
+            "EnabledBy": "TestSetup",
+            "LastModified": "2026-04-21",
+            "EnableUEFICertUpdate": 1
+        }
+        expected_file_status_when_update_cert_true_numeric = True
+        expected_enable_uefi_when_update_cert_true_numeric = True
+
+        test_input_output_table = [
+            [uefi_settings_update_cert_when_no_uefi_config, expected_file_status_when_no_uefi_config, expected_enable_uefi_when_no_uefi_config],
+            [uefi_settings_update_cert_when_enable_not_in_config, expected_file_status_when_enable_not_in_config, expected_enable_uefi_when_enable_not_in_config],
+            [uefi_settings_update_cert_illformed_config, expected_file_status_when_illformed_config, expected_enable_uefi_when_illformed_config],
+            [uefi_settings_update_cert_false, expected_file_status_when_update_cert_false, expected_enable_uefi_when_update_cert_false],
+            [uefi_settings_when_update_cert_is_str, expected_file_status_when_update_cert_is_str, expected_enable_uefi_when_update_cert_is_str],
+            [uefi_settings_when_update_cert_is_str_test2, expected_file_status_when_update_cert_is_str_test2, expected_enable_uefi_when_update_cert_is_str_test2],
+            [uefi_settings_when_update_cert_is_float, expected_file_status_when_update_cert_is_float, expected_enable_uefi_when_update_cert_is_float],
+            [uefi_settings_when_update_cert_true, expected_file_status_when_update_cert_true, expected_enable_uefi_when_update_cert_true],
+            [uefi_settings_when_update_cert_true_str, expected_file_status_when_update_cert_true_str, expected_enable_uefi_when_update_cert_true_str],
+            [uefi_settings_when_update_cert_true_str_lower_case, expected_file_status_when_update_cert_true_str_lower_case, expected_enable_uefi_when_update_cert_true_str_lower_case],
+            [uefi_settings_when_update_cert_true_numericstr, expected_file_status_when_update_cert_true_numericstr, expected_enable_uefi_when_update_cert_true_numericstr],
+            [uefi_settings_when_update_cert_true_numeric, expected_file_status_when_update_cert_true_numeric, expected_enable_uefi_when_update_cert_true_numeric]
+        ]
+
+        for row in test_input_output_table:
+            runtime, execution_config = self.__setup_and_init_execution_config(write_to_file=True, config="UEFI", config_settings=row[0])
+            self.__assert_uefi_configs(execution_config=execution_config, expected_file_exists=row[1], expected_enable_uefi_cert_update=row[2])
+            self.__teardown(runtime)
 
     def __assert_uefi_configs(self, execution_config, expected_file_exists, expected_enable_uefi_cert_update):
         self.assertEqual(os.path.exists(Constants.AzGPSPaths.UEFI_SETTINGS), expected_file_exists)

--- a/src/core/tests/Test_PatchInstaller.py
+++ b/src/core/tests/Test_PatchInstaller.py
@@ -32,6 +32,26 @@ class TestPatchInstaller(unittest.TestCase):
     def tearDown(self):
         pass
 
+    # region Mocks
+    def mock_update_certs_raise_exception(self):
+        raise Exception("Simulated cert update failure")
+    # endregion
+
+    # region Utility functions (update cert tests)
+    def _create_update_certs_runtime(self, enable_uefi_cert_update=True, health_store_id=None, operation=Constants.INSTALLATION):
+        runtime = RuntimeCompositor(ArgumentComposer().get_composed_arguments(), True, Constants.APT)
+        runtime.patch_installer.execution_config.enable_uefi_cert_update = enable_uefi_cert_update
+        runtime.patch_installer.execution_config.health_store_id = health_store_id
+        runtime.patch_installer.execution_config.operation = operation
+        return runtime
+
+    @staticmethod
+    def _track_method_call(obj, method_name):
+        call_count = []
+        setattr(obj, method_name, lambda: call_count.append(True))
+        return call_count
+    # endregion
+
     def test_yum_install_updates_maintenance_window_exceeded(self):
         current_time = datetime.datetime.utcnow()
         td = datetime.timedelta(hours=1, minutes=2)
@@ -714,6 +734,71 @@ class TestPatchInstaller(unittest.TestCase):
 
         self.assertEqual(calculated_max_batch_size, expected_max_batch_size)
         runtime.stop()
+
+    # region test update certs
+    def test_try_update_certs_skipped_when_enable_uefi_cert_update_is_false(self):
+        """try_update_certificates_for_default_patching should NOT be called when the feature flag is off."""
+        runtime = self._create_update_certs_runtime(enable_uefi_cert_update=False, health_store_id="pub_off_sku_2025.01.01")
+        runtime.set_legacy_test_type('SuccessInstallPath')
+
+        try_update_certs_for_default_patching_called = self._track_method_call(runtime.patch_installer, 'try_update_certificates_for_default_patching')
+
+        runtime.patch_installer.start_installation(simulate=True)
+        self.assertEqual(len(try_update_certs_for_default_patching_called), 0)
+        runtime.stop()
+
+    def test_try_update_certs_skipped_when_health_store_id_is_none(self):
+        """update_certs should NOT be called when health_store_id is None."""
+        runtime = self._create_update_certs_runtime(enable_uefi_cert_update=True, health_store_id=None)
+
+        update_certs_called = self._track_method_call(runtime.patch_installer.package_manager, 'update_certs')
+
+        runtime.patch_installer.try_update_certificates_for_default_patching()
+        self.assertEqual(len(update_certs_called), 0)
+        runtime.stop()
+
+    def test_try_update_certs_skipped_when_health_store_id_is_empty_string(self):
+        """update_certs should NOT be called when health_store_id is an empty string."""
+        runtime = self._create_update_certs_runtime(enable_uefi_cert_update=True, health_store_id=str())
+
+        update_certs_called = self._track_method_call(runtime.patch_installer.package_manager, 'update_certs')
+
+        runtime.patch_installer.try_update_certificates_for_default_patching()
+        self.assertEqual(len(update_certs_called), 0)
+        runtime.stop()
+
+    def test_try_update_certs_skipped_when_operation_is_not_installation(self):
+        """update_certs should NOT be called when operation is Assessment (not Installation)."""
+        runtime = self._create_update_certs_runtime(enable_uefi_cert_update=True, operation=Constants.ASSESSMENT)
+
+        update_certs_called = self._track_method_call(runtime.patch_installer.package_manager, 'update_certs')
+
+        runtime.patch_installer.try_update_certificates_for_default_patching()
+        self.assertEqual(len(update_certs_called), 0)
+        runtime.stop()
+
+    def test_try_update_certs_invoked_for_default_patching(self):
+        """update_certs SHOULD be called when feature flag is on, health_store_id is set, and operation is Installation (for default patching)"""
+        runtime = self._create_update_certs_runtime(enable_uefi_cert_update=True, health_store_id="pub_off_sku_2025.01.01")
+
+        update_certs_called = self._track_method_call(runtime.patch_installer.package_manager, 'update_certs')
+
+        runtime.patch_installer.try_update_certificates_for_default_patching()
+        self.assertEqual(len(update_certs_called), 1)
+        runtime.stop()
+
+    def test_try_update_certs_swallows_exception_from_update_certs(self):
+        """An exception raised by update_certs should be swallowed and not propagate."""
+        runtime = self._create_update_certs_runtime(enable_uefi_cert_update=True, health_store_id="pub_off_sku_2025.01.01")
+        backup_up_update_certs = runtime.patch_installer.package_manager.update_certs
+
+        runtime.patch_installer.package_manager.update_certs = self.mock_update_certs_raise_exception
+        runtime.patch_installer.try_update_certificates_for_default_patching()
+
+        runtime.patch_installer.package_manager.update_certs = backup_up_update_certs
+        runtime.stop()
+    # endregion
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/core/tests/Test_PatchInstaller.py
+++ b/src/core/tests/Test_PatchInstaller.py
@@ -54,9 +54,8 @@ class TestPatchInstaller(unittest.TestCase):
 
     @staticmethod
     def __write_config_settings_to_file(config_settings, config_file_path):
-        f = open(config_file_path, "w+")
-        f.write(json.dumps(config_settings))
-        f.close()
+        with open(config_file_path, "w+") as f:
+            f.write(json.dumps(config_settings))
 
     @staticmethod
     def _track_method_call(obj, method_name):

--- a/src/core/tests/Test_PatchInstaller.py
+++ b/src/core/tests/Test_PatchInstaller.py
@@ -39,11 +39,24 @@ class TestPatchInstaller(unittest.TestCase):
 
     # region Utility functions (update cert tests)
     def _create_update_certs_runtime(self, enable_uefi_cert_update=True, health_store_id=None, operation=Constants.INSTALLATION):
-        runtime = RuntimeCompositor(ArgumentComposer().get_composed_arguments(), True, Constants.APT)
-        runtime.patch_installer.execution_config.enable_uefi_cert_update = enable_uefi_cert_update
-        runtime.patch_installer.execution_config.health_store_id = health_store_id
-        runtime.patch_installer.execution_config.operation = operation
+        argument_composer = ArgumentComposer()
+        argument_composer.health_store_id = health_store_id
+        argument_composer.operation = operation
+        config_file_path = Constants.AzGPSPaths.UEFI_SETTINGS
+        config_settings = {
+            "EnabledBy": "TestSetup",
+            "LastModified": "2026-04-21",
+            "EnableUEFICertUpdate": True if enable_uefi_cert_update else False,
+        }
+        self.__write_config_settings_to_file(config_settings, config_file_path=config_file_path)
+        runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.APT)
         return runtime
+
+    @staticmethod
+    def __write_config_settings_to_file(config_settings, config_file_path):
+        f = open(config_file_path, "w+")
+        f.write(json.dumps(config_settings))
+        f.close()
 
     @staticmethod
     def _track_method_call(obj, method_name):
@@ -736,56 +749,63 @@ class TestPatchInstaller(unittest.TestCase):
         runtime.stop()
 
     # region test update certs
-    def test_try_update_certs_skipped_when_enable_uefi_cert_update_is_false(self):
-        """try_update_certificates_for_default_patching should NOT be called when the feature flag is off."""
-        runtime = self._create_update_certs_runtime(enable_uefi_cert_update=False, health_store_id="pub_off_sku_2025.01.01")
-        runtime.set_legacy_test_type('SuccessInstallPath')
+    def test_try_update_certificates_for_default_patching(self):
+        """ Test update certificates code path depending on different configurations """
 
-        try_update_certs_for_default_patching_called = self._track_method_call(runtime.patch_installer, 'try_update_certificates_for_default_patching')
+        # Use case 1: Feature flag is off
+        enable_uefi_cert_update_usecase1 = False
+        health_store_id_usecase1 = "pub_off_sku_2025.01.01"
+        operation_usecase1 = Constants.INSTALLATION
+        method_to_track_usecase1 = 'try_update_certificates_for_default_patching'
+        is_package_manager_method_usecase1 = False
+        number_of_times_method_called_usecase1 = 0
 
-        runtime.patch_installer.start_installation(simulate=True)
-        self.assertEqual(len(try_update_certs_for_default_patching_called), 0)
-        runtime.stop()
+        # Use case 2: update_certs should NOT be called when health_store_id is None i.e. not a default patching operation
+        enable_uefi_cert_update_usecase2 = True
+        health_store_id_usecase2 = None
+        operation_usecase2 = Constants.INSTALLATION
+        method_to_track_usecase2 = 'update_certs'
+        is_package_manager_method_usecase2 = True
+        number_of_times_method_called_usecase2= 0
 
-    def test_try_update_certs_skipped_when_health_store_id_is_none(self):
-        """update_certs should NOT be called when health_store_id is None."""
-        runtime = self._create_update_certs_runtime(enable_uefi_cert_update=True, health_store_id=None)
+        # Use case 3: """update_certs should NOT be called when health_store_id is an empty string i.e. not a default patching operation
+        enable_uefi_cert_update_usecase3 = True
+        health_store_id_usecase3 = str()
+        operation_usecase3 = Constants.INSTALLATION
+        method_to_track_usecase3 = 'update_certs'
+        is_package_manager_method_usecase3 = True
+        number_of_times_method_called_usecase3 = 0
 
-        update_certs_called = self._track_method_call(runtime.patch_installer.package_manager, 'update_certs')
+        # Use case 4: update_certs should NOT be called when operation is Assessment (not Installation). i.e. not default patching operation
+        enable_uefi_cert_update_usecase4 = True
+        health_store_id_usecase4 = None
+        operation_usecase4 = Constants.ASSESSMENT
+        method_to_track_usecase4 = 'update_certs'
+        is_package_manager_method_usecase4 = True
+        number_of_times_method_called_usecase4 = 0
 
-        runtime.patch_installer.try_update_certificates_for_default_patching()
-        self.assertEqual(len(update_certs_called), 0)
-        runtime.stop()
+        # Use case 5: update_certs SHOULD be called when feature flag is on, health_store_id is set, and operation is Installation (for default patching)
+        enable_uefi_cert_update_usecase5 = True
+        health_store_id_usecase5 = "pub_off_sku_2025.01.01"
+        operation_usecase5 = Constants.INSTALLATION
+        method_to_track_usecase5 = 'update_certs'
+        is_package_manager_method_usecase5 = True
+        number_of_times_method_called_usecase5 = 1
 
-    def test_try_update_certs_skipped_when_health_store_id_is_empty_string(self):
-        """update_certs should NOT be called when health_store_id is an empty string."""
-        runtime = self._create_update_certs_runtime(enable_uefi_cert_update=True, health_store_id=str())
+        test_input_output_table = [
+            [enable_uefi_cert_update_usecase1, health_store_id_usecase1, operation_usecase1, method_to_track_usecase1, is_package_manager_method_usecase1, number_of_times_method_called_usecase1],
+            [enable_uefi_cert_update_usecase2, health_store_id_usecase2, operation_usecase2, method_to_track_usecase2, is_package_manager_method_usecase2, number_of_times_method_called_usecase2],
+            [enable_uefi_cert_update_usecase3, health_store_id_usecase3, operation_usecase3, method_to_track_usecase3, is_package_manager_method_usecase3, number_of_times_method_called_usecase3],
+            [enable_uefi_cert_update_usecase4, health_store_id_usecase4, operation_usecase4, method_to_track_usecase4, is_package_manager_method_usecase4, number_of_times_method_called_usecase4],
+            [enable_uefi_cert_update_usecase5, health_store_id_usecase5, operation_usecase5, method_to_track_usecase5, is_package_manager_method_usecase5, number_of_times_method_called_usecase5],
+        ]
 
-        update_certs_called = self._track_method_call(runtime.patch_installer.package_manager, 'update_certs')
-
-        runtime.patch_installer.try_update_certificates_for_default_patching()
-        self.assertEqual(len(update_certs_called), 0)
-        runtime.stop()
-
-    def test_try_update_certs_skipped_when_operation_is_not_installation(self):
-        """update_certs should NOT be called when operation is Assessment (not Installation)."""
-        runtime = self._create_update_certs_runtime(enable_uefi_cert_update=True, operation=Constants.ASSESSMENT)
-
-        update_certs_called = self._track_method_call(runtime.patch_installer.package_manager, 'update_certs')
-
-        runtime.patch_installer.try_update_certificates_for_default_patching()
-        self.assertEqual(len(update_certs_called), 0)
-        runtime.stop()
-
-    def test_try_update_certs_invoked_for_default_patching(self):
-        """update_certs SHOULD be called when feature flag is on, health_store_id is set, and operation is Installation (for default patching)"""
-        runtime = self._create_update_certs_runtime(enable_uefi_cert_update=True, health_store_id="pub_off_sku_2025.01.01")
-
-        update_certs_called = self._track_method_call(runtime.patch_installer.package_manager, 'update_certs')
-
-        runtime.patch_installer.try_update_certificates_for_default_patching()
-        self.assertEqual(len(update_certs_called), 1)
-        runtime.stop()
+        for row in test_input_output_table:
+            runtime = self._create_update_certs_runtime(enable_uefi_cert_update=bool(row[0]), health_store_id=row[1], operation=row[2])
+            method_called = self._track_method_call(runtime.patch_installer.package_manager if row[4] == True else runtime.patch_installer, row[3])
+            runtime.patch_installer.start_installation(simulate=True)
+            self.assertEqual(len(method_called), row[5], "Failed for row: {row}")
+            runtime.stop()
 
     def test_try_update_certs_swallows_exception_from_update_certs(self):
         """An exception raised by update_certs should be swallowed and not propagate."""
@@ -793,7 +813,7 @@ class TestPatchInstaller(unittest.TestCase):
         backup_up_update_certs = runtime.patch_installer.package_manager.update_certs
 
         runtime.patch_installer.package_manager.update_certs = self.mock_update_certs_raise_exception
-        runtime.patch_installer.try_update_certificates_for_default_patching()
+        runtime.patch_installer.start_installation(simulate=True)
 
         runtime.patch_installer.package_manager.update_certs = backup_up_update_certs
         runtime.stop()

--- a/src/core/tests/library/ArgumentComposer.py
+++ b/src/core/tests/library/ArgumentComposer.py
@@ -48,6 +48,7 @@ class ArgumentComposer(object):
         self.events_folder = self.__get_custom_folder(self.__log_folder, self.__EVENTS_FOLDER)
         self.temp_folder = self.__get_custom_folder(scratch_folder, self.__TEMP_FOLDER)
         Constants.AzGPSPaths.EULA_SETTINGS = os.path.join(scratch_folder, "patch.eula.settings")
+        Constants.AzGPSPaths.UEFI_SETTINGS = os.path.join(scratch_folder, "patch.uefi.settings")
 
         # config settings
         self.operation = Constants.INSTALLATION

--- a/src/core/tests/library/LegacyEnvLayerExtensions.py
+++ b/src/core/tests/library/LegacyEnvLayerExtensions.py
@@ -539,6 +539,46 @@ class LegacyEnvLayerExtensions():
                     elif cmd.find('pro security-status --format=json') > -1:
                         code = 0
                         output = "{\"summary\":{\"ua\":{\"attached\":true}}}"
+                    elif cmd.find('apt-get install -y -qq mokutil') > -1:
+                        code = 0
+                        output = "Installed"
+                    elif cmd.find("mokutil --kek | grep 'CN='") > -1:
+                        code = 0
+                        output = ("Issuer: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft Corporation Third Party Marketplace Root"
+                                  "Subject: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft Corporation KEK CA 2011")
+                    elif cmd.find("mokutil --db | grep 'CN='") > -1:
+                        code = 0
+                        output = ("Issuer: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft Corporation Third Party Marketplace Root"
+                                  "Subject: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft Corporation UEFI CA 2011")
+                    elif cmd.find("bash -c 'echo \"deb http://archive.ubuntu.com/ubuntu/ "
+                                  "$( . /etc/os-release && echo $VERSION_CODENAME )-proposed restricted main multiverse universe") > -1:
+                        code = 0
+                        output = "deb http://archive.ubuntu.com/ubuntu/ jammy-proposed restricted main multiverse universe "
+                    elif cmd.find("apt-get -q update") > -1:
+                        code = 0
+                        output = "Hit:1 http://archive.ubuntu.com/ubuntu jammy InRelease\n" + \
+                                 "Hit:2 http://archive.ubuntu.com/ubuntu jammy-updates InRelease\n" + \
+                                 "Hit:3 http://archive.ubuntu.com/ubuntu jammy-backports InRelease\n" + \
+                                 "Hit:4 http://security.ubuntu.com/ubuntu jammy-security InRelease\n" + \
+                                 "Hit:5 http://archive.ubuntu.com/ubuntu jammy-proposed InRelease\n" + \
+                                 "Reading package lists...\n"
+                    elif cmd.find("bash -c 'cat << EOF | sudo tee") > -1:
+                        code = 0
+                        output = ("Package: * "
+                                  "Pin: release a=jammy-proposed "
+                                  "Pin-Priority: 100 ")
+                    elif cmd.find("bash -c 'sudo apt-get install -y -t $( . /etc/os-release") > -1:
+                        code = 0
+                        output = ("Reading package lists... Done"
+                                  "Building dependency tree... Done"
+                                  "Reading state information... Done "
+                                  "2 upgraded, 7 newly installed, 0 to remove and 37 not upgraded")
+                    elif cmd.find("sudo fwupdmgr refresh") > -1:
+                        code = 0
+                        output = "Success"
+                    elif cmd.find("sudo fwupdmgr update") > -1:
+                        code = 0
+                        output = "Successfully installed firmware"
                 elif self.legacy_package_manager_name is Constants.TDNF:
                     if cmd.find("--security list updates") > -1:
                         code = 0
@@ -657,6 +697,9 @@ class LegacyEnvLayerExtensions():
                     elif cmd.find('pro security-status --format=json') > -1:
                         code = 0
                         output = "{\"summary\":{\"ua\":{\"attached\":false}}}"
+                    elif cmd.find('apt-get install -y -qq mokutil') > 1:
+                        code = 1
+                        output = "E: Unable to locate package mokutil\n"
                 elif self.legacy_package_manager_name is Constants.YUM:
                     if cmd.find("microcode_ctl") > -1:
                         code = 1
@@ -898,6 +941,18 @@ class LegacyEnvLayerExtensions():
                         "sudo LANG=en_US.UTF8 zypper --non-interactive update --dry-run") > -1:
                         code = 0
                         output = "Package sucessfully installed!"
+                    elif cmd.find("mokutil --kek | grep 'CN='") > -1:
+                        code = 0
+                        output = ("Issuer: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft Corporation Third Party Marketplace Root"
+                                  "Subject: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft Corporation KEK CA 2011"
+                                  "Issuer: C=US, O=Microsoft Corporation, CN=Microsoft RSA Devices Root CA 2021"
+                                  "Subject: C=US, O=Microsoft Corporation, CN=Microsoft Corporation KEK 2K CA 2023")
+                    elif cmd.find("mokutil --db | grep 'CN='") > -1:
+                        code = 0
+                        output = ("Issuer: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft Corporation Third Party Marketplace Root"
+                                  "Subject: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft Corporation UEFI CA 2011"
+                                  "Issuer: C=US, O=Microsoft Corporation, CN=Microsoft RSA Devices Root CA 2021"
+                                  "Subject: C=US, O=Microsoft Corporation, CN=Microsoft UEFI CA 2023")
                 elif self.legacy_package_manager_name is Constants.TDNF:
                     if cmd.find("simulate-install") > -1 or cmd.find("sudo tdnf install --assumeno --skip-broken hyperv-daemons-license") > -1:
                         code = 8

--- a/src/core/tests/library/LegacyEnvLayerExtensions.py
+++ b/src/core/tests/library/LegacyEnvLayerExtensions.py
@@ -700,6 +700,10 @@ class LegacyEnvLayerExtensions():
                     elif cmd.find('apt-get install -y -qq mokutil') > 1:
                         code = 1
                         output = "E: Unable to locate package mokutil\n"
+                    elif cmd.find("bash -c 'echo \"deb http://archive.ubuntu.com/ubuntu/ "
+                                  "$( . /etc/os-release && echo $VERSION_CODENAME )-proposed restricted main multiverse universe") > -1:
+                        code = 1
+                        output = "Error: Unable to locate package multiverse universe\n "
                 elif self.legacy_package_manager_name is Constants.YUM:
                     if cmd.find("microcode_ctl") > -1:
                         code = 1
@@ -1122,6 +1126,9 @@ class LegacyEnvLayerExtensions():
                     elif cmd.find("force-dpkg-failure") > -1:
                         code = 100
                         output = "E: dpkg was interrupted, you must manually run 'sudo dpkg --configure -a' to correct the problem."
+                    elif cmd.find("bash -c 'sudo apt-get install -y -t $( . /etc/os-release") > -1:
+                        code = 1
+                        output = "Error"
                 elif self.legacy_package_manager_name is Constants.TDNF:
                     if cmd.find("simulate-install") > -1 or cmd.find("sudo tdnf install --assumeno --skip-broken hyperv-daemons-license") > -1:
                         code = 100

--- a/src/core/tests/library/LegacyEnvLayerExtensions.py
+++ b/src/core/tests/library/LegacyEnvLayerExtensions.py
@@ -539,6 +539,9 @@ class LegacyEnvLayerExtensions():
                     elif cmd.find('pro security-status --format=json') > -1:
                         code = 0
                         output = "{\"summary\":{\"ua\":{\"attached\":true}}}"
+                    elif cmd.find('command -v mokutil') > -1:
+                        code = 0
+                        output = '/usr/bin/mokutil'
                     elif cmd.find('apt-get install -y -qq mokutil') > -1:
                         code = 0
                         output = "Installed"
@@ -697,9 +700,15 @@ class LegacyEnvLayerExtensions():
                     elif cmd.find('pro security-status --format=json') > -1:
                         code = 0
                         output = "{\"summary\":{\"ua\":{\"attached\":false}}}"
+                    elif cmd.find('command -v mokutil') > -1:
+                        code = 1
+                        output = 'E: Unable to locate package mokutil'
                     elif cmd.find('apt-get install -y -qq mokutil') > 1:
                         code = 1
                         output = "E: Unable to locate package mokutil\n"
+                    elif cmd.find("mokutil --db | grep 'CN='") > -1:
+                        code = 1
+                        output = "No Db cert found"
                     elif cmd.find("bash -c 'echo \"deb http://archive.ubuntu.com/ubuntu/ "
                                   "$( . /etc/os-release && echo $VERSION_CODENAME )-proposed restricted main multiverse universe") > -1:
                         code = 1

--- a/src/core/tests/library/LegacyEnvLayerExtensions.py
+++ b/src/core/tests/library/LegacyEnvLayerExtensions.py
@@ -553,7 +553,7 @@ class LegacyEnvLayerExtensions():
                         code = 0
                         output = ("Issuer: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft Corporation Third Party Marketplace Root"
                                   "Subject: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft Corporation UEFI CA 2011")
-                    elif cmd.find("bash -c 'echo \"deb http://archive.ubuntu.com/ubuntu/ "
+                    elif cmd.find("bash -c 'echo \"deb https://archive.ubuntu.com/ubuntu/ "
                                   "$( . /etc/os-release && echo $VERSION_CODENAME )-proposed restricted main multiverse universe") > -1:
                         code = 0
                         output = "deb http://archive.ubuntu.com/ubuntu/ jammy-proposed restricted main multiverse universe "
@@ -709,7 +709,7 @@ class LegacyEnvLayerExtensions():
                     elif cmd.find("mokutil --db | grep 'CN='") > -1:
                         code = 1
                         output = "No Db cert found"
-                    elif cmd.find("bash -c 'echo \"deb http://archive.ubuntu.com/ubuntu/ "
+                    elif cmd.find("bash -c 'echo \"deb https://archive.ubuntu.com/ubuntu/ "
                                   "$( . /etc/os-release && echo $VERSION_CODENAME )-proposed restricted main multiverse universe") > -1:
                         code = 1
                         output = "Error: Unable to locate package multiverse universe\n "

--- a/src/tools/references/patch.uefi.settings
+++ b/src/tools/references/patch.uefi.settings
@@ -1,0 +1,1 @@
+{"EnableUEFICertUpdate": "true", "EnabledBy": "LSG", "LastModified": "2026-05-23"}


### PR DESCRIPTION
Description:

This PR aims to provide a best effort attempt to update UEFI and kek certificates for our Canonical default patching customers. This is an ask from a partner to help address Microsoft certificate rotations: https://discourse.ubuntu.com/t/microsoft-uefi-ca-rotation-what-it-means-for-ubuntu-users-and-vendors/82652

Changes:

- Certificates should only be updated for Default Patching customers
- This is a best effort scenario within patch installation i.e. Any failure in certificate installation should not affect the regular default patching workflow
- Certificate update instructions have been provided by our partners. Please see internal PR review post for more details.
- Have kept the changes behind a feature flag that will only be used for partner testing. Only the changes are validated by partners, we will remove the feature flag. NOTE: Customers will NOT be required to enable the feature flag

Steps to onboard for UEFI and kek updates using Feature Flag:
- Enabling UEFI and kek updates is achieved via an in-VM configuration. 
- Create the directory structure within your VM: /var/lib/azure/linuxpatchextension/
- Create a config file named '**patch.uefi.settings**' under **/var/lib/azure/linuxpatchextension/** with configuration: {"EnableUEFICertUpdate": "<bool>", "EnabledBy": "<>", "LastModified": "<>"} 
- Sample configuration: {"**EnableUEFICertUpdate**": "true", "EnabledBy": "LSG", "LastModified": "2026-05-23"} OR refer a sample configuration file at: src/tools/references/patch.uefi.settings
- NOTE: **EnableUEFICertUpdate** should be set to true for certs to be updated. 
- Upon enabling feature flag, default patching operations on the VM will attempt to update UEFI and kek certs to 2023 versions, if those certs are not already installed on the VM


Validation tests - Via Auto Patching execution on Ubuntu 22_04-lts-gen2 VM
- Success case where certs were updated and Auto Patching was successful: [2.core.log](https://github.com/user-attachments/files/28656509/2.core.log), [2.status.txt](https://github.com/user-attachments/files/28656510/2.status.txt)

<img width="949" height="297" alt="image" src="https://github.com/user-attachments/assets/2b0b2fdd-7720-4bd8-bc41-602e0600d32f" />

<img width="722" height="164" alt="image" src="https://github.com/user-attachments/assets/9c36e173-93df-45ab-a1dd-dcfb574f30de" />


