### PR TITLE
Feature: [Ubuntu, no-CVM] Use default repo for UEFI and kek certificate updates

### DIFF
--- a/src/core/src/core_logic/VersionComparator.py
+++ b/src/core/src/core_logic/VersionComparator.py
@@ -40,7 +40,7 @@ class VersionComparator(object):
         # type (str) -> str
         """
         Extract the version part from a given version string.
-        Input os version	                        Extracted Version
+        Input version version	                   Extracted Version
         34                                          34
         34~18                                       34
         34.~18.04                                   34

--- a/src/core/src/core_logic/VersionComparator.py
+++ b/src/core/src/core_logic/VersionComparator.py
@@ -36,10 +36,10 @@ class VersionComparator(object):
         return (len(parse_version_a) > len(parse_version_b)) - (len(parse_version_a) < len(parse_version_b))
 
     @staticmethod
-    def extract_version_from_os_version_nums(os_version):
+    def extract_version_from_version_str(version_str):
         # type (str) -> str
         """
-        Extract the version part from a given os version.
+        Extract the version part from a given version string.
         Input os version	                        Extracted Version
         34                                          34
         34~18                                       34
@@ -56,7 +56,7 @@ class VersionComparator(object):
         34.13.4abc-18.04.1                          34.13.4
         abc.34.13.4!@abc                            34.13.4
         """
-        version_num = re.search(r'(\d+(?:\.\d+)*)', os_version)  # extract numbers with optional dot-separated parts
+        version_num = re.search(r'(\d+(?:\.\d+)*)', version_str)  # extract numbers with optional dot-separated parts
         return version_num.group(1) if version_num else str()
 
     def __version_key(self, version_input):
@@ -65,7 +65,7 @@ class VersionComparator(object):
         os version input: "34~18.04"
         Return: (34)
         """
-        version_numbers = self.extract_version_from_os_version_nums(os_version=version_input)
+        version_numbers = self.extract_version_from_version_str(version_str=version_input)
         return tuple(map(int, version_numbers.split('.'))) if version_numbers else (0, 0, 0)
 
     def __parse_version(self, version_components):

--- a/src/core/src/core_logic/VersionComparator.py
+++ b/src/core/src/core_logic/VersionComparator.py
@@ -40,7 +40,7 @@ class VersionComparator(object):
         # type (str) -> str
         """
         Extract the version part from a given version string.
-        Input version version	                   Extracted Version
+        Input version	                   Extracted Version
         34                                          34
         34~18                                       34
         34.~18.04                                   34

--- a/src/core/src/package_managers/AptitudePackageManager.py
+++ b/src/core/src/package_managers/AptitudePackageManager.py
@@ -1036,6 +1036,7 @@ class AptitudePackageManager(PackageManager):
         """Return installed fwupd version, or empty string when fwupd is not installed."""
         cmd = self.get_installed_fwupd_version_cmd
         code, out = self.env_layer.run_command_output(cmd, False, False)
+        self.composite_logger.log_debug("[APM][Certs] Get installed fwupd version command executed. [Command={0}][Code={1}][Output={2}]".format(cmd, str(code), str(out)))
         if code != self.apt_exitcode_ok:
             self.composite_logger.log_debug("[APM][Certs] fwupd not installed or version could not be determined. [Command={0}][Code={1}][Output={2}]".format(str(cmd), str(code), str(out)))
             return str()

--- a/src/core/src/package_managers/AptitudePackageManager.py
+++ b/src/core/src/package_managers/AptitudePackageManager.py
@@ -23,6 +23,7 @@ import sys
 
 from core.src.package_managers.PackageManager import PackageManager
 from core.src.bootstrap.Constants import Constants
+from core.src.core_logic.VersionComparator import VersionComparator
 from core.src.package_managers.UbuntuProClient import UbuntuProClient
 
 
@@ -88,27 +89,17 @@ class AptitudePackageManager(PackageManager):
 
         self.ubuntu_pro_client_all_updates_cached = []
         self.ubuntu_pro_client_all_updates_versions_cached = []
-        
+        self.version_comparator = VersionComparator()
+
         self.package_install_expected_avg_time_in_seconds = 90  # As per telemetry data, the average time to install package is around 81 seconds for apt.
 
-        # Update certificates in factory defaults NOTE: The proposed references are short-term as it will be moved out soon
+        # Update certificates in factory defaults using default Ubuntu repos.
         self.install_mokutil_cmd = "sudo apt-get install -y -qq mokutil"
-        self.proposed_repo_file_path = "/etc/apt/sources.list.d/proposed.list"
-        self.proposed_pin_file_path = "/etc/apt/preferences.d/proposed"
-        self.add_proposed_repo_cmd = (
-            "bash -c 'echo \"deb https://archive.ubuntu.com/ubuntu/ "
-            "$( . /etc/os-release && echo $VERSION_CODENAME )-proposed restricted main multiverse universe\" "
-            "| sudo tee {0}'").format(self.proposed_repo_file_path)
-        self.create_proposed_pin_cmd = (
-            "bash -c 'cat << EOF | sudo tee {0}\n"
-            "Package: *\n"
-            "Pin: release a=$( . /etc/os-release && echo $VERSION_CODENAME )-proposed\n"
-            "Pin-Priority: 100\n"
-            "EOF'").format(self.proposed_pin_file_path)
-        self.remove_proposed_repo_cmd = "sudo rm -f {0}".format(self.proposed_repo_file_path)
-        self.remove_proposed_pin_cmd = "sudo rm -f {0}".format(self.proposed_pin_file_path)
         self.apt_update_cmd = "sudo apt-get -q update"
-        self.install_fwupd_from_proposed_cmd = "bash -c 'sudo apt-get install -y -t $( . /etc/os-release && echo $VERSION_CODENAME )-proposed fwupd'"
+        self.min_fwupd_version = "2.0.0"
+        self.get_installed_fwupd_version_cmd = "fwupdmgr --version"
+        self.remove_fwupd_cmd = "sudo apt purge -y fwupd"
+        self.install_fwupd_cmd = "sudo apt-get install -y fwupd"
         self.fwupd_refresh_cmd = "sudo fwupdmgr refresh" # NOTE: This could be made generic in package manager, depending on what solution type is adopted for other distros
         self.fwupd_update_cmd = "sudo fwupdmgr update -y"
 
@@ -984,10 +975,8 @@ class AptitudePackageManager(PackageManager):
 
         success = False
         try:
-            self.__run_cert_shell_command(self.add_proposed_repo_cmd, "AddProposedRepo", raise_on_error=True)
-            self.__run_cert_apt_command(self.apt_update_cmd, "AptUpdateAfterRepo", raise_on_error=True)
-            self.__run_cert_shell_command(self.create_proposed_pin_cmd, "CreateAptPin", raise_on_error=True)
-            self.__run_cert_apt_command(self.install_fwupd_from_proposed_cmd, "InstallFwupdFromProposed", raise_on_error=True)
+            self.__run_cert_apt_command(self.apt_update_cmd, "AptUpdate", raise_on_error=True)
+            self.__ensure_fwupd_installation()
 
             # shell fwupd commands to update certificates
             self.__run_cert_shell_command(self.fwupd_refresh_cmd, "FwupdRefresh", raise_on_error=True)
@@ -1007,18 +996,68 @@ class AptitudePackageManager(PackageManager):
         except Exception as error:
             self.composite_logger.log_error("[APM][Certs] Exception during cert update flow. [Error={0}]".format(repr(error)))
 
-        finally:
-            # best-effort cleanup
-            self.__run_cert_shell_command(self.remove_proposed_pin_cmd, "CleanupAptPin", raise_on_error=False)
-            self.__run_cert_shell_command(self.remove_proposed_repo_cmd, "CleanupProposedRepo", raise_on_error=False)
-            self.__run_cert_apt_command(self.apt_update_cmd, "AptUpdateAfterCleanup", raise_on_error=False)
-
         if success:
             # Not explicitly rebooting the VM to honor the customer's reboot preference and to avoid unexpected reboots.
             # Reboot will only be performed if it is required by the VM after cert update and if the customer has set reboot setting in patch configuration to 'Reboot if required'.
             self.status_handler.set_reboot_pending(self.is_reboot_pending())
 
         return success
+
+    def __ensure_fwupd_installation(self):
+        # type: () -> bool
+        """Ensure fwupd is installed at minimum required version for cert update flow."""
+        installed_version = self.__get_installed_fwupd_version()
+        if installed_version != str() and self.__is_min_fwupd_version_installed(installed_version):
+            self.composite_logger.log_debug("[APM][Certs] Existing fwupd version meets minimum requirement. [InstalledVersion={0}][MinimumVersion={1}]"
+                                            .format(installed_version, self.min_fwupd_version))
+            return True
+
+        if installed_version != str():
+            self.composite_logger.log("[APM][Certs] Existing fwupd version is below minimum. Reinstalling latest. [InstalledVersion={0}][MinimumVersion={1}]"
+                                      .format(installed_version, self.min_fwupd_version))
+            self.__run_cert_apt_command(self.remove_fwupd_cmd, "RemoveOldFwupd", raise_on_error=True)
+        else:
+            self.composite_logger.log_debug("[APM][Certs] fwupd is not installed. Installing latest version.")
+
+        self.__run_cert_apt_command(self.install_fwupd_cmd, "InstallFwupd", raise_on_error=True)
+        return True
+
+    def __get_installed_fwupd_version(self):
+        # type: () -> str
+        """Return installed fwupd version, or empty string when fwupd is not installed."""
+        cmd = self.get_installed_fwupd_version_cmd
+        code, out = self.env_layer.run_command_output(cmd, False, False)
+        if code != self.apt_exitcode_ok:
+            self.composite_logger.log_debug("[APM][Certs] fwupd not installed or version could not be determined. [Command={0}][Code={1}][Output={2}]".format(str(cmd), str(code), str(out)))
+            return str()
+
+        output = str(out).strip()
+        if output == str():
+            return str()
+
+        # Partner guidance: use the org.freedesktop.fwupd line from fwupdmgr --version.
+        match = re.search(r'org\.freedesktop\.fwupd\s+([0-9][0-9A-Za-z\.\-:+~]*)', output)
+        if match is None:
+            self.composite_logger.log_debug("[APM][Certs] fwupd version was not found in fwupdmgr output. [Output={0}]".format(output))
+            return str()
+
+        return match.group(1).strip()
+
+    def __is_min_fwupd_version_installed(self, installed_version):
+        # type: (str) -> bool
+        """Use VersionComparator to determine if installed fwupd meets minimum version."""
+        installed_normalized = self.version_comparator.extract_version_from_version_str(str(installed_version))
+        minimum_normalized = self.version_comparator.extract_version_from_version_str(str(self.min_fwupd_version))
+        if installed_normalized == str() or minimum_normalized == str():
+            self.composite_logger.log_debug("[APM][Certs] fwupd version comparison failed to normalize version values. [InstalledVersion={0}][InstalledNormalized={1}][MinimumVersion={2}][MinimumNormalized={3}]"
+                                            .format(str(installed_version), str(installed_normalized), str(self.min_fwupd_version), str(minimum_normalized)))
+            return False
+
+        compare_result = self.version_comparator.compare_versions(installed_normalized, minimum_normalized)
+        meets_minimum = compare_result >= 0
+        self.composite_logger.log_debug("[APM][Certs] fwupd version comparison result. [InstalledVersion={0}][InstalledNormalized={1}][MinimumVersion={2}][MinimumNormalized={3}][CompareResult={4}][MeetsMinimum={5}]"
+                                        .format(str(installed_version), str(installed_normalized), str(self.min_fwupd_version), str(minimum_normalized), str(compare_result), str(meets_minimum)))
+        return meets_minimum
 
     def __run_cert_apt_command(self, command, step_name, raise_on_error=False):
         """Run apt/dpkg commands through package-manager wrapper."""

--- a/src/core/src/package_managers/AptitudePackageManager.py
+++ b/src/core/src/package_managers/AptitudePackageManager.py
@@ -96,9 +96,9 @@ class AptitudePackageManager(PackageManager):
         # Update certificates in factory defaults using default Ubuntu repos.
         self.install_mokutil_cmd = "sudo apt-get install -y -qq mokutil"
         self.apt_update_cmd = "sudo apt-get -q update"
-        self.min_fwupd_version = "2.0.0"
+        self.min_fwupd_version = "2.0.8" # Refer public docs: https://github.com/fwupd/fwupd/releases/tag/2.0.8 and https://discourse.ubuntu.com/t/microsoft-uefi-ca-rotation-what-it-means-for-ubuntu-users-and-vendors/82652
         self.get_installed_fwupd_version_cmd = "fwupdmgr --version"
-        self.remove_fwupd_cmd = "sudo apt purge -y fwupd"
+        self.remove_fwupd_cmd = "sudo apt-get purge -y fwupd"
         self.install_fwupd_cmd = "sudo apt-get install -y fwupd"
         self.fwupd_refresh_cmd = "sudo fwupdmgr refresh" # NOTE: This could be made generic in package manager, depending on what solution type is adopted for other distros
         self.fwupd_update_cmd = "sudo fwupdmgr update -y"
@@ -1020,6 +1020,15 @@ class AptitudePackageManager(PackageManager):
             self.composite_logger.log_debug("[APM][Certs] fwupd is not installed. Installing latest version.")
 
         self.__run_cert_apt_command(self.install_fwupd_cmd, "InstallFwupd", raise_on_error=True)
+
+        # Validate that the installed fwupd meets the minimum requirement.
+        installed_version = self.__get_installed_fwupd_version()
+        if installed_version == str() or not self.__is_min_fwupd_version_installed(installed_version):
+            msg = "[APM][Certs] fwupd does not meet minimum version requirement after install. [InstalledVersion={0}][MinimumVersion={1}]".format(str(installed_version), str(self.min_fwupd_version))
+            self.composite_logger.log_error(msg)
+            self.status_handler.add_error_to_status(msg, Constants.PatchOperationErrorCodes.CERTIFICATE_UPDATE)
+            raise Exception(msg, "[{0}]".format(Constants.ERROR_ADDED_TO_STATUS))
+
         return True
 
     def __get_installed_fwupd_version(self):

--- a/src/core/src/package_managers/UbuntuProClient.py
+++ b/src/core/src/package_managers/UbuntuProClient.py
@@ -57,7 +57,7 @@ class UbuntuProClient:
             ubuntu_pro_client_version = version_result.installed_version
 
             # extract version from pro_client_verison 27.13.4~18.04.1 -> 27.13.4
-            extracted_ubuntu_pro_client_version = self.version_comparator.extract_version_from_os_version_nums(ubuntu_pro_client_version)
+            extracted_ubuntu_pro_client_version = self.version_comparator.extract_version_from_version_str(ubuntu_pro_client_version)
 
             self.composite_logger.log_verbose("[APM][Pro] Ubuntu Pro Client current version: [ClientVersion={0}]".format(str(extracted_ubuntu_pro_client_version)))
 

--- a/src/core/tests/Test_AptitudePackageManager.py
+++ b/src/core/tests/Test_AptitudePackageManager.py
@@ -107,6 +107,33 @@ class TestAptitudePackageManager(unittest.TestCase):
 
         return "2.0.15"
 
+    def mock_run_command_output_fwupd_version_not_found_in_first_attempt_and_found_later(self, cmd, no_output=False, chk_err=True):
+
+        if cmd.find(self.runtime.package_manager.get_installed_fwupd_version_cmd) > -1:
+            self.get_installed_fwupd_version_check_attempts += 1
+
+            # Mock the first attempt to return lower fwupd version
+            if self.get_installed_fwupd_version_check_attempts == 1:
+                return 0, ("compile    info.libusb                   1.0.25\n"
+                           "compile   com.hughsie.libxmlb           0.3.24\n"
+                           "compile   com.hughsie.libjcat           0.2.3\n"
+                           "runtime   org.freedesktop.fwupd-efi     1.4\n"
+                           "runtime   com.hughsie.libxmlb           0.3.24\n"
+                           "runtime   com.hughsie.libjcat           0.2.3\n"
+                           "runtime   org.kernel                    6.8.0-1052-azure\n")
+
+            else:
+                return 0, ("compile    info.libusb                   1.0.25\n"
+                           "compile   org.freedesktop.fwupd         2.0.20\n"
+                           "compile   com.hughsie.libxmlb           0.3.24\n"
+                           "compile   com.hughsie.libjcat           0.2.3\n"
+                           "runtime   org.freedesktop.fwupd-efi     1.4\n"
+                           "runtime   com.hughsie.libxmlb           0.3.24\n"
+                           "runtime   com.hughsie.libjcat           0.2.3\n"
+                           "runtime   org.kernel                    6.8.0-1052-azure\n"
+                           "runtime   org.freedesktop.fwupd         2.0.20\n")
+        return 0, ""
+
     def mock_run_command_output_fwupd_refresh_fails(self, cmd, no_output=False, chk_err=True):
         if cmd.find(self.runtime.package_manager.fwupd_refresh_cmd) > -1:
             return 1, "Error"
@@ -1177,7 +1204,7 @@ class TestAptitudePackageManager(unittest.TestCase):
         package_manager.is_reboot_pending = backup_is_reboot_pending
         package_manager.are_latest_certs_present = backup_are_latest_certs_present
 
-    def test_try_update_certs_skips_install_when_fwupd_meets_minimum_version(self):
+    def test_try_update_certs_when_fwupd_meets_minimum_version(self):
         package_manager = self.container.get('package_manager')
 
         backup_is_reboot_pending = package_manager.is_reboot_pending
@@ -1207,6 +1234,53 @@ class TestAptitudePackageManager(unittest.TestCase):
         package_manager.is_reboot_pending = backup_is_reboot_pending
         package_manager.are_latest_certs_present = backup_are_latest_certs_present
         package_manager._AptitudePackageManager__get_installed_fwupd_version = backup_get_installed_fwupd_version
+
+    def test_try_update_certs_when_fwupd_not_pre_installed(self):
+        package_manager = self.container.get('package_manager')
+
+        backup_is_reboot_pending = package_manager.is_reboot_pending
+        backup_are_latest_certs_present = package_manager.are_latest_certs_present
+        backup_run_command_output = package_manager.env_layer.run_command_output
+        package_manager.is_reboot_pending = self.mock_is_reboot_pending_returns_bool_False
+        package_manager.are_latest_certs_present = self.mock_are_latest_certs_present_with_different_output_across_multiple_attempts
+        package_manager.env_layer.run_command_output = self.mock_run_command_output_fwupd_version_not_found_in_first_attempt_and_found_later
+
+        self.assertTrue(package_manager.try_update_certs())
+        self.assertEqual(package_manager.status_handler.is_reboot_pending, False)
+
+        package_manager.is_reboot_pending = backup_is_reboot_pending
+        package_manager.are_latest_certs_present = backup_are_latest_certs_present
+        package_manager.env_layer.run_command_output = backup_run_command_output
+
+    def test_try_update_certs_when_fwupd_install_failed(self):
+        self.runtime.set_legacy_test_type('FailInstallPath')
+        package_manager = self.container.get('package_manager')
+
+        backup_is_reboot_pending = package_manager.is_reboot_pending
+        backup_are_latest_certs_present = package_manager.are_latest_certs_present
+        package_manager.is_reboot_pending = self.mock_is_reboot_pending_returns_bool_False
+        package_manager.are_latest_certs_present = self.mock_are_latest_certs_present_with_different_output_across_multiple_attempts
+
+        self.assertFalse(package_manager.try_update_certs())
+        self.assertEqual(package_manager.status_handler.is_reboot_pending, False)
+
+        package_manager.is_reboot_pending = backup_is_reboot_pending
+        package_manager.are_latest_certs_present = backup_are_latest_certs_present
+
+    def test_try_update_certs_when_older_fwupd_installed_by_azgps(self):
+        self.runtime.set_legacy_test_type('SuccessInstallPath')
+        package_manager = self.container.get('package_manager')
+
+        backup_is_reboot_pending = package_manager.is_reboot_pending
+        backup_are_latest_certs_present = package_manager.are_latest_certs_present
+        package_manager.is_reboot_pending = self.mock_is_reboot_pending_returns_bool_False
+        package_manager.are_latest_certs_present = self.mock_are_latest_certs_present_with_different_output_across_multiple_attempts
+
+        self.assertFalse(package_manager.try_update_certs())
+        self.assertEqual(package_manager.status_handler.is_reboot_pending, False)
+
+        package_manager.is_reboot_pending = backup_is_reboot_pending
+        package_manager.are_latest_certs_present = backup_are_latest_certs_present
 
     def test_try_update_certs_all_commands_succeed_but_certs_not_updated(self):
         """ Test when all commands to update certs succeed but certs are still not updated,

--- a/src/core/tests/Test_AptitudePackageManager.py
+++ b/src/core/tests/Test_AptitudePackageManager.py
@@ -39,6 +39,7 @@ class TestAptitudePackageManager(unittest.TestCase):
         self.container = self.runtime.container
         self.latest_certs_check_attempts = 0
         self.latest_apt_update_cmd_attempt = 0
+        self.get_installed_fwupd_version_check_attempts = 0
 
     def tearDown(self):
         self.runtime.stop()
@@ -96,6 +97,15 @@ class TestAptitudePackageManager(unittest.TestCase):
             return False
 
         return True
+
+    def mock_get_installed_fwupd_version_with_different_output_across_multiple_attempts(self):
+        self.get_installed_fwupd_version_check_attempts += 1
+
+        # Mock the first attempt to return lower fwupd version
+        if self.get_installed_fwupd_version_check_attempts == 1:
+            return "2.0.1"
+
+        return "2.0.15"
 
     def mock_run_command_output_fwupd_refresh_fails(self, cmd, no_output=False, chk_err=True):
         if cmd.find(self.runtime.package_manager.fwupd_refresh_cmd) > -1:
@@ -1170,62 +1180,33 @@ class TestAptitudePackageManager(unittest.TestCase):
     def test_try_update_certs_skips_install_when_fwupd_meets_minimum_version(self):
         package_manager = self.container.get('package_manager')
 
-        backup_are_latest_certs_present = package_manager.are_latest_certs_present
         backup_is_reboot_pending = package_manager.is_reboot_pending
-        backup_get_installed_fwupd_version = package_manager._AptitudePackageManager__get_installed_fwupd_version
-        backup_is_min_fwupd_version_installed = package_manager._AptitudePackageManager__is_min_fwupd_version_installed
-        backup_run_cert_apt_command = package_manager._AptitudePackageManager__run_cert_apt_command
-        backup_run_cert_shell_command = package_manager._AptitudePackageManager__run_cert_shell_command
-
-        apt_steps = []
-        shell_steps = []
-        package_manager.are_latest_certs_present = self.mock_are_latest_certs_present_with_different_output_across_multiple_attempts
+        backup_are_latest_certs_present = package_manager.are_latest_certs_present
         package_manager.is_reboot_pending = self.mock_is_reboot_pending_returns_bool_False
-        package_manager._AptitudePackageManager__get_installed_fwupd_version = lambda: "2.0.1"
-        package_manager._AptitudePackageManager__is_min_fwupd_version_installed = lambda version: True
-        package_manager._AptitudePackageManager__run_cert_apt_command = lambda command, step_name, raise_on_error=False: (apt_steps.append(step_name), (True, ""))[1]
-        package_manager._AptitudePackageManager__run_cert_shell_command = lambda command, step_name, raise_on_error=False: (shell_steps.append(step_name), (True, ""))[1]
+        package_manager.are_latest_certs_present = self.mock_are_latest_certs_present_with_different_output_across_multiple_attempts
 
         self.assertTrue(package_manager.try_update_certs())
-        self.assertEqual(apt_steps, ["AptUpdate"])
-        self.assertEqual(shell_steps, ["FwupdRefresh", "FwupdUpdate"])
+        self.assertEqual(package_manager.status_handler.is_reboot_pending, False)
 
-        package_manager.are_latest_certs_present = backup_are_latest_certs_present
         package_manager.is_reboot_pending = backup_is_reboot_pending
-        package_manager._AptitudePackageManager__get_installed_fwupd_version = backup_get_installed_fwupd_version
-        package_manager._AptitudePackageManager__is_min_fwupd_version_installed = backup_is_min_fwupd_version_installed
-        package_manager._AptitudePackageManager__run_cert_apt_command = backup_run_cert_apt_command
-        package_manager._AptitudePackageManager__run_cert_shell_command = backup_run_cert_shell_command
+        package_manager.are_latest_certs_present = backup_are_latest_certs_present
 
     def test_try_update_certs_removes_old_fwupd_before_install(self):
         package_manager = self.container.get('package_manager')
 
-        backup_are_latest_certs_present = package_manager.are_latest_certs_present
         backup_is_reboot_pending = package_manager.is_reboot_pending
+        backup_are_latest_certs_present = package_manager.are_latest_certs_present
         backup_get_installed_fwupd_version = package_manager._AptitudePackageManager__get_installed_fwupd_version
-        backup_is_min_fwupd_version_installed = package_manager._AptitudePackageManager__is_min_fwupd_version_installed
-        backup_run_cert_apt_command = package_manager._AptitudePackageManager__run_cert_apt_command
-        backup_run_cert_shell_command = package_manager._AptitudePackageManager__run_cert_shell_command
-
-        apt_steps = []
-        shell_steps = []
-        package_manager.are_latest_certs_present = self.mock_are_latest_certs_present_with_different_output_across_multiple_attempts
         package_manager.is_reboot_pending = self.mock_is_reboot_pending_returns_bool_False
-        package_manager._AptitudePackageManager__get_installed_fwupd_version = lambda: "1.9.12-1"
-        package_manager._AptitudePackageManager__is_min_fwupd_version_installed = lambda version: False
-        package_manager._AptitudePackageManager__run_cert_apt_command = lambda command, step_name, raise_on_error=False: (apt_steps.append(step_name), (True, ""))[1]
-        package_manager._AptitudePackageManager__run_cert_shell_command = lambda command, step_name, raise_on_error=False: (shell_steps.append(step_name), (True, ""))[1]
+        package_manager.are_latest_certs_present = self.mock_are_latest_certs_present_with_different_output_across_multiple_attempts
+        package_manager._AptitudePackageManager__get_installed_fwupd_version = self.mock_get_installed_fwupd_version_with_different_output_across_multiple_attempts
 
         self.assertTrue(package_manager.try_update_certs())
-        self.assertEqual(apt_steps, ["AptUpdate", "RemoveOldFwupd", "InstallFwupd"])
-        self.assertEqual(shell_steps, ["FwupdRefresh", "FwupdUpdate"])
+        self.assertEqual(package_manager.status_handler.is_reboot_pending, False)
 
-        package_manager.are_latest_certs_present = backup_are_latest_certs_present
         package_manager.is_reboot_pending = backup_is_reboot_pending
+        package_manager.are_latest_certs_present = backup_are_latest_certs_present
         package_manager._AptitudePackageManager__get_installed_fwupd_version = backup_get_installed_fwupd_version
-        package_manager._AptitudePackageManager__is_min_fwupd_version_installed = backup_is_min_fwupd_version_installed
-        package_manager._AptitudePackageManager__run_cert_apt_command = backup_run_cert_apt_command
-        package_manager._AptitudePackageManager__run_cert_shell_command = backup_run_cert_shell_command
 
     def test_try_update_certs_all_commands_succeed_but_certs_not_updated(self):
         """ Test when all commands to update certs succeed but certs are still not updated,

--- a/src/core/tests/Test_AptitudePackageManager.py
+++ b/src/core/tests/Test_AptitudePackageManager.py
@@ -97,8 +97,8 @@ class TestAptitudePackageManager(unittest.TestCase):
 
         return True
 
-    def mock_run_command_output_remove_proposed_pin_fails(self, cmd, no_output=False, chk_err=True):
-        if cmd.find(self.runtime.package_manager.remove_proposed_pin_cmd) > -1:
+    def mock_run_command_output_fwupd_refresh_fails(self, cmd, no_output=False, chk_err=True):
+        if cmd.find(self.runtime.package_manager.fwupd_refresh_cmd) > -1:
             return 1, "Error"
         return 0, ""
 
@@ -1167,6 +1167,66 @@ class TestAptitudePackageManager(unittest.TestCase):
         package_manager.is_reboot_pending = backup_is_reboot_pending
         package_manager.are_latest_certs_present = backup_are_latest_certs_present
 
+    def test_try_update_certs_skips_install_when_fwupd_meets_minimum_version(self):
+        package_manager = self.container.get('package_manager')
+
+        backup_are_latest_certs_present = package_manager.are_latest_certs_present
+        backup_is_reboot_pending = package_manager.is_reboot_pending
+        backup_get_installed_fwupd_version = package_manager._AptitudePackageManager__get_installed_fwupd_version
+        backup_is_min_fwupd_version_installed = package_manager._AptitudePackageManager__is_min_fwupd_version_installed
+        backup_run_cert_apt_command = package_manager._AptitudePackageManager__run_cert_apt_command
+        backup_run_cert_shell_command = package_manager._AptitudePackageManager__run_cert_shell_command
+
+        apt_steps = []
+        shell_steps = []
+        package_manager.are_latest_certs_present = self.mock_are_latest_certs_present_with_different_output_across_multiple_attempts
+        package_manager.is_reboot_pending = self.mock_is_reboot_pending_returns_bool_False
+        package_manager._AptitudePackageManager__get_installed_fwupd_version = lambda: "2.0.1"
+        package_manager._AptitudePackageManager__is_min_fwupd_version_installed = lambda version: True
+        package_manager._AptitudePackageManager__run_cert_apt_command = lambda command, step_name, raise_on_error=False: (apt_steps.append(step_name), (True, ""))[1]
+        package_manager._AptitudePackageManager__run_cert_shell_command = lambda command, step_name, raise_on_error=False: (shell_steps.append(step_name), (True, ""))[1]
+
+        self.assertTrue(package_manager.try_update_certs())
+        self.assertEqual(apt_steps, ["AptUpdate"])
+        self.assertEqual(shell_steps, ["FwupdRefresh", "FwupdUpdate"])
+
+        package_manager.are_latest_certs_present = backup_are_latest_certs_present
+        package_manager.is_reboot_pending = backup_is_reboot_pending
+        package_manager._AptitudePackageManager__get_installed_fwupd_version = backup_get_installed_fwupd_version
+        package_manager._AptitudePackageManager__is_min_fwupd_version_installed = backup_is_min_fwupd_version_installed
+        package_manager._AptitudePackageManager__run_cert_apt_command = backup_run_cert_apt_command
+        package_manager._AptitudePackageManager__run_cert_shell_command = backup_run_cert_shell_command
+
+    def test_try_update_certs_removes_old_fwupd_before_install(self):
+        package_manager = self.container.get('package_manager')
+
+        backup_are_latest_certs_present = package_manager.are_latest_certs_present
+        backup_is_reboot_pending = package_manager.is_reboot_pending
+        backup_get_installed_fwupd_version = package_manager._AptitudePackageManager__get_installed_fwupd_version
+        backup_is_min_fwupd_version_installed = package_manager._AptitudePackageManager__is_min_fwupd_version_installed
+        backup_run_cert_apt_command = package_manager._AptitudePackageManager__run_cert_apt_command
+        backup_run_cert_shell_command = package_manager._AptitudePackageManager__run_cert_shell_command
+
+        apt_steps = []
+        shell_steps = []
+        package_manager.are_latest_certs_present = self.mock_are_latest_certs_present_with_different_output_across_multiple_attempts
+        package_manager.is_reboot_pending = self.mock_is_reboot_pending_returns_bool_False
+        package_manager._AptitudePackageManager__get_installed_fwupd_version = lambda: "1.9.12-1"
+        package_manager._AptitudePackageManager__is_min_fwupd_version_installed = lambda version: False
+        package_manager._AptitudePackageManager__run_cert_apt_command = lambda command, step_name, raise_on_error=False: (apt_steps.append(step_name), (True, ""))[1]
+        package_manager._AptitudePackageManager__run_cert_shell_command = lambda command, step_name, raise_on_error=False: (shell_steps.append(step_name), (True, ""))[1]
+
+        self.assertTrue(package_manager.try_update_certs())
+        self.assertEqual(apt_steps, ["AptUpdate", "RemoveOldFwupd", "InstallFwupd"])
+        self.assertEqual(shell_steps, ["FwupdRefresh", "FwupdUpdate"])
+
+        package_manager.are_latest_certs_present = backup_are_latest_certs_present
+        package_manager.is_reboot_pending = backup_is_reboot_pending
+        package_manager._AptitudePackageManager__get_installed_fwupd_version = backup_get_installed_fwupd_version
+        package_manager._AptitudePackageManager__is_min_fwupd_version_installed = backup_is_min_fwupd_version_installed
+        package_manager._AptitudePackageManager__run_cert_apt_command = backup_run_cert_apt_command
+        package_manager._AptitudePackageManager__run_cert_shell_command = backup_run_cert_shell_command
+
     def test_try_update_certs_all_commands_succeed_but_certs_not_updated(self):
         """ Test when all commands to update certs succeed but certs are still not updated,
         which should return False and not change reboot pending status """
@@ -1197,7 +1257,7 @@ class TestAptitudePackageManager(unittest.TestCase):
         package_manager = self.container.get('package_manager')
 
         backup_run_command_output = package_manager.env_layer.run_command_output
-        package_manager.env_layer.run_command_output = self.mock_run_command_output_remove_proposed_pin_fails
+        package_manager.env_layer.run_command_output = self.mock_run_command_output_fwupd_refresh_fails
 
         previous_reboot_pending_status = package_manager.status_handler.is_reboot_pending
         self.assertFalse(package_manager.try_update_certs())

--- a/src/core/tests/Test_AptitudePackageManager.py
+++ b/src/core/tests/Test_AptitudePackageManager.py
@@ -1267,6 +1267,24 @@ class TestAptitudePackageManager(unittest.TestCase):
         package_manager.is_reboot_pending = backup_is_reboot_pending
         package_manager.are_latest_certs_present = backup_are_latest_certs_present
 
+    def test_try_update_certs_when_fwupd_version_normalization_fails(self):
+        self.runtime.set_legacy_test_type('SuccessInstallPath')
+        package_manager = self.container.get('package_manager')
+
+        backup_is_reboot_pending = package_manager.is_reboot_pending
+        backup_are_latest_certs_present = package_manager.are_latest_certs_present
+        backup_min_fwupd_version = package_manager.min_fwupd_version
+        package_manager.is_reboot_pending = self.mock_is_reboot_pending_returns_bool_False
+        package_manager.are_latest_certs_present = self.mock_are_latest_certs_present_with_different_output_across_multiple_attempts
+        package_manager.min_fwupd_version = "test"
+
+        self.assertFalse(package_manager.try_update_certs())
+        self.assertEqual(package_manager.status_handler.is_reboot_pending, False)
+
+        package_manager.is_reboot_pending = backup_is_reboot_pending
+        package_manager.are_latest_certs_present = backup_are_latest_certs_present
+        package_manager.min_fwupd_version = backup_min_fwupd_version
+
     def test_try_update_certs_when_older_fwupd_installed_by_azgps(self):
         self.runtime.set_legacy_test_type('SuccessInstallPath')
         package_manager = self.container.get('package_manager')

--- a/src/core/tests/Test_VersionComparator.py
+++ b/src/core/tests/Test_VersionComparator.py
@@ -26,31 +26,31 @@ class TestVersionComparator(unittest.TestCase):
 
     def test_extract_version_from_os_version_nums(self):
         """ Test extract version logic on Ubuntuproclient version """
-        self.assertEqual(self.version_comparator.extract_version_from_os_version_nums("34"), "34")
-        self.assertEqual(self.version_comparator.extract_version_from_os_version_nums("34~18"), "34")
-        self.assertEqual(self.version_comparator.extract_version_from_os_version_nums("34.~18.04"), "34")
-        self.assertEqual(self.version_comparator.extract_version_from_os_version_nums("34.a+18.04.1"), "34")
-        self.assertEqual(self.version_comparator.extract_version_from_os_version_nums("34abc-18.04"), "34")
-        self.assertEqual(self.version_comparator.extract_version_from_os_version_nums("abc34~18.04"), "34")
-        self.assertEqual(self.version_comparator.extract_version_from_os_version_nums("abc34~18.04.123"), "34")
-        self.assertEqual(self.version_comparator.extract_version_from_os_version_nums("34~25.1.2-18.04.1"), "34")
+        self.assertEqual(self.version_comparator.extract_version_from_version_str("34"), "34")
+        self.assertEqual(self.version_comparator.extract_version_from_version_str("34~18"), "34")
+        self.assertEqual(self.version_comparator.extract_version_from_version_str("34.~18.04"), "34")
+        self.assertEqual(self.version_comparator.extract_version_from_version_str("34.a+18.04.1"), "34")
+        self.assertEqual(self.version_comparator.extract_version_from_version_str("34abc-18.04"), "34")
+        self.assertEqual(self.version_comparator.extract_version_from_version_str("abc34~18.04"), "34")
+        self.assertEqual(self.version_comparator.extract_version_from_version_str("abc34~18.04.123"), "34")
+        self.assertEqual(self.version_comparator.extract_version_from_version_str("34~25.1.2-18.04.1"), "34")
 
-        self.assertEqual(self.version_comparator.extract_version_from_os_version_nums("34.1~18.04.1"), "34.1")
-        self.assertEqual(self.version_comparator.extract_version_from_os_version_nums("34.13.4"), "34.13.4")
-        self.assertEqual(self.version_comparator.extract_version_from_os_version_nums("34.13.4~18.04.1"), "34.13.4")
-        self.assertEqual(self.version_comparator.extract_version_from_os_version_nums("34.13.4-ab+18.04.1"), "34.13.4")
-        self.assertEqual(self.version_comparator.extract_version_from_os_version_nums("34.13.4abc-18.04.1"), "34.13.4")
-        self.assertEqual(self.version_comparator.extract_version_from_os_version_nums("abc.34.13.4!@abc"), "34.13.4")
+        self.assertEqual(self.version_comparator.extract_version_from_version_str("34.1~18.04.1"), "34.1")
+        self.assertEqual(self.version_comparator.extract_version_from_version_str("34.13.4"), "34.13.4")
+        self.assertEqual(self.version_comparator.extract_version_from_version_str("34.13.4~18.04.1"), "34.13.4")
+        self.assertEqual(self.version_comparator.extract_version_from_version_str("34.13.4-ab+18.04.1"), "34.13.4")
+        self.assertEqual(self.version_comparator.extract_version_from_version_str("34.13.4abc-18.04.1"), "34.13.4")
+        self.assertEqual(self.version_comparator.extract_version_from_version_str("abc.34.13.4!@abc"), "34.13.4")
 
     def test_linux_os_version_comparison(self):
         """ Test compare versions logic Ubuntuproclient version with existing vm version """
-        test_extracted_good_version = self.version_comparator.extract_version_from_os_version_nums("34.13.4~18.04.1")  # return 34
+        test_extracted_good_version = self.version_comparator.extract_version_from_version_str("34.13.4~18.04.1")  # return 34
 
         self.assertEqual(self.version_comparator.compare_versions(test_extracted_good_version, "34.13.4"), 0)  # equal  34.13.4 == 34.13.4
         self.assertEqual(self.version_comparator.compare_versions(test_extracted_good_version, "34.13.3"), 1)  # greater 34.13.4 > 34.13.3
         self.assertEqual(self.version_comparator.compare_versions(test_extracted_good_version, "34.13.5"), -1)  # less 34.13.4 < 34.13.5
 
-        test_extracted_bad_version = self.version_comparator.extract_version_from_os_version_nums("abc~18.04.1")  # return ""
+        test_extracted_bad_version = self.version_comparator.extract_version_from_version_str("abc~18.04.1")  # return ""
         self.assertEqual(self.version_comparator.compare_versions(test_extracted_bad_version, "34.13.4"), -1)  # less "" < 34.13.4
 
 

--- a/src/core/tests/Test_VersionComparator.py
+++ b/src/core/tests/Test_VersionComparator.py
@@ -24,7 +24,7 @@ class TestVersionComparator(unittest.TestCase):
     def setUp(self):
         self.version_comparator = VersionComparator()
 
-    def test_extract_version_from_os_version_nums(self):
+    def test_extract_version_from_version_str(self):
         """ Test extract version logic on Ubuntuproclient version """
         self.assertEqual(self.version_comparator.extract_version_from_version_str("34"), "34")
         self.assertEqual(self.version_comparator.extract_version_from_version_str("34~18"), "34")

--- a/src/core/tests/library/LegacyEnvLayerExtensions.py
+++ b/src/core/tests/library/LegacyEnvLayerExtensions.py
@@ -545,6 +545,15 @@ class LegacyEnvLayerExtensions():
                     elif cmd.find('apt-get install -y -qq mokutil') > -1:
                         code = 0
                         output = "Installed"
+                    elif cmd.find("fwupdmgr --version") > -1:
+                        code = 1
+                        output = ""
+                    elif cmd.find("dpkg --compare-versions") > -1:
+                        code = 1
+                        output = ""
+                    elif cmd.find("sudo apt purge -y fwupd") > -1:
+                        code = 0
+                        output = "Removed"
                     elif cmd.find("mokutil --kek | grep 'CN='") > -1:
                         code = 0
                         output = ("Issuer: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft Corporation Third Party Marketplace Root"
@@ -553,24 +562,14 @@ class LegacyEnvLayerExtensions():
                         code = 0
                         output = ("Issuer: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft Corporation Third Party Marketplace Root"
                                   "Subject: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft Corporation UEFI CA 2011")
-                    elif cmd.find("bash -c 'echo \"deb https://archive.ubuntu.com/ubuntu/ "
-                                  "$( . /etc/os-release && echo $VERSION_CODENAME )-proposed restricted main multiverse universe") > -1:
-                        code = 0
-                        output = "deb http://archive.ubuntu.com/ubuntu/ jammy-proposed restricted main multiverse universe "
                     elif cmd.find("apt-get -q update") > -1:
                         code = 0
                         output = "Hit:1 http://archive.ubuntu.com/ubuntu jammy InRelease\n" + \
                                  "Hit:2 http://archive.ubuntu.com/ubuntu jammy-updates InRelease\n" + \
                                  "Hit:3 http://archive.ubuntu.com/ubuntu jammy-backports InRelease\n" + \
                                  "Hit:4 http://security.ubuntu.com/ubuntu jammy-security InRelease\n" + \
-                                 "Hit:5 http://archive.ubuntu.com/ubuntu jammy-proposed InRelease\n" + \
                                  "Reading package lists...\n"
-                    elif cmd.find("bash -c 'cat << EOF | sudo tee") > -1:
-                        code = 0
-                        output = ("Package: * "
-                                  "Pin: release a=jammy-proposed "
-                                  "Pin-Priority: 100 ")
-                    elif cmd.find("bash -c 'sudo apt-get install -y -t $( . /etc/os-release") > -1:
+                    elif cmd.find("sudo apt-get install -y fwupd") > -1:
                         code = 0
                         output = ("Reading package lists... Done"
                                   "Building dependency tree... Done"
@@ -709,10 +708,6 @@ class LegacyEnvLayerExtensions():
                     elif cmd.find("mokutil --db | grep 'CN='") > -1:
                         code = 1
                         output = "No Db cert found"
-                    elif cmd.find("bash -c 'echo \"deb https://archive.ubuntu.com/ubuntu/ "
-                                  "$( . /etc/os-release && echo $VERSION_CODENAME )-proposed restricted main multiverse universe") > -1:
-                        code = 1
-                        output = "Error: Unable to locate package multiverse universe\n "
                 elif self.legacy_package_manager_name is Constants.YUM:
                     if cmd.find("microcode_ctl") > -1:
                         code = 1
@@ -1135,7 +1130,10 @@ class LegacyEnvLayerExtensions():
                     elif cmd.find("force-dpkg-failure") > -1:
                         code = 100
                         output = "E: dpkg was interrupted, you must manually run 'sudo dpkg --configure -a' to correct the problem."
-                    elif cmd.find("bash -c 'sudo apt-get install -y -t $( . /etc/os-release") > -1:
+                    elif cmd.find("fwupdmgr --version") > -1:
+                        code = 1
+                        output = ""
+                    elif cmd.find("sudo apt-get install -y fwupd") > -1:
                         code = 1
                         output = "Error"
                 elif self.legacy_package_manager_name is Constants.TDNF:

--- a/src/core/tests/library/LegacyEnvLayerExtensions.py
+++ b/src/core/tests/library/LegacyEnvLayerExtensions.py
@@ -1050,6 +1050,17 @@ class LegacyEnvLayerExtensions():
                                   "Subject: C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft Corporation UEFI CA 2011"
                                   "Issuer: C=US, O=Microsoft Corporation, CN=Microsoft RSA Devices Root CA 2021"
                                   "Subject: C=US, O=Microsoft Corporation, CN=Microsoft UEFI CA 2023")
+                    elif cmd.find("fwupdmgr --version") > -1:
+                        code = 0
+                        output = ("compile   info.libusb                   1.0.25\n"
+                                  "compile   org.freedesktop.fwupd         2.0.2\n"
+                                  "compile   com.hughsie.libxmlb           0.3.24\n"
+                                  "compile   com.hughsie.libjcat           0.2.3\n"
+                                  "runtime   org.freedesktop.fwupd-efi     1.4\n"
+                                  "runtime   com.hughsie.libxmlb           0.3.24\n"
+                                  "runtime   com.hughsie.libjcat           0.2.3\n"
+                                  "runtime   org.kernel                    6.8.0-1052-azure\n"
+                                  "runtime   org.freedesktop.fwupd         2.0.2\n")
                 elif self.legacy_package_manager_name is Constants.TDNF:
                     if cmd.find("simulate-install") > -1 or cmd.find("sudo tdnf install --assumeno --skip-broken hyperv-daemons-license") > -1:
                         code = 8

--- a/src/core/tests/library/LegacyEnvLayerExtensions.py
+++ b/src/core/tests/library/LegacyEnvLayerExtensions.py
@@ -546,12 +546,17 @@ class LegacyEnvLayerExtensions():
                         code = 0
                         output = "Installed"
                     elif cmd.find("fwupdmgr --version") > -1:
-                        code = 1
-                        output = ""
-                    elif cmd.find("dpkg --compare-versions") > -1:
-                        code = 1
-                        output = ""
-                    elif cmd.find("sudo apt purge -y fwupd") > -1:
+                        code = 0
+                        output = ("compile    info.libusb                   1.0.25\n"
+                                  "compile   org.freedesktop.fwupd         2.0.20\n"
+                                  "compile   com.hughsie.libxmlb           0.3.24\n"
+                                  "compile   com.hughsie.libjcat           0.2.3\n"
+                                  "runtime   org.freedesktop.fwupd-efi     1.4\n"
+                                  "runtime   com.hughsie.libxmlb           0.3.24\n"
+                                  "runtime   com.hughsie.libjcat           0.2.3\n"
+                                  "runtime   org.kernel                    6.8.0-1052-azure\n"
+                                  "runtime   org.freedesktop.fwupd         2.0.20\n")
+                    elif cmd.find("sudo apt-get purge -y fwupd") > -1:
                         code = 0
                         output = "Removed"
                     elif cmd.find("mokutil --kek | grep 'CN='") > -1:


### PR DESCRIPTION
Changing repository references from proposed to default 

In-VM test logs: 
[5.core.log](https://github.com/user-attachments/files/29062907/5.core.log) [5.status.txt](https://github.com/user-attachments/files/29062914/5.status.txt)

Some screenshots of cert update from logs:
<img width="956" height="167" alt="image" src="https://github.com/user-attachments/assets/0e1a6321-a134-4443-9f57-79c751475219" />

<img width="948" height="104" alt="image" src="https://github.com/user-attachments/assets/1d2ab6ef-fe63-4382-9eb3-143e43bb3cd6" />

<img width="959" height="122" alt="image" src="https://github.com/user-attachments/assets/acf56919-544c-458d-998e-03a247ef9327" />

<img width="952" height="52" alt="image" src="https://github.com/user-attachments/assets/071e4230-17dd-4899-9812-6a17ebfcb7ad" />

<img width="959" height="208" alt="image" src="https://github.com/user-attachments/assets/d5c0981a-cccf-4527-a4d7-8844deeaa122" />




