### PR TITLE
Updating to v1.6.68

### DIFF
--- a/src/extension/src/manifest.xml
+++ b/src/extension/src/manifest.xml
@@ -2,7 +2,7 @@
 <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure">
   <ProviderNameSpace>Microsoft.CPlat.Core</ProviderNameSpace>
   <Type>LinuxPatchExtension</Type>
-  <Version>1.6.67</Version>
+  <Version>1.6.68</Version>
   <Label>Microsoft Azure VM InGuest Patch Extension for Linux Virtual Machines</Label>
   <HostingResources>VmRole</HostingResources>
   <MediaLink></MediaLink>


### PR DESCRIPTION
This release contains:

Remove distutils import which is deprecated since Python 3.12 : [361](https://github.com/Azure/LinuxPatchExtension/pull/361)

[Bugfix] Core packager to always keep __main_ at the end : [360](https://github.com/Azure/LinuxPatchExtension/pull/360)

Feature: [Ubuntu, no-CVM] CVM machines to not get UEFI and kek certificate updates : [356](https://github.com/Azure/LinuxPatchExtension/pull/356) 
