### PR TITLE
[Bugfix] Core packager to always keep __main_ at the end

### DIFF
--- a/src/tools/packager/Package-Core.py
+++ b/src/tools/packager/Package-Core.py
@@ -133,7 +133,7 @@ def generate_compiled_script(source_code_path, merged_file_full_path, merged_fil
                 elif os.path.basename(file_path) in ('PatchOperator.py', 'PackageManager.py', 'Constants.py', 'LifecycleManager.py', 'SystemctlManager.py'):
                     modules_to_be_merged.insert(0, file_path)
                 elif os.path.basename(file_path) == 'TdnfPackageManager.py':
-                    # Insert before `AzL3PackageManager.py`; fallback to append.
+                    # Insert before `AzL3TdnfPackageManager.py`; fallback to insert before __main__.py or append.
                     inserted = False
                     for i, p in enumerate(modules_to_be_merged):
                         if os.path.basename(p) == 'AzL3TdnfPackageManager.py':
@@ -141,7 +141,10 @@ def generate_compiled_script(source_code_path, merged_file_full_path, merged_fil
                             inserted = True
                             break
                     if not inserted:
-                        modules_to_be_merged.append(file_path)
+                        if len(modules_to_be_merged) > 0 and '__main__.py' in modules_to_be_merged[-1]:
+                            modules_to_be_merged.insert(-1, file_path)
+                        else:
+                            modules_to_be_merged.append(file_path)
                 else:
                     if len(modules_to_be_merged) > 0 and '__main__.py' in modules_to_be_merged[-1]:
                         modules_to_be_merged.insert(-1, file_path)


### PR DESCRIPTION
**Bug**:

- **Title**: Package-Core.py can place TdnfPackageManager.py after __main__.py during merge
- **Area**: Core packager (src/tools/packager/Package-Core.py)
- **Description**: 

As a part of the build process, packager classes (Package-All.py and Package-Core.py), package all modules within extension and core directories into MsftLinuxPatchExt,py and MsftLinuxPatchCore.py respectively, which are then used to perform different patching operations. Since MsftLinuxPatchExt.py and MsftLinuxPatchCore.py contain multiple extension and core modules, the order in which these modules are added is important during patch process execution in python. Especially, __main__() should always be added at the very end, since it will start the execution flow and will only consider modules that were loaded before it. So, if a module is added after __main__, it will raise a Not found error.

This issue was observed in one of the recent builds where TdnfPackageManager (and some other modules) were inserted after __main__(), due to the code in Package-Core.py handling the special case for TdnfPackageManager. This led those modules marked as not found during execution

<img width="1918" height="853" alt="image" src="https://github.com/user-attachments/assets/69129f84-70ba-4c62-a291-fe3844b24791" />

Below is the packager log for Core modules (Notice __main__.py is in between with TdnfPackageManager.py right after it):

              =============================== (1/3) GENERATING MsftLinuxPatchCore.py... ===============================
              
              ------------- Delete old core file if it exists.
              ------------- Merging modules:
              LifecycleManager.py, PackageManager.py, Constants.py, SystemctlManager.py, CoreMain.py, FileLogger.py, CompositeLogger.py, StdOutFileMirror.py, Stopwatch.py, PatchAssessor.py, PackageFilter.py, ServiceManager.py, RebootManager.py, ExecutionConfig.py, VersionComparator.py, MaintenanceWindow.py, PatchInstaller.py, ConfigurePatchingProcessor.py, TimerManager.py, EnvLayer.py, Bootstrapper.py, ConfigurationFactory.py, Container.py, YumPackageManager.py, **__main__.py, TdnfPackageManager.py**, AzL3TdnfPackageManager.py, ZypperPackageManager.py, UbuntuProClient.py, Dnf5PackageManager.py, AptitudePackageManager.py, LifecycleManagerArc.py, LifecycleManagerAzure.py, TelemetryWriter.py, StatusHandler.py, <end>
              ------------- Prepend all import statements
              ------------- Set Copyright, Version and Environment. Also enforce UNIX-style line endings.
              ------------- Merged core code was saved to:
              /__w/1/s/src/LinuxPatchExtension/codesrc/src/out/MsftLinuxPatchCore.py



**Expected Behavior**:
__main__.py should be last (or near-last entrypoint), and package manager modules should appear before it.
TdnfPackageManager.py should be before AzL3TdnfPackageManager.py, and both should be before __main__.py.
Impact
The merged file order becomes inconsistent and can violate intended initialization/dependency sequencing.
Behavior is traversal-order sensitive (depends on os.walk() encounter order), so it may appear intermittently across environments.

**Root Cause**:
In src/tools/packager/Package-Core.py, branch for TdnfPackageManager.py does:
Insert before AzL3TdnfPackageManager.py if already present
Else append unconditionally
If __main__.py is already appended, fallback append puts TdnfPackageManager.py after __main__.py.
The generic fallback logic for other files already handles this correctly using:
modules_to_be_merged.insert(-1, file_path) when __main__.py is last.

This isn't something introduced in recent commits, but the change in packager locations could have caused os.walk() to process modules in a different order triggering this

**Proposed Fix**:
In Package-Core.py, for the special case handling TdnfPackageManager, add a fallback, use same guard as generic path:
If last module is __main__.py, insert at -1; else append.
This preserves both constraints:
TdnfPackageManager.py before AzL3TdnfPackageManager.py when possible
Neither ends up after __main__.py.

**Acceptance Criteria**:
Packager output order always satisfies:
TdnfPackageManager.py appears before AzL3TdnfPackageManager.py
__main__.py appears after both
Behavior remains stable regardless of os.walk() traversal order.