### PR TITLE
[Release] Updating to v1.6.66

### DIFF
--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -31,7 +31,7 @@ class Constants(object):
     UNKNOWN = "Unknown"
 
     # Extension version (todo: move to a different file)
-    EXT_VERSION = "1.6.65"
+    EXT_VERSION = "1.6.66"
 
     # Runtime environments
     TEST = 'Test'

--- a/src/extension/src/Constants.py
+++ b/src/extension/src/Constants.py
@@ -28,7 +28,7 @@ class Constants(object):
                         yield item
 
     # Extension version (todo: move to a different file)
-    EXT_VERSION = "1.6.65"
+    EXT_VERSION = "1.6.66"
 
     # Runtime environments
     TEST = 'Test'

--- a/src/extension/src/manifest.xml
+++ b/src/extension/src/manifest.xml
@@ -2,7 +2,7 @@
 <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure">
   <ProviderNameSpace>Microsoft.CPlat.Core</ProviderNameSpace>
   <Type>LinuxPatchExtension</Type>
-  <Version>1.6.65</Version>
+  <Version>1.6.66</Version>
   <Label>Microsoft Azure VM InGuest Patch Extension for Linux Virtual Machines</Label>
   <HostingResources>VmRole</HostingResources>
   <MediaLink></MediaLink>


### PR DESCRIPTION
This release contains:
- Fix: Include FIPS-updates repo in security source list [348](https://github.com/Azure/LinuxPatchExtension/pull/348)
- Fix: Failing UT [347](https://github.com/Azure/LinuxPatchExtension/pull/347)
- Feature: [Ubuntu, non-CVM] Updating UEFI and kek certificates during default patching [346](https://github.com/Azure/LinuxPatchExtension/pull/346)
- Feature: Adding Azure Linux 4.0 Base Support using dnf5 package manager [343](https://github.com/Azure/LinuxPatchExtension/pull/343)