### PR TITLE
Remove distutils import which is deprecated since Python 3.12

### DIFF
--- a/src/tools/packager/Package-All.py
+++ b/src/tools/packager/Package-All.py
@@ -34,8 +34,7 @@ import xml.etree.ElementTree as et
 # imports in VERY_FIRST_IMPORTS, order should be kept
 VERY_FIRST_IMPORTS = [
     'from __future__ import print_function\n',
-    'from abc import ABCMeta, abstractmethod\n',
-    'from distutils.version import LooseVersion\n']
+    'from abc import ABCMeta, abstractmethod\n']
 GLOBAL_IMPORTS = set()
 
 


### PR DESCRIPTION
 Fixed distutils module deprecation since python 312 .This deprecation is causing failure in Linux4 VM where python version is 3.14.3.
There is code already in place to address the above deprecation: https://github.com/Azure/LinuxPatchExtension/pull/280  
Import got reintroduced as a part of a separate PR and needs to be removed.

<img width="1088" height="448" alt="disutils" src="https://github.com/user-attachments/assets/645140aa-b69d-4318-970f-36085f0b22a7" />
