### PR TITLE
Feature: [Ubuntu, no-CVM] Change opt-in logic to update certificates for Ubuntu

### DIFF
--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -90,7 +90,7 @@ class Constants(object):
 
     class UEFISettings(EnumBackport):
         ENABLE_UEFI_CERT_UPDATE_FOR_AUTO_PATCHING = 'EnableUEFICertUpdateForAutoPatching'
-        ENABLE_UEFI_CERT_UPDATE_FOR_ALL_PATCHING= 'EnableUEFICertUpdateForAllPatching'
+        ENABLE_UEFI_CERT_UPDATE_FOR_ALL_PATCHING = 'EnableUEFICertUpdateForAllPatching'
         ENABLED_BY = 'EnabledBy'
         LAST_MODIFIED = 'LastModified'
 

--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -90,7 +90,7 @@ class Constants(object):
 
     class UEFISettings(EnumBackport):
         ENABLE_UEFI_CERT_UPDATE_FOR_AUTO_PATCHING = 'EnableUEFICertUpdateForAutoPatching'
-        ENABLE_UEFI_CERT_UPDATE_FOR_NON_AUTO_PATCHING = 'EnableUEFICertUpdateForNonAutoPatching'
+        ENABLE_UEFI_CERT_UPDATE_FOR_ALL_PATCHING= 'EnableUEFICertUpdateForAllPatching'
         ENABLED_BY = 'EnabledBy'
         LAST_MODIFIED = 'LastModified'
 

--- a/src/core/src/bootstrap/Constants.py
+++ b/src/core/src/bootstrap/Constants.py
@@ -89,7 +89,8 @@ class Constants(object):
         LAST_MODIFIED = 'LastModified'
 
     class UEFISettings(EnumBackport):
-        ENABLE_UEFI_CERT_UPDATE = 'EnableUEFICertUpdate'
+        ENABLE_UEFI_CERT_UPDATE_FOR_AUTO_PATCHING = 'EnableUEFICertUpdateForAutoPatching'
+        ENABLE_UEFI_CERT_UPDATE_FOR_NON_AUTO_PATCHING = 'EnableUEFICertUpdateForNonAutoPatching'
         ENABLED_BY = 'EnabledBy'
         LAST_MODIFIED = 'LastModified'
 

--- a/src/core/src/core_logic/ExecutionConfig.py
+++ b/src/core/src/core_logic/ExecutionConfig.py
@@ -272,7 +272,7 @@ class ExecutionConfig(object):
 
     def __fetch_uefi_cert_update_settings(self):
         # type: () -> (any, any)
-        """  Reads customer provided config on UEFI cert update from disk and returns the values for both uefi update enabled
+        """ Reads customer provided config on UEFI cert update from disk and returns the values for both UEFI update enabled
         for auto patching and all patching operations. If not found, returns None for both values."""
         enable_uefi_cert_update_for_auto_patching = None
         enable_uefi_cert_update_for_all_patching = None

--- a/src/core/src/core_logic/ExecutionConfig.py
+++ b/src/core/src/core_logic/ExecutionConfig.py
@@ -93,7 +93,7 @@ class ExecutionConfig(object):
         self.accept_package_eula = self.__is_eula_accepted_for_all_patches()
 
         # UEFI config
-        self.enable_uefi_cert_update = self.__is_uefi_cert_update_enabled()
+        self.enable_uefi_cert_update_for_auto_patching, self.enable_uefi_cert_update_for_non_auto_patching = self.__fetch_uefi_cert_update_settings()
 
     def __transform_execution_config_for_auto_assessment(self):
         self.activity_id = str(uuid.uuid4())
@@ -270,26 +270,55 @@ class ExecutionConfig(object):
             return settings_source[setting_to_fetch]
         return None
 
-    def __is_uefi_cert_update_enabled(self):
-        # type: () -> bool
-        """ Reads customer provided config on UEFI cert update from disk and returns a boolean.
-        NOTE: This is a temporary solution implemented expressly for validating cert updates with partners and will be deprecated soon """
-        is_uefi_cert_update_enabled = False
+    def __fetch_uefi_cert_update_settings(self):
+        # type: () -> (any, any)
+        """  Reads customer provided config on UEFI cert update from disk and returns the values for both uefi update enabled for auto patching and non-auto patching. If not found, returns None for both values."""
+        enable_uefi_cert_update_for_auto_patching = None
+        enable_uefi_cert_update_for_non_auto_patching = None
         try:
             if os.path.exists(Constants.AzGPSPaths.UEFI_SETTINGS):
                 uefi_cert_update_settings = json.loads(self.env_layer.file_system.read_with_retry(Constants.AzGPSPaths.UEFI_SETTINGS) or 'null')
-                enable_uefi_cert_update = self.__fetch_specific_azgps_setting(uefi_cert_update_settings, Constants.UEFISettings.ENABLE_UEFI_CERT_UPDATE)
+                enable_uefi_cert_update_for_auto_patching = self.__fetch_specific_azgps_setting(uefi_cert_update_settings, Constants.UEFISettings.ENABLE_UEFI_CERT_UPDATE_FOR_AUTO_PATCHING)
+                enable_uefi_cert_update_for_non_auto_patching = self.__fetch_specific_azgps_setting(uefi_cert_update_settings,Constants.UEFISettings.ENABLE_UEFI_CERT_UPDATE_FOR_NON_AUTO_PATCHING)
                 enabled_by = self.__fetch_specific_azgps_setting(uefi_cert_update_settings, Constants.UEFISettings.ENABLED_BY)
                 last_modified = self.__fetch_specific_azgps_setting(uefi_cert_update_settings, Constants.UEFISettings.LAST_MODIFIED)
-                if enable_uefi_cert_update is not None and self.__is_truthy(enable_uefi_cert_update):
-                    is_uefi_cert_update_enabled = True
-                self.composite_logger.log_debug("UEFI cert update config values from disk: [EnableUefiCertUpdate={0}] [EnabledBy={1}] [LastModified={2}]. Computed value of [IsUefiCertUpdateEnabled={3}]"
-                                                .format(str(enable_uefi_cert_update), str(enabled_by), str(last_modified), str(is_uefi_cert_update_enabled)))
+                self.composite_logger.log_debug("UEFI cert update config values from disk: [EnableUefiCertUpdateForAutoPatching={0}] [EnableUefiCertUpdateForNonAutoPatching={1}] "
+                                                "[EnabledBy={2}] [LastModified={3}].".format(str(enable_uefi_cert_update_for_auto_patching),
+                                                                                             str(enable_uefi_cert_update_for_non_auto_patching), str(enabled_by), str(last_modified)))
             else:
-                self.composite_logger.log_debug("No UEFI cert update settings found on the VM. Computed value of [IsUefiCertUpdateEnabled={0}]".format(str(is_uefi_cert_update_enabled)))
+                self.composite_logger.log_debug("No UEFI cert update settings found on the VM.")
         except Exception as error:
-            self.composite_logger.log_debug("Error occurred while reading and parsing UEFI cert update settings. Not enabling UEFI cert update. Error=[{0}]".format(repr(error)))
+            self.composite_logger.log_debug("Error occurred while reading and parsing UEFI cert update settings. [Error={0}]".format(repr(error)))
+        return enable_uefi_cert_update_for_auto_patching, enable_uefi_cert_update_for_non_auto_patching
 
+    def is_cert_update_for_auto_patching_explicitly_enabled(self):
+        # type: () -> bool
+        """ Verifies if certificate update for auto patching is enabled explicitly """
+        is_uefi_cert_update_enabled = False
+        if self.enable_uefi_cert_update_for_auto_patching is not None and self.__is_truthy(self.enable_uefi_cert_update_for_auto_patching):
+            is_uefi_cert_update_enabled = True
+            self.composite_logger.log_debug("UEFI cert update config value from disk: [EnableUefiCertUpdateForAutoPatching={0}]. Computed value of [IsUefiCertUpdateForAutoPatchingExplicitlyEnabled={1}]"
+                                                .format(str(self.enable_uefi_cert_update_for_auto_patching), str(is_uefi_cert_update_enabled)))
+        return is_uefi_cert_update_enabled
+
+    def is_cert_update_for_auto_patching_explicitly_disabled(self):
+        # type: () -> bool
+        """ Verifies if certificate update for auto patching is disabled explicitly """
+        is_uefi_cert_update_enabled = True
+        if self.enable_uefi_cert_update_for_auto_patching is not None and not self.__is_truthy(self.enable_uefi_cert_update_for_auto_patching):
+            is_uefi_cert_update_enabled = False
+            self.composite_logger.log_debug("UEFI cert update config value from disk: [EnableUefiCertUpdateForAutoPatching={0}]. Computed value of [IsUefiCertUpdateForAutoPatchingExplicitlyEnabled={1}]"
+                                                .format(str(self.enable_uefi_cert_update_for_auto_patching), str(is_uefi_cert_update_enabled)))
+        return not is_uefi_cert_update_enabled
+
+    def is_cert_update_for_non_auto_patching_explicitly_enabled(self):
+        # type: () -> bool
+        """ Verifies if certificate update for non auto patching is enabled explicitly """
+        is_uefi_cert_update_enabled = False
+        if self.enable_uefi_cert_update_for_non_auto_patching is not None and self.__is_truthy(self.enable_uefi_cert_update_for_non_auto_patching):
+            is_uefi_cert_update_enabled = True
+            self.composite_logger.log_debug("UEFI cert update config value from disk: [EnableUefiCertUpdateForNonAutoPatching={0}]. Computed value of [IsUefiCertUpdateForNonAutoPatchingExplicitlyEnabled={1}]"
+                                                .format(str(self.enable_uefi_cert_update_for_non_auto_patching), str(is_uefi_cert_update_enabled)))
         return is_uefi_cert_update_enabled
 
     @staticmethod

--- a/src/core/src/core_logic/ExecutionConfig.py
+++ b/src/core/src/core_logic/ExecutionConfig.py
@@ -322,6 +322,13 @@ class ExecutionConfig(object):
                                             .format(str(self.enable_uefi_cert_update_for_all_patching), str(is_uefi_cert_update_enabled)))
         return is_uefi_cert_update_enabled
 
+    def is_default_patching(self):
+        # type: () -> bool
+        """ Returns true if the patching run is a default patching run"""
+        return (self.health_store_id is not None and
+                self.health_store_id != "" and
+                self.operation.lower() == Constants.INSTALLATION.lower())
+
     @staticmethod
     def __is_truthy(value):
         # type: (any) -> bool

--- a/src/core/src/core_logic/ExecutionConfig.py
+++ b/src/core/src/core_logic/ExecutionConfig.py
@@ -93,7 +93,7 @@ class ExecutionConfig(object):
         self.accept_package_eula = self.__is_eula_accepted_for_all_patches()
 
         # UEFI config
-        self.enable_uefi_cert_update_for_auto_patching, self.enable_uefi_cert_update_for_non_auto_patching = self.__fetch_uefi_cert_update_settings()
+        self.enable_uefi_cert_update_for_auto_patching, self.enable_uefi_cert_update_for_all_patching = self.__fetch_uefi_cert_update_settings()
 
     def __transform_execution_config_for_auto_assessment(self):
         self.activity_id = str(uuid.uuid4())
@@ -272,24 +272,25 @@ class ExecutionConfig(object):
 
     def __fetch_uefi_cert_update_settings(self):
         # type: () -> (any, any)
-        """  Reads customer provided config on UEFI cert update from disk and returns the values for both uefi update enabled for auto patching and non-auto patching. If not found, returns None for both values."""
+        """  Reads customer provided config on UEFI cert update from disk and returns the values for both uefi update enabled
+        for auto patching and all patching operations. If not found, returns None for both values."""
         enable_uefi_cert_update_for_auto_patching = None
-        enable_uefi_cert_update_for_non_auto_patching = None
+        enable_uefi_cert_update_for_all_patching = None
         try:
             if os.path.exists(Constants.AzGPSPaths.UEFI_SETTINGS):
                 uefi_cert_update_settings = json.loads(self.env_layer.file_system.read_with_retry(Constants.AzGPSPaths.UEFI_SETTINGS) or 'null')
                 enable_uefi_cert_update_for_auto_patching = self.__fetch_specific_azgps_setting(uefi_cert_update_settings, Constants.UEFISettings.ENABLE_UEFI_CERT_UPDATE_FOR_AUTO_PATCHING)
-                enable_uefi_cert_update_for_non_auto_patching = self.__fetch_specific_azgps_setting(uefi_cert_update_settings,Constants.UEFISettings.ENABLE_UEFI_CERT_UPDATE_FOR_NON_AUTO_PATCHING)
+                enable_uefi_cert_update_for_all_patching = self.__fetch_specific_azgps_setting(uefi_cert_update_settings, Constants.UEFISettings.ENABLE_UEFI_CERT_UPDATE_FOR_ALL_PATCHING)
                 enabled_by = self.__fetch_specific_azgps_setting(uefi_cert_update_settings, Constants.UEFISettings.ENABLED_BY)
                 last_modified = self.__fetch_specific_azgps_setting(uefi_cert_update_settings, Constants.UEFISettings.LAST_MODIFIED)
-                self.composite_logger.log_debug("UEFI cert update config values from disk: [EnableUefiCertUpdateForAutoPatching={0}] [EnableUefiCertUpdateForNonAutoPatching={1}] "
+                self.composite_logger.log_debug("UEFI cert update config values from disk: [EnableUefiCertUpdateForAutoPatching={0}] [EnableUefiCertUpdateForAllPatching={1}] "
                                                 "[EnabledBy={2}] [LastModified={3}].".format(str(enable_uefi_cert_update_for_auto_patching),
-                                                                                             str(enable_uefi_cert_update_for_non_auto_patching), str(enabled_by), str(last_modified)))
+                                                                                             str(enable_uefi_cert_update_for_all_patching), str(enabled_by), str(last_modified)))
             else:
                 self.composite_logger.log_debug("No UEFI cert update settings found on the VM.")
         except Exception as error:
             self.composite_logger.log_debug("Error occurred while reading and parsing UEFI cert update settings. [Error={0}]".format(repr(error)))
-        return enable_uefi_cert_update_for_auto_patching, enable_uefi_cert_update_for_non_auto_patching
+        return enable_uefi_cert_update_for_auto_patching, enable_uefi_cert_update_for_all_patching
 
     def is_cert_update_for_auto_patching_explicitly_enabled(self):
         # type: () -> bool
@@ -307,18 +308,18 @@ class ExecutionConfig(object):
         is_uefi_cert_update_enabled = True
         if self.enable_uefi_cert_update_for_auto_patching is not None and not self.__is_truthy(self.enable_uefi_cert_update_for_auto_patching):
             is_uefi_cert_update_enabled = False
-            self.composite_logger.log_debug("UEFI cert update config value from disk: [EnableUefiCertUpdateForAutoPatching={0}]. Computed value of [IsUefiCertUpdateForAutoPatchingExplicitlyEnabled={1}]"
-                                                .format(str(self.enable_uefi_cert_update_for_auto_patching), str(is_uefi_cert_update_enabled)))
+            self.composite_logger.log_debug("UEFI cert update config value from disk: [EnableUefiCertUpdateForAutoPatching={0}]. Computed value of [IsUefiCertUpdateForAutoPatchingExplicitlyDisabled={1}]"
+                                                .format(str(self.enable_uefi_cert_update_for_auto_patching), str(not is_uefi_cert_update_enabled)))
         return not is_uefi_cert_update_enabled
 
-    def is_cert_update_for_non_auto_patching_explicitly_enabled(self):
+    def is_cert_update_for_all_patching_explicitly_enabled(self):
         # type: () -> bool
-        """ Verifies if certificate update for non auto patching is enabled explicitly """
+        """ Verifies if certificate update for all patching operations is enabled explicitly """
         is_uefi_cert_update_enabled = False
-        if self.enable_uefi_cert_update_for_non_auto_patching is not None and self.__is_truthy(self.enable_uefi_cert_update_for_non_auto_patching):
+        if self.enable_uefi_cert_update_for_all_patching is not None and self.__is_truthy(self.enable_uefi_cert_update_for_all_patching):
             is_uefi_cert_update_enabled = True
-            self.composite_logger.log_debug("UEFI cert update config value from disk: [EnableUefiCertUpdateForNonAutoPatching={0}]. Computed value of [IsUefiCertUpdateForNonAutoPatchingExplicitlyEnabled={1}]"
-                                                .format(str(self.enable_uefi_cert_update_for_non_auto_patching), str(is_uefi_cert_update_enabled)))
+            self.composite_logger.log_debug("UEFI cert update config value from disk: [EnableUefiCertUpdateForAllPatching={0}]. Computed value of [IsUefiCertUpdateForAllPatchingExplicitlyEnabled={1}]"
+                                            .format(str(self.enable_uefi_cert_update_for_all_patching), str(is_uefi_cert_update_enabled)))
         return is_uefi_cert_update_enabled
 
     @staticmethod

--- a/src/core/src/core_logic/PatchInstaller.py
+++ b/src/core/src/core_logic/PatchInstaller.py
@@ -830,26 +830,36 @@ class PatchInstaller(object):
 
     def __is_cert_update_allowed_for_apt(self):
         # type: () -> bool
-        """For apt (Canonical): cert update is allowed unless explicitly disabled.
-        Exception: if disabled for auto but enabled for non-auto, only allow non-auto patching."""
-        if self.execution_config.is_cert_update_for_auto_patching_explicitly_disabled() and self.execution_config.is_cert_update_for_non_auto_patching_explicitly_enabled():
-            # Hybrid mode: allow only for non-auto patching
-            self.composite_logger.log_debug("Certificate update enabled only for non auto patching operations for Canonical. Verifying if current operation is non auto patching")
-            if self.__is_not_default_patching():
-                self.composite_logger.log_debug("UEFI certificate will be updated in this non auto patching operation")
+        """For apt (Canonical): determines whether cert update is allowed based on explicit configuration.
+        - If cert update is explicitly enabled for all patching (EnableUEFICertUpdateForAllPatching=True):
+          cert update is allowed for any patch installation operation, auto or non-auto.
+        - If cert update is explicitly disabled for auto patching (EnableUEFICertUpdateForAutoPatching=False):
+          cert update is blocked for auto (default) patching operations.
+        - Default (no explicit config): cert update is allowed only for auto (default) patching operations.
+        - Cert update will NOT be applied for anything outside of these conditions. """
+        if self.execution_config.is_cert_update_for_all_patching_explicitly_enabled():
+            # Hybrid mode: allow for all patching operation
+            self.composite_logger.log_debug("Certificate update enabled on this VM for all patching operations for Canonical. Verifying if current operation is patch installation...")
+            if self.execution_config.operation.lower() == Constants.INSTALLATION.lower():
+                self.composite_logger.log_debug("UEFI certificate update will be attempted in this patch installation operation")
                 return True
             else:
-                self.composite_logger.log_debug("UEFI certificate will not be updated since this is not a non auto patching operation")
+                self.composite_logger.log_debug("UEFI certificate will NOT be updated since this is not a patch installation operation")
                 return False
-
-        if self.execution_config.is_cert_update_for_auto_patching_explicitly_disabled():
+        elif self.execution_config.is_cert_update_for_auto_patching_explicitly_disabled():
             # Explicitly disabled for auto patching
-            self.composite_logger.log_debug("UEFI certificate update is disabled for Canonical. Continuing patch installation without certificate update.")
-            return False
+            self.composite_logger.log_debug("UEFI certificate update is disabled for auto patching operations on Canonical. Verifying if this is an auto patching operation...")
+            if self.__is_default_patching():
+                self.composite_logger.log_debug("UEFI certificate will NOT be updated for this auto patching operation as per user configuration. Continuing without certificate update.")
+                return False
+        else:
+            # Default: allowed for Auto Patching
+            if self.__is_default_patching():
+                self.composite_logger.log_debug("UEFI certificate update is allowed by default for auto patching operation. Certificate update will be attempted")
+                return True
 
-        # Default: allowed for apt
-        self.composite_logger.log_debug("UEFI certificate update is allowed for Canonical. Certificates will be updated")
-        return True
+        self.composite_logger.log_debug("UEFI certificate update will NOT be attempted since this operation does not meet update criteria. Continuing without certificate update.")
+        return False
 
     def __is_cert_update_allowed_for_non_apt(self):
         # type: () -> bool

--- a/src/core/src/core_logic/PatchInstaller.py
+++ b/src/core/src/core_logic/PatchInstaller.py
@@ -77,9 +77,8 @@ class PatchInstaller(object):
                 self.composite_logger.log_debug("Attempting to reboot the machine prior to patch installation as there is a reboot pending...")
                 reboot_manager.start_reboot_if_required_and_time_available(maintenance_window.get_remaining_time_in_minutes(None, False))
 
-        # Update certificates if feature flag to update certs is set
-        if self.execution_config.enable_uefi_cert_update and self.package_manager.is_certificate_update_enabled_for_package_manager:
-            self.try_update_certificates_for_default_patching()
+        # Update boot certificates if enabled
+        self.try_update_certificates()
 
         if self.execution_config.max_patch_publish_date != str():
             self.package_manager.set_max_patch_publish_date(self.execution_config.max_patch_publish_date)
@@ -801,11 +800,11 @@ class PatchInstaller(object):
 
         return max_batch_size_for_packages
 
-    def try_update_certificates_for_default_patching(self):
+    def try_update_certificates(self):
         # type: () -> None
-        """ Attempts to update certificates on the machine for default patching"""
-        if not self.__is_default_patching():
-            self.composite_logger.log_debug("Not updating certificates since this is not a default patching operation.")
+        """ Attempts to update certificates on the machine """
+        if not self.__is_cert_update_allowed():
+            self.composite_logger.log_debug("Certificate update not performed: system configuration restricts certificate updates")
             return
 
         if self.__are_prerequisites_for_updating_certs_met():
@@ -821,11 +820,64 @@ class PatchInstaller(object):
                 self.composite_logger.log_error(error_msg)
                 self.status_handler.add_error_to_status(error_msg, Constants.PatchOperationErrorCodes.CERTIFICATE_UPDATE)
 
+    def __is_cert_update_allowed(self):
+        # type: () -> bool
+        """Determines if certificate update is allowed based on package manager type and configuration."""
+        if self.package_manager_name == Constants.APT:
+            return self.__is_cert_update_allowed_for_apt()
+        else:
+            return self.__is_cert_update_allowed_for_non_apt()
+
+    def __is_cert_update_allowed_for_apt(self):
+        # type: () -> bool
+        """For apt (Canonical): cert update is allowed unless explicitly disabled.
+        Exception: if disabled for auto but enabled for non-auto, only allow non-auto patching."""
+        if self.execution_config.is_cert_update_for_auto_patching_explicitly_disabled() and self.execution_config.is_cert_update_for_non_auto_patching_explicitly_enabled():
+            # Hybrid mode: allow only for non-auto patching
+            self.composite_logger.log_debug("Certificate update enabled only for non auto patching operations for Canonical. Verifying if current operation is non auto patching")
+            if self.__is_not_default_patching():
+                self.composite_logger.log_debug("UEFI certificate will be updated in this non auto patching operation")
+                return True
+            else:
+                self.composite_logger.log_debug("UEFI certificate will not be updated since this is not a non auto patching operation")
+                return False
+
+        if self.execution_config.is_cert_update_for_auto_patching_explicitly_disabled():
+            # Explicitly disabled for auto patching
+            self.composite_logger.log_debug("UEFI certificate update is disabled for Canonical. Continuing patch installation without certificate update.")
+            return False
+
+        # Default: allowed for apt
+        self.composite_logger.log_debug("UEFI certificate update is allowed for Canonical. Certificates will be updated")
+        return True
+
+    def __is_cert_update_allowed_for_non_apt(self):
+        # type: () -> bool
+        """For non-apt package managers: cert update is only allowed if explicitly enabled for auto patching."""
+        if self.execution_config.is_cert_update_for_auto_patching_explicitly_enabled():
+            self.composite_logger.log_debug("Certificate update enabled on this VM for an auto patching operation. Verifying if current operation is an auto patching operation")
+            if self.__is_default_patching():
+                self.composite_logger.log_debug("UEFI certificate will be updated in this auto patching operation")
+                return True
+            else:
+                self.composite_logger.log_debug("UEFI certificate will not be updated since this is not an auto patching operation")
+                return False
+
+        # Default: not allowed for non-apt unless explicitly enabled
+        return False
+
     def __is_default_patching(self):
         # type: () -> bool
         """ Returns true if the patching run is a default patching run"""
         return (self.execution_config.health_store_id is not None and
                 self.execution_config.health_store_id != "" and
+                self.execution_config.operation.lower() == Constants.INSTALLATION.lower())
+
+    def __is_not_default_patching(self):
+        # type: () -> bool
+        """ Returns true if the patching run is not default patching run"""
+        return ((self.execution_config.health_store_id is None or
+                self.execution_config.health_store_id == "") and
                 self.execution_config.operation.lower() == Constants.INSTALLATION.lower())
 
     def __are_prerequisites_for_updating_certs_met(self):

--- a/src/core/src/core_logic/PatchInstaller.py
+++ b/src/core/src/core_logic/PatchInstaller.py
@@ -803,7 +803,7 @@ class PatchInstaller(object):
     def try_update_certificates(self):
         # type: () -> None
         """ Attempts to update certificates on the machine """
-        if not self.__is_cert_update_allowed():
+        if not self.package_manager.is_cert_update_supported():
             self.composite_logger.log_debug("Certificate update not performed: system configuration restricts certificate updates")
             return
 
@@ -819,76 +819,6 @@ class PatchInstaller(object):
                 error_msg = "An error was encountered while attempting to update certificates. Continuing with patch installation... [Error: {0}]".format(str(e))
                 self.composite_logger.log_error(error_msg)
                 self.status_handler.add_error_to_status(error_msg, Constants.PatchOperationErrorCodes.CERTIFICATE_UPDATE)
-
-    def __is_cert_update_allowed(self):
-        # type: () -> bool
-        """Determines if certificate update is allowed based on package manager type and configuration."""
-        if self.package_manager_name == Constants.APT:
-            return self.__is_cert_update_allowed_for_apt()
-        else:
-            return self.__is_cert_update_allowed_for_non_apt()
-
-    def __is_cert_update_allowed_for_apt(self):
-        # type: () -> bool
-        """For apt (Canonical): determines whether cert update is allowed based on explicit configuration.
-        - If cert update is explicitly enabled for all patching (EnableUEFICertUpdateForAllPatching=True):
-          cert update is allowed for any patch installation operation, auto or non-auto.
-        - If cert update is explicitly disabled for auto patching (EnableUEFICertUpdateForAutoPatching=False):
-          cert update is blocked for auto (default) patching operations.
-        - Default (no explicit config): cert update is allowed only for auto (default) patching operations.
-        - Cert update will NOT be applied for anything outside of these conditions. """
-        if self.execution_config.is_cert_update_for_all_patching_explicitly_enabled():
-            # Hybrid mode: allow for all patching operation
-            self.composite_logger.log_debug("Certificate update enabled on this VM for all patching operations for Canonical. Verifying if current operation is patch installation...")
-            if self.execution_config.operation.lower() == Constants.INSTALLATION.lower():
-                self.composite_logger.log_debug("UEFI certificate update will be attempted in this patch installation operation")
-                return True
-            else:
-                self.composite_logger.log_debug("UEFI certificate will NOT be updated since this is not a patch installation operation")
-                return False
-        elif self.execution_config.is_cert_update_for_auto_patching_explicitly_disabled():
-            # Explicitly disabled for auto patching
-            self.composite_logger.log_debug("UEFI certificate update is disabled for auto patching operations on Canonical. Verifying if this is an auto patching operation...")
-            if self.__is_default_patching():
-                self.composite_logger.log_debug("UEFI certificate will NOT be updated for this auto patching operation as per user configuration. Continuing without certificate update.")
-                return False
-        else:
-            # Default: allowed for Auto Patching
-            if self.__is_default_patching():
-                self.composite_logger.log_debug("UEFI certificate update is allowed by default for auto patching operation. Certificate update will be attempted")
-                return True
-
-        self.composite_logger.log_debug("UEFI certificate update will NOT be attempted since this operation does not meet update criteria. Continuing without certificate update.")
-        return False
-
-    def __is_cert_update_allowed_for_non_apt(self):
-        # type: () -> bool
-        """For non-apt package managers: cert update is only allowed if explicitly enabled for auto patching."""
-        if self.execution_config.is_cert_update_for_auto_patching_explicitly_enabled():
-            self.composite_logger.log_debug("Certificate update enabled on this VM for an auto patching operation. Verifying if current operation is an auto patching operation")
-            if self.__is_default_patching():
-                self.composite_logger.log_debug("UEFI certificate will be updated in this auto patching operation")
-                return True
-            else:
-                self.composite_logger.log_debug("UEFI certificate will not be updated since this is not an auto patching operation")
-                return False
-
-        # Default: not allowed for non-apt unless explicitly enabled
-        return False
-
-    def __is_default_patching(self):
-        # type: () -> bool
-        """ Returns true if the patching run is a default patching run"""
-        return (self.execution_config.health_store_id is not None and
-                self.execution_config.health_store_id != "" and
-                self.execution_config.operation.lower() == Constants.INSTALLATION.lower())
-
-    def __is_not_default_patching(self):
-        # type: () -> bool
-        """ Returns true if the patching run is not default patching run"""
-        return ((self.execution_config.health_store_id is None or
-                self.execution_config.health_store_id == "") and
-                self.execution_config.operation.lower() == Constants.INSTALLATION.lower())
 
     def __are_prerequisites_for_updating_certs_met(self):
         # type: () -> bool

--- a/src/core/src/core_logic/PatchInstaller.py
+++ b/src/core/src/core_logic/PatchInstaller.py
@@ -803,7 +803,7 @@ class PatchInstaller(object):
     def try_update_certificates(self):
         # type: () -> None
         """ Attempts to update certificates on the machine """
-        if not self.package_manager.is_cert_update_supported():
+        if not self.package_manager.is_cert_update_expected():
             self.composite_logger.log_debug("Certificate update not performed: system configuration restricts certificate updates")
             return
 

--- a/src/core/src/package_managers/AptitudePackageManager.py
+++ b/src/core/src/package_managers/AptitudePackageManager.py
@@ -94,7 +94,6 @@ class AptitudePackageManager(PackageManager):
         self.package_install_expected_avg_time_in_seconds = 90  # As per telemetry data, the average time to install package is around 81 seconds for apt.
 
         # Update certificates in factory defaults.
-        self.is_certificate_update_enabled_for_package_manager = True
         self.install_mokutil_cmd = "sudo apt-get install -y -qq mokutil"
         self.apt_update_cmd = "sudo apt-get -q update"
         self.min_fwupd_version = "2.0.8" # Refer public docs: https://github.com/fwupd/fwupd/releases/tag/2.0.8 and https://discourse.ubuntu.com/t/microsoft-uefi-ca-rotation-what-it-means-for-ubuntu-users-and-vendors/82652

--- a/src/core/src/package_managers/AptitudePackageManager.py
+++ b/src/core/src/package_managers/AptitudePackageManager.py
@@ -1150,10 +1150,10 @@ class AptitudePackageManager(PackageManager):
         self.composite_logger.log_debug("[APM][UpdateCerts] Shell step succeeded. [Step={0}][Command={1}][Code={2}][Output={3}]".format(step_name, str(command), str(code), str(out)))
         return True, out
 
-    def is_cert_update_supported(self):
+    def is_cert_update_expected(self):
         # type: () -> bool
         """ Checks whether certificate update is supported """
-        """For apt (Canonical): determines whether cert update is allowed based on explicit configuration.
+        """ For apt (Canonical): determines whether cert update is allowed based on explicit configuration.
         - If cert update is explicitly enabled for all patching (EnableUEFICertUpdateForAllPatching=True):
           cert update is allowed for any patch installation operation, auto or non-auto.
         - If cert update is explicitly disabled for auto patching (EnableUEFICertUpdateForAutoPatching=False):

--- a/src/core/src/package_managers/AptitudePackageManager.py
+++ b/src/core/src/package_managers/AptitudePackageManager.py
@@ -1149,5 +1149,39 @@ class AptitudePackageManager(PackageManager):
 
         self.composite_logger.log_debug("[APM][UpdateCerts] Shell step succeeded. [Step={0}][Command={1}][Code={2}][Output={3}]".format(step_name, str(command), str(code), str(out)))
         return True, out
+
+    def is_cert_update_supported(self):
+        # type: () -> bool
+        """ Checks whether certificate update is supported """
+        """For apt (Canonical): determines whether cert update is allowed based on explicit configuration.
+        - If cert update is explicitly enabled for all patching (EnableUEFICertUpdateForAllPatching=True):
+          cert update is allowed for any patch installation operation, auto or non-auto.
+        - If cert update is explicitly disabled for auto patching (EnableUEFICertUpdateForAutoPatching=False):
+          cert update is blocked for auto (default) patching operations.
+        - Default (no explicit config): cert update is allowed only for auto (default) patching operations.
+        - Cert update will NOT be applied for anything outside of these conditions. """
+        if self.execution_config.is_cert_update_for_all_patching_explicitly_enabled():
+            # Hybrid mode: allow for all patching operation
+            self.composite_logger.log_debug("Certificate update enabled on this VM for all patching operations for Canonical. Verifying if current operation is patch installation...")
+            if self.execution_config.operation.lower() == Constants.INSTALLATION.lower():
+                self.composite_logger.log_debug("UEFI certificate update will be attempted in this patch installation operation")
+                return True
+            else:
+                self.composite_logger.log_debug("UEFI certificate will NOT be updated since this is not a patch installation operation")
+                return False
+        elif self.execution_config.is_cert_update_for_auto_patching_explicitly_disabled():
+            # Explicitly disabled for auto patching
+            self.composite_logger.log_debug("UEFI certificate update is disabled for auto patching operations on Canonical. Verifying if this is an auto patching operation...")
+            if self.execution_config.is_default_patching():
+                self.composite_logger.log_debug("UEFI certificate will NOT be updated for this auto patching operation as per user configuration. Continuing without certificate update.")
+                return False
+        else:
+            # Default: allowed for Auto Patching
+            if self.execution_config.is_default_patching():
+                self.composite_logger.log_debug("UEFI certificate update is allowed by default for auto patching operation. Certificate update will be attempted")
+                return True
+
+        self.composite_logger.log_debug("UEFI certificate update will NOT be attempted since this operation does not meet update criteria. Continuing without certificate update.")
+        return False
     # endregion
 

--- a/src/core/src/package_managers/PackageManager.py
+++ b/src/core/src/package_managers/PackageManager.py
@@ -26,6 +26,7 @@ class PackageManager(object):
 
     def __init__(self, env_layer, execution_config, composite_logger, telemetry_writer, status_handler):
         self.env_layer = env_layer
+        self.execution_config = execution_config
         self.composite_logger = composite_logger
         self.telemetry_writer = telemetry_writer
         self.status_handler = status_handler
@@ -588,5 +589,22 @@ class PackageManager(object):
     def is_reboot_required_before_cert_update(self):
         """ Checks if a reboot is required before updating certificates """
         pass
+
+    def is_cert_update_supported(self):
+        # type: () -> bool
+        """ Checks whether certificate update is supported. This should be overridden in individual package managers if they have specific criteria for cert update support. """
+        """For all package managers: cert update is only allowed if explicitly enabled for auto patching."""
+        if self.execution_config.is_cert_update_for_auto_patching_explicitly_enabled():
+            self.composite_logger.log_debug("Certificate update enabled on this VM for an auto patching operation. Verifying if current operation is an auto patching operation")
+            if self.execution_config.is_default_patching():
+                self.composite_logger.log_debug("UEFI certificate update will be attempted in this auto patching operation")
+                return True
+            else:
+                self.composite_logger.log_debug("UEFI certificate will NOT be updated since this is not an auto patching operation. Continuing without certificate update.")
+                return False
+
+        # Default: not allowed unless explicitly enabled
+        self.composite_logger.log_debug("UEFI certificate update will NOT be attempted since this operation does not meet update criteria. Continuing without certificate update.")
+        return False
     # endregion
 

--- a/src/core/src/package_managers/PackageManager.py
+++ b/src/core/src/package_managers/PackageManager.py
@@ -54,7 +54,6 @@ class PackageManager(object):
         self.REBOOT_PENDING_FILE_PATH = '/var/run/reboot-required'
 
         # Update certificates in factory defaults
-        self.is_certificate_update_enabled_for_package_manager = False # NOTE: This should be removed once certificate update is enabled for all package managers
         self.check_mokutil_exists_cmd = "command -v mokutil"
         self.get_kek_cert_status_cmd = "mokutil --kek | grep 'CN='"
         self.get_db_cert_status_cmd = "mokutil --db | grep 'CN='"

--- a/src/core/src/package_managers/PackageManager.py
+++ b/src/core/src/package_managers/PackageManager.py
@@ -590,10 +590,10 @@ class PackageManager(object):
         """ Checks if a reboot is required before updating certificates """
         pass
 
-    def is_cert_update_supported(self):
+    def is_cert_update_expected(self):
         # type: () -> bool
         """ Checks whether certificate update is supported. This should be overridden in individual package managers if they have specific criteria for cert update support. """
-        """For all package managers: cert update is only allowed if explicitly enabled for auto patching."""
+        """ For all package managers: cert update is only allowed if explicitly enabled for auto patching."""
         if self.execution_config.is_cert_update_for_auto_patching_explicitly_enabled():
             self.composite_logger.log_debug("Certificate update enabled on this VM for an auto patching operation. Verifying if current operation is an auto patching operation")
             if self.execution_config.is_default_patching():

--- a/src/core/tests/Test_AptitudePackageManager.py
+++ b/src/core/tests/Test_AptitudePackageManager.py
@@ -1605,6 +1605,46 @@ class TestAptitudePackageManager(unittest.TestCase):
                 )
         finally:
             package_manager.env_layer.run_command_output = backup_run_command_output
+
+    def test_is_cert_update_supported__with_various_use_cases(self):
+        """Test AptitudePackageManager.is_cert_update_supported across APT-specific configuration combinations."""
+        package_manager = self.container.get('package_manager')
+
+        backup_health_store_id = package_manager.execution_config.health_store_id
+        backup_operation = package_manager.execution_config.operation
+        backup_enable_auto = package_manager.execution_config.enable_uefi_cert_update_for_auto_patching
+        backup_enable_all = package_manager.execution_config.enable_uefi_cert_update_for_all_patching
+
+        test_input_output_table = [
+            ["default_patching_allowed_by_default", "pub_off_sku_2025.01.01", Constants.INSTALLATION, None, None, True],
+            ["non_default_patching_blocked_by_default", None, Constants.ASSESSMENT, None, None, False],
+            ["all_patching_enabled_allows_default_patching", "pub_off_sku_2025.01.01", Constants.INSTALLATION, False, True, True],
+            ["all_patching_enabled_allows_non_default_patching", None, Constants.INSTALLATION, False, True, True],
+            ["auto_explicitly_disabled_blocks_default_patching", "pub_off_sku_2025.01.01", Constants.INSTALLATION, False, None, False],
+            ["auto_explicitly_disabled_blocks_non_default_patching", None, Constants.ASSESSMENT, False, None, False],
+            ["auto_explicitly_enabled_allows_default_patching", "pub_off_sku_2025.01.01", Constants.INSTALLATION, True, None, True],
+            ["auto_explicitly_enabled_blocks_non_default_patching", None, Constants.ASSESSMENT, True, None, False],
+        ]
+
+        try:
+            for row in test_input_output_table:
+                name, health_store_id, operation, enable_auto, enable_all, expected_result = row
+
+                package_manager.execution_config.health_store_id = health_store_id
+                package_manager.execution_config.operation = operation
+                package_manager.execution_config.enable_uefi_cert_update_for_auto_patching = enable_auto
+                package_manager.execution_config.enable_uefi_cert_update_for_all_patching = enable_all
+
+                self.assertEqual(
+                    package_manager.is_cert_update_supported(),
+                    expected_result,
+                    "Failed use case: {0}".format(name)
+                )
+        finally:
+            package_manager.execution_config.health_store_id = backup_health_store_id
+            package_manager.execution_config.operation = backup_operation
+            package_manager.execution_config.enable_uefi_cert_update_for_auto_patching = backup_enable_auto
+            package_manager.execution_config.enable_uefi_cert_update_for_all_patching = backup_enable_all
     # endregion
 
 

--- a/src/core/tests/Test_AptitudePackageManager.py
+++ b/src/core/tests/Test_AptitudePackageManager.py
@@ -1636,7 +1636,7 @@ class TestAptitudePackageManager(unittest.TestCase):
                 package_manager.execution_config.enable_uefi_cert_update_for_all_patching = enable_all
 
                 self.assertEqual(
-                    package_manager.is_cert_update_supported(),
+                    package_manager.is_cert_update_expected(),
                     expected_result,
                     "Failed use case: {0}".format(name)
                 )

--- a/src/core/tests/Test_ExecutionConfig.py
+++ b/src/core/tests/Test_ExecutionConfig.py
@@ -56,29 +56,29 @@ class TestExecutionConfig(unittest.TestCase):
         # UEFI in-VM customer config does not exist
         runtime, execution_config = self.__setup_and_init_execution_config(write_to_file=False, config="UEFI")
         self.__assert_uefi_configs(execution_config=execution_config, expected_file_exists=False,
-                                  expected_enable_auto_patching=None, expected_enable_non_auto_patching=None)
+                                   expected_enable_auto_patching=None, expected_enable_all_patching=None)
         self.__teardown(runtime)
 
     def test_uefi_config_when_file_read_raises_exception(self):
         uefi_settings = {
             "EnabledBy": "TestSetup",
             "LastModified": "2026-04-21",
-            "EnableUefiCertUpdateForAutoPatching": True
+            "EnableUEFICertUpdateForAutoPatching": True
         }
         runtime, execution_config = self.__setup_and_init_execution_config(write_to_file=True, config="UEFI", config_settings=uefi_settings)
         self.backup_read_with_retry = runtime.env_layer.file_system.read_with_retry
         runtime.env_layer.file_system.read_with_retry = self.mock_read_with_retry_raise_exception
         exec_config = ExecutionConfig(runtime.env_layer, runtime.composite_logger, str(runtime.argv))
         self.__assert_uefi_configs(execution_config=exec_config, expected_file_exists=True,
-                                  expected_enable_auto_patching=None, expected_enable_non_auto_patching=None)
+                                   expected_enable_auto_patching=None, expected_enable_all_patching=None)
         runtime.env_layer.file_system.read_with_retry = self.backup_read_with_retry
         self.__teardown(runtime)
 
 
-    def __assert_uefi_configs(self, execution_config, expected_file_exists, expected_enable_auto_patching, expected_enable_non_auto_patching):
+    def __assert_uefi_configs(self, execution_config, expected_file_exists, expected_enable_auto_patching, expected_enable_all_patching):
         self.assertEqual(os.path.exists(Constants.AzGPSPaths.UEFI_SETTINGS), expected_file_exists)
         self.assertEqual(execution_config.enable_uefi_cert_update_for_auto_patching, expected_enable_auto_patching)
-        self.assertEqual(execution_config.enable_uefi_cert_update_for_non_auto_patching, expected_enable_non_auto_patching)
+        self.assertEqual(execution_config.enable_uefi_cert_update_for_all_patching, expected_enable_all_patching)
 
     def __setup_and_init_execution_config(self, write_to_file=False, config=None, config_settings=None):
         argument_composer = ArgumentComposer()
@@ -174,12 +174,12 @@ class TestExecutionConfig(unittest.TestCase):
 
         self.__teardown(runtime)
 
-    def test_is_cert_update_for_non_auto_patching_explicitly_enabled(self):
-        """Tests is_cert_update_for_non_auto_patching_explicitly_enabled() returns True only for explicitly set truthy values.
+    def test_is_cert_update_for_all_patching_explicitly_enabled(self):
+        """Tests is_cert_update_for_all_patching_explicitly_enabled() returns True only for explicitly set truthy values.
         Follows the same truthy evaluation rules as the auto patching equivalent."""
         runtime, execution_config = self.__setup_and_init_execution_config()
 
-        # [value for enable_uefi_cert_update_for_non_auto_patching, expected_result for is_cert_update_for_non_auto_patching_explicitly_enabled]
+        # [value for enable_uefi_cert_update_for_all_patching, expected_result for is_cert_update_for_all_patching_explicitly_enabled]
         test_cases = [
             # Not set - not explicitly enabled
             [None,    False],
@@ -201,9 +201,9 @@ class TestExecutionConfig(unittest.TestCase):
         ]
 
         for value, expected in test_cases:
-            execution_config.enable_uefi_cert_update_for_non_auto_patching = value
-            self.assertEqual(execution_config.is_cert_update_for_non_auto_patching_explicitly_enabled(), expected,
-                             msg="Failed for enable_uefi_cert_update_for_non_auto_patching={0}".format(repr(value)))
+            execution_config.enable_uefi_cert_update_for_all_patching = value
+            self.assertEqual(execution_config.is_cert_update_for_all_patching_explicitly_enabled(), expected,
+                             msg="Failed for enable_uefi_cert_update_for_all_patching={0}".format(repr(value)))
 
         self.__teardown(runtime)
 

--- a/src/core/tests/Test_ExecutionConfig.py
+++ b/src/core/tests/Test_ExecutionConfig.py
@@ -55,149 +55,30 @@ class TestExecutionConfig(unittest.TestCase):
     def test_uefi_config_when_file_does_not_exist(self):
         # UEFI in-VM customer config does not exist
         runtime, execution_config = self.__setup_and_init_execution_config(write_to_file=False, config="UEFI")
-        self.__assert_uefi_configs(execution_config=execution_config, expected_file_exists=False, expected_enable_uefi_cert_update=False)
+        self.__assert_uefi_configs(execution_config=execution_config, expected_file_exists=False,
+                                  expected_enable_auto_patching=None, expected_enable_non_auto_patching=None)
         self.__teardown(runtime)
 
     def test_uefi_config_when_file_read_raises_exception(self):
         uefi_settings = {
             "EnabledBy": "TestSetup",
             "LastModified": "2026-04-21",
-            "EnableUEFICertUpdate": "test"
+            "EnableUefiCertUpdateForAutoPatching": True
         }
         runtime, execution_config = self.__setup_and_init_execution_config(write_to_file=True, config="UEFI", config_settings=uefi_settings)
         self.backup_read_with_retry = runtime.env_layer.file_system.read_with_retry
         runtime.env_layer.file_system.read_with_retry = self.mock_read_with_retry_raise_exception
         exec_config = ExecutionConfig(runtime.env_layer, runtime.composite_logger, str(runtime.argv))
-        self.__assert_uefi_configs(execution_config=exec_config, expected_file_exists=True, expected_enable_uefi_cert_update=False)
+        self.__assert_uefi_configs(execution_config=exec_config, expected_file_exists=True,
+                                  expected_enable_auto_patching=None, expected_enable_non_auto_patching=None)
         runtime.env_layer.file_system.read_with_retry = self.backup_read_with_retry
         self.__teardown(runtime)
 
-    def test_uefi_config_file_with_enable_uefi_cert_update(self):
-        # Tests UEFI cert update enable set with different values based in uefi config
 
-        # Use Case 1: No UEFI config found on VM
-        uefi_settings_update_cert_when_no_uefi_config = None
-        expected_file_status_when_no_uefi_config = True
-        expected_enable_uefi_when_no_uefi_config = False
-
-        # Use Case 2: UEFI settings are illformed
-        uefi_settings_update_cert_when_enable_not_in_config = {
-            "EnabledBy": "TestSetup",
-            "LastModified": "2026-04-21"
-        }
-        expected_file_status_when_enable_not_in_config = True
-        expected_enable_uefi_when_enable_not_in_config = False
-
-        # Use Case 3: UEFI settings are illformed
-        uefi_settings_update_cert_illformed_config = ["test unexpected config value"]
-        expected_file_status_when_illformed_config = True
-        expected_enable_uefi_when_illformed_config = False
-
-        # Use Case 4: Value set to boolean False
-        uefi_settings_update_cert_false = {
-            "EnabledBy": "TestSetup",
-            "LastModified": "2026-04-21",
-            "EnableUEFICertUpdate": False
-        }
-        expected_file_status_when_update_cert_false = True
-        expected_enable_uefi_when_update_cert_false = False
-
-        # Use Case 5: Value set to random string
-        uefi_settings_when_update_cert_is_str = {
-            "EnabledBy": "TestSetup",
-            "LastModified": "2026-04-21",
-            "EnableUEFICertUpdate": "3"
-        }
-        expected_file_status_when_update_cert_is_str = True
-        expected_enable_uefi_when_update_cert_is_str = False
-
-        # Use Case 6: Value set to random string test 2
-        uefi_settings_when_update_cert_is_str_test2 = {
-            "EnabledBy": "TestSetup",
-            "LastModified": "2026-04-21",
-            "EnableUEFICertUpdate": "test"
-        }
-        expected_file_status_when_update_cert_is_str_test2 = True
-        expected_enable_uefi_when_update_cert_is_str_test2 = False
-
-        # Use Case 7: Value set to float
-        uefi_settings_when_update_cert_is_float = {
-            "EnabledBy": "TestSetup",
-            "LastModified": "2026-04-21",
-            "EnableUEFICertUpdate": 3.1
-        }
-        expected_file_status_when_update_cert_is_float = True
-        expected_enable_uefi_when_update_cert_is_float = False
-
-        # Tests EnableUEFICertUpdate with all acceptable values of true
-        # Use Case 8: Value set to boolean True
-        uefi_settings_when_update_cert_true = {
-            "EnabledBy": "TestSetup",
-            "LastModified": "2026-04-21",
-            "EnableUEFICertUpdate": True
-        }
-        expected_file_status_when_update_cert_true = True
-        expected_enable_uefi_when_update_cert_true = True
-
-        # Use Case 9: Value set to boolean True
-        uefi_settings_when_update_cert_true_str = {
-            "EnabledBy": "TestSetup",
-            "LastModified": "2026-04-21",
-            "EnableUEFICertUpdate": "True"
-        }
-        expected_file_status_when_update_cert_true_str = True
-        expected_enable_uefi_when_update_cert_true_str = True
-
-        # Use Case 10: Value set to boolean True
-        uefi_settings_when_update_cert_true_str_lower_case = {
-            "EnabledBy": "TestSetup",
-            "LastModified": "2026-04-21",
-            "EnableUEFICertUpdate": "true"
-        }
-        expected_file_status_when_update_cert_true_str_lower_case = True
-        expected_enable_uefi_when_update_cert_true_str_lower_case = True
-
-        # Use Case 11: Value set to boolean True
-        uefi_settings_when_update_cert_true_numericstr = {
-            "EnabledBy": "TestSetup",
-            "LastModified": "2026-04-21",
-            "EnableUEFICertUpdate": "1"
-        }
-        expected_file_status_when_update_cert_true_numericstr = True
-        expected_enable_uefi_when_update_cert_true_numericstr = True
-
-        # Use Case 12: Value set to boolean True
-        uefi_settings_when_update_cert_true_numeric = {
-            "EnabledBy": "TestSetup",
-            "LastModified": "2026-04-21",
-            "EnableUEFICertUpdate": 1
-        }
-        expected_file_status_when_update_cert_true_numeric = True
-        expected_enable_uefi_when_update_cert_true_numeric = True
-
-        test_input_output_table = [
-            [uefi_settings_update_cert_when_no_uefi_config, expected_file_status_when_no_uefi_config, expected_enable_uefi_when_no_uefi_config],
-            [uefi_settings_update_cert_when_enable_not_in_config, expected_file_status_when_enable_not_in_config, expected_enable_uefi_when_enable_not_in_config],
-            [uefi_settings_update_cert_illformed_config, expected_file_status_when_illformed_config, expected_enable_uefi_when_illformed_config],
-            [uefi_settings_update_cert_false, expected_file_status_when_update_cert_false, expected_enable_uefi_when_update_cert_false],
-            [uefi_settings_when_update_cert_is_str, expected_file_status_when_update_cert_is_str, expected_enable_uefi_when_update_cert_is_str],
-            [uefi_settings_when_update_cert_is_str_test2, expected_file_status_when_update_cert_is_str_test2, expected_enable_uefi_when_update_cert_is_str_test2],
-            [uefi_settings_when_update_cert_is_float, expected_file_status_when_update_cert_is_float, expected_enable_uefi_when_update_cert_is_float],
-            [uefi_settings_when_update_cert_true, expected_file_status_when_update_cert_true, expected_enable_uefi_when_update_cert_true],
-            [uefi_settings_when_update_cert_true_str, expected_file_status_when_update_cert_true_str, expected_enable_uefi_when_update_cert_true_str],
-            [uefi_settings_when_update_cert_true_str_lower_case, expected_file_status_when_update_cert_true_str_lower_case, expected_enable_uefi_when_update_cert_true_str_lower_case],
-            [uefi_settings_when_update_cert_true_numericstr, expected_file_status_when_update_cert_true_numericstr, expected_enable_uefi_when_update_cert_true_numericstr],
-            [uefi_settings_when_update_cert_true_numeric, expected_file_status_when_update_cert_true_numeric, expected_enable_uefi_when_update_cert_true_numeric]
-        ]
-
-        for row in test_input_output_table:
-            runtime, execution_config = self.__setup_and_init_execution_config(write_to_file=True, config="UEFI", config_settings=row[0])
-            self.__assert_uefi_configs(execution_config=execution_config, expected_file_exists=row[1], expected_enable_uefi_cert_update=row[2])
-            self.__teardown(runtime)
-
-    def __assert_uefi_configs(self, execution_config, expected_file_exists, expected_enable_uefi_cert_update):
+    def __assert_uefi_configs(self, execution_config, expected_file_exists, expected_enable_auto_patching, expected_enable_non_auto_patching):
         self.assertEqual(os.path.exists(Constants.AzGPSPaths.UEFI_SETTINGS), expected_file_exists)
-        self.assertEqual(execution_config.enable_uefi_cert_update, expected_enable_uefi_cert_update)
+        self.assertEqual(execution_config.enable_uefi_cert_update_for_auto_patching, expected_enable_auto_patching)
+        self.assertEqual(execution_config.enable_uefi_cert_update_for_non_auto_patching, expected_enable_non_auto_patching)
 
     def __setup_and_init_execution_config(self, write_to_file=False, config=None, config_settings=None):
         argument_composer = ArgumentComposer()
@@ -223,6 +104,108 @@ class TestExecutionConfig(unittest.TestCase):
         if os.path.exists(Constants.AzGPSPaths.UEFI_SETTINGS):
             os.remove(Constants.AzGPSPaths.UEFI_SETTINGS)
         runtime.stop()
+
+    def test_is_cert_update_for_auto_patching_explicitly_enabled(self):
+        """Tests is_cert_update_for_auto_patching_explicitly_enabled() returns True only for explicitly set truthy values.
+        None (not set) should return False - absence of config is not the same as being explicitly enabled.
+        Only boolean True, string 'True'/'true'/'1', and integer 1 should return True (per __is_truthy logic)."""
+        runtime, execution_config = self.__setup_and_init_execution_config()
+
+        # [value for enable_uefi_cert_update_for_auto_patching, expected_result from is_cert_update_for_auto_patching_explicitly_enabled]
+        test_cases = [
+            # Not set - not explicitly enabled
+            [None,    False],
+            # Truthy values - explicitly enabled
+            [True,    True],
+            ["True",  True],
+            ["true",  True],
+            ["1",     True],
+            [1,       True],
+            # Falsy/invalid values - not explicitly enabled
+            [False,   False],
+            ["False", False],
+            ["false", False],
+            ["0",     False],
+            [0,       False],
+            ["3",     False],
+            ["test",  False],
+            [3.1,     False],
+        ]
+
+        for value, expected in test_cases:
+            execution_config.enable_uefi_cert_update_for_auto_patching = value
+            self.assertEqual(execution_config.is_cert_update_for_auto_patching_explicitly_enabled(), expected,
+                             msg="Failed for enable_uefi_cert_update_for_auto_patching={0}".format(repr(value)))
+
+        self.__teardown(runtime)
+
+    def test_is_cert_update_for_auto_patching_explicitly_disabled(self):
+        """Tests is_cert_update_for_auto_patching_explicitly_disabled() returns True only for explicitly set falsy values.
+        None (not set) should return False - absence of config means not explicitly disabled.
+        Truthy values (True, 'True', '1', 1) should also return False - they are explicitly enabled, not disabled.
+        Only explicitly set non-truthy values (False, 'test', 3.1, etc.) should return True."""
+        runtime, execution_config = self.__setup_and_init_execution_config()
+
+        # [value for enable_uefi_cert_update_for_auto_patching, expected_result for is_cert_update_for_auto_patching_explicitly_disabled]
+        test_cases = [
+            # Not set - not explicitly disabled
+            [None,    False],
+            # Truthy values - not disabled (they are enabled)
+            [True,    False],
+            ["True",  False],
+            ["true",  False],
+            ["1",     False],
+            [1,       False],
+            # Explicitly set to falsy - explicitly disabled
+            [False,   True],
+            ["False", True],
+            ["false", True],
+            ["0",     True],
+            [0,       True],
+            ["3",     True],
+            ["test",  True],
+            [3.1,     True],
+        ]
+
+        for value, expected in test_cases:
+            execution_config.enable_uefi_cert_update_for_auto_patching = value
+            self.assertEqual(execution_config.is_cert_update_for_auto_patching_explicitly_disabled(), expected,
+                             msg="Failed for enable_uefi_cert_update_for_auto_patching={0}".format(repr(value)))
+
+        self.__teardown(runtime)
+
+    def test_is_cert_update_for_non_auto_patching_explicitly_enabled(self):
+        """Tests is_cert_update_for_non_auto_patching_explicitly_enabled() returns True only for explicitly set truthy values.
+        Follows the same truthy evaluation rules as the auto patching equivalent."""
+        runtime, execution_config = self.__setup_and_init_execution_config()
+
+        # [value for enable_uefi_cert_update_for_non_auto_patching, expected_result for is_cert_update_for_non_auto_patching_explicitly_enabled]
+        test_cases = [
+            # Not set - not explicitly enabled
+            [None,    False],
+            # Truthy values - explicitly enabled
+            [True,    True],
+            ["True",  True],
+            ["true",  True],
+            ["1",     True],
+            [1,       True],
+            # Falsy/invalid values - not explicitly enabled
+            [False,   False],
+            ["False", False],
+            ["false", False],
+            ["0",     False],
+            [0,       False],
+            ["3",     False],
+            ["test",  False],
+            [3.1,     False],
+        ]
+
+        for value, expected in test_cases:
+            execution_config.enable_uefi_cert_update_for_non_auto_patching = value
+            self.assertEqual(execution_config.is_cert_update_for_non_auto_patching_explicitly_enabled(), expected,
+                             msg="Failed for enable_uefi_cert_update_for_non_auto_patching={0}".format(repr(value)))
+
+        self.__teardown(runtime)
 
 
 if __name__ == '__main__':

--- a/src/core/tests/Test_PatchInstaller.py
+++ b/src/core/tests/Test_PatchInstaller.py
@@ -77,6 +77,12 @@ class TestPatchInstaller(unittest.TestCase):
 
     def mock_try_update_certs_returns_true(self):
         return True
+
+    def mock_is_cert_update_supported_returns_true(self):
+        return True
+
+    def mock_is_cert_update_supported_returns_false(self):
+        return False
     # endregion
 
     # region Utility functions (update cert tests)
@@ -828,6 +834,18 @@ class TestPatchInstaller(unittest.TestCase):
                 "expected_present": [],
                 "expected_absent": ["Certificates may not have been updated"]
             },
+            # Use case 2b: package manager support gate should block certificate updates before any prerequisites run
+            {
+                "name": "package_manager_disallows_cert_update",
+                "enable_uefi_cert_update": True,
+                "health_store_id": "pub_off_sku_2025.01.01",
+                "operation": Constants.INSTALLATION,
+                "reboot_setting": "IfRequired",
+                "mock_is_cert_update_supported": self.mock_is_cert_update_supported_returns_false,
+                "mock_detect_confidential_vm": self.mock_detect_confidential_vm_raises_exception,
+                "expected_present": [],
+                "expected_absent": ["attempting to update certificates", "Certificates may not have been updated", "Unable to determine whether the VM is a Confidential VM"]
+            },
             # Use case 3: try_update_certs should NOT be called when health_store_id is an empty string (not a default patching operation)
             {
                 "name": "not_default_patching_health_store_id_empty",
@@ -956,6 +974,7 @@ class TestPatchInstaller(unittest.TestCase):
             backup_detect_confidential_vm_by_imds = runtime.env_layer.detect_confidential_vm_by_imds
             backup_hibernation = runtime.package_manager.is_hibernation_enabled_for_cert_update
             backup_latest_certs = runtime.package_manager.are_latest_certs_present
+            backup_is_cert_update_supported = runtime.package_manager.is_cert_update_supported
             backup_try_update_certs = runtime.package_manager.try_update_certs
 
             if "mock_should_reboot" in use_case:
@@ -968,6 +987,8 @@ class TestPatchInstaller(unittest.TestCase):
                 runtime.package_manager.is_hibernation_enabled_for_cert_update = use_case["mock_hibernation"]
             if "mock_latest_certs" in use_case:
                 runtime.package_manager.are_latest_certs_present = use_case["mock_latest_certs"]
+            if "mock_is_cert_update_supported" in use_case:
+                runtime.package_manager.is_cert_update_supported = use_case["mock_is_cert_update_supported"]
             if "mock_try_update_certs" in use_case:
                 runtime.package_manager.try_update_certs = use_case["mock_try_update_certs"]
 
@@ -991,6 +1012,7 @@ class TestPatchInstaller(unittest.TestCase):
             runtime.env_layer.detect_confidential_vm_by_imds = backup_detect_confidential_vm_by_imds
             runtime.package_manager.is_hibernation_enabled_for_cert_update = backup_hibernation
             runtime.package_manager.are_latest_certs_present = backup_latest_certs
+            runtime.package_manager.is_cert_update_supported = backup_is_cert_update_supported
             runtime.package_manager.try_update_certs = backup_try_update_certs
             runtime.stop()
 

--- a/src/core/tests/Test_PatchInstaller.py
+++ b/src/core/tests/Test_PatchInstaller.py
@@ -74,10 +74,13 @@ class TestPatchInstaller(unittest.TestCase):
 
     def mock_are_latest_certs_present_with_mokutil_check_returns_false(self):
         return False
+
+    def mock_try_update_certs_returns_true(self):
+        return True
     # endregion
 
     # region Utility functions (update cert tests)
-    def _create_update_certs_runtime(self, enable_uefi_cert_update=True, health_store_id=None, operation=Constants.INSTALLATION, reboot_setting=None):
+    def _create_update_certs_runtime(self, enable_uefi_cert_update=True, health_store_id=None, operation=Constants.INSTALLATION, reboot_setting=None, package_manager_name=Constants.APT):
         argument_composer = ArgumentComposer()
         argument_composer.health_store_id = health_store_id
         argument_composer.operation = operation
@@ -90,7 +93,7 @@ class TestPatchInstaller(unittest.TestCase):
             "EnableUEFICertUpdate": True if enable_uefi_cert_update else False,
         }
         self.__write_config_settings_to_file(config_settings, config_file_path=config_file_path)
-        runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, Constants.APT)
+        runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, package_manager_name)
         return runtime
 
     @staticmethod
@@ -1144,6 +1147,284 @@ class TestPatchInstaller(unittest.TestCase):
             runtime.stop()
     # endregion
 
+    # region Unit Tests for Certificate Update Allow/Deny Logic
+    def test_cert_update_allow_deny_with_various_config_combinations(self):
+        """Test cert update allow/deny across APT (default-allow) and non-APT (default-deny) package managers
+        with various EnableUEFICertUpdate configuration combinations.
+        When cert update is expected to proceed: try_update_certs returns False, producing a
+        'Certificates may not have been updated' error to confirm it was reached.
+        When cert update is expected to be blocked: try_update_certs raises an exception; the absence
+        of that error in status confirms it was never called."""
+
+        # Use case 1: APT - both config flags not set (None) - cert update proceeds by default
+        name_uc1 = "APT_default_allow"
+        package_manager_uc1 = Constants.APT
+        health_store_id_uc1 = None
+        reboot_setting_uc1 = 'IfRequired'
+        enable_auto_uc1 = None
+        enable_non_auto_uc1 = None
+        mock_detect_cvm_uc1 = self.mock_detect_confidential_vm_returns_false
+        mock_hibernation_uc1 = self.mock_is_hibernation_enabled_for_cert_update_returns_false
+        mock_latest_certs_uc1 = self.mock_are_latest_certs_present_with_mokutil_check_returns_false
+        mock_should_reboot_uc1 = self.mock_should_reboot_before_cert_update_returns_false
+        mock_try_update_certs_uc1 = self.mock_update_certs_returns_false
+        expected_cert_update_called_uc1 = True
+
+        # Use case 2: APT - auto-patching explicitly disabled - cert update is blocked
+        name_uc2 = "APT_auto_explicitly_disabled"
+        package_manager_uc2 = Constants.APT
+        health_store_id_uc2 = None
+        reboot_setting_uc2 = None
+        enable_auto_uc2 = False
+        enable_non_auto_uc2 = None
+        mock_detect_cvm_uc2 = None
+        mock_hibernation_uc2 = None
+        mock_latest_certs_uc2 = None
+        mock_should_reboot_uc2 = None
+        mock_try_update_certs_uc2 = self.mock_try_update_certs_raise_exception
+        expected_cert_update_called_uc2 = False
+
+        # Use case 3: APT hybrid mode (auto=False, non_auto=True) during default patching - cert update is blocked
+        name_uc3 = "APT_hybrid_mode_default_patching_blocked"
+        package_manager_uc3 = Constants.APT
+        health_store_id_uc3 = "pub_off_sku_2025.01.01"
+        reboot_setting_uc3 = None
+        enable_auto_uc3 = False
+        enable_non_auto_uc3 = True
+        mock_detect_cvm_uc3 = None
+        mock_hibernation_uc3 = None
+        mock_latest_certs_uc3 = None
+        mock_should_reboot_uc3 = None
+        mock_try_update_certs_uc3 = self.mock_try_update_certs_raise_exception
+        expected_cert_update_called_uc3 = False
+
+        # Use case 4: APT hybrid mode (auto=False, non_auto=True) during non-default patching - cert update is allowed
+        name_uc4 = "APT_hybrid_mode_non_default_patching_allowed"
+        package_manager_uc4 = Constants.APT
+        health_store_id_uc4 = None
+        reboot_setting_uc4 = 'IfRequired'
+        enable_auto_uc4 = False
+        enable_non_auto_uc4 = True
+        mock_detect_cvm_uc4 = self.mock_detect_confidential_vm_returns_false
+        mock_hibernation_uc4 = self.mock_is_hibernation_enabled_for_cert_update_returns_false
+        mock_latest_certs_uc4 = self.mock_are_latest_certs_present_with_mokutil_check_returns_false
+        mock_should_reboot_uc4 = self.mock_should_reboot_before_cert_update_returns_false
+        mock_try_update_certs_uc4 = self.mock_update_certs_returns_false
+        expected_cert_update_called_uc4 = True
+
+        # Use case 5: Non-APT - both config flags not set (None) - cert update is blocked by default
+        name_uc5 = "non_APT_default_deny"
+        package_manager_uc5 = Constants.TDNF
+        health_store_id_uc5 = "pub_off_sku_2025.01.01"
+        reboot_setting_uc5 = None
+        enable_auto_uc5 = None
+        enable_non_auto_uc5 = None
+        mock_detect_cvm_uc5 = None
+        mock_hibernation_uc5 = None
+        mock_latest_certs_uc5 = None
+        mock_should_reboot_uc5 = None
+        mock_try_update_certs_uc5 = self.mock_try_update_certs_raise_exception
+        expected_cert_update_called_uc5 = False
+
+        # Use case 6: Non-APT - auto-patching explicitly enabled during default patching - cert update is allowed
+        name_uc6 = "non_APT_auto_enabled_default_patching_allowed"
+        package_manager_uc6 = Constants.TDNF
+        health_store_id_uc6 = "pub_off_sku_2025.01.01"
+        reboot_setting_uc6 = 'IfRequired'
+        enable_auto_uc6 = True
+        enable_non_auto_uc6 = None
+        mock_detect_cvm_uc6 = self.mock_detect_confidential_vm_returns_false
+        mock_hibernation_uc6 = self.mock_is_hibernation_enabled_for_cert_update_returns_false
+        mock_latest_certs_uc6 = self.mock_are_latest_certs_present_with_mokutil_check_returns_false
+        mock_should_reboot_uc6 = self.mock_should_reboot_before_cert_update_returns_false
+        mock_try_update_certs_uc6 = self.mock_update_certs_returns_false
+        expected_cert_update_called_uc6 = True
+
+        # Use case 7: Non-APT - auto-patching explicitly enabled during non-default patching (health_store_id is None) - cert update is blocked
+        name_uc7 = "non_APT_auto_enabled_non_default_patching_blocked"
+        package_manager_uc7 = Constants.TDNF
+        health_store_id_uc7 = None
+        reboot_setting_uc7 = None
+        enable_auto_uc7 = True
+        enable_non_auto_uc7 = None
+        mock_detect_cvm_uc7 = None
+        mock_hibernation_uc7 = None
+        mock_latest_certs_uc7 = None
+        mock_should_reboot_uc7 = None
+        mock_try_update_certs_uc7 = self.mock_try_update_certs_raise_exception
+        expected_cert_update_called_uc7 = False
+
+        test_input_output_table = [
+            [name_uc1, package_manager_uc1, health_store_id_uc1, reboot_setting_uc1, enable_auto_uc1, enable_non_auto_uc1, mock_detect_cvm_uc1, mock_hibernation_uc1, mock_latest_certs_uc1, mock_should_reboot_uc1, mock_try_update_certs_uc1, expected_cert_update_called_uc1],
+            [name_uc2, package_manager_uc2, health_store_id_uc2, reboot_setting_uc2, enable_auto_uc2, enable_non_auto_uc2, mock_detect_cvm_uc2, mock_hibernation_uc2, mock_latest_certs_uc2, mock_should_reboot_uc2, mock_try_update_certs_uc2, expected_cert_update_called_uc2],
+            [name_uc3, package_manager_uc3, health_store_id_uc3, reboot_setting_uc3, enable_auto_uc3, enable_non_auto_uc3, mock_detect_cvm_uc3, mock_hibernation_uc3, mock_latest_certs_uc3, mock_should_reboot_uc3, mock_try_update_certs_uc3, expected_cert_update_called_uc3],
+            [name_uc4, package_manager_uc4, health_store_id_uc4, reboot_setting_uc4, enable_auto_uc4, enable_non_auto_uc4, mock_detect_cvm_uc4, mock_hibernation_uc4, mock_latest_certs_uc4, mock_should_reboot_uc4, mock_try_update_certs_uc4, expected_cert_update_called_uc4],
+            [name_uc5, package_manager_uc5, health_store_id_uc5, reboot_setting_uc5, enable_auto_uc5, enable_non_auto_uc5, mock_detect_cvm_uc5, mock_hibernation_uc5, mock_latest_certs_uc5, mock_should_reboot_uc5, mock_try_update_certs_uc5, expected_cert_update_called_uc5],
+            [name_uc6, package_manager_uc6, health_store_id_uc6, reboot_setting_uc6, enable_auto_uc6, enable_non_auto_uc6, mock_detect_cvm_uc6, mock_hibernation_uc6, mock_latest_certs_uc6, mock_should_reboot_uc6, mock_try_update_certs_uc6, expected_cert_update_called_uc6],
+            [name_uc7, package_manager_uc7, health_store_id_uc7, reboot_setting_uc7, enable_auto_uc7, enable_non_auto_uc7, mock_detect_cvm_uc7, mock_hibernation_uc7, mock_latest_certs_uc7, mock_should_reboot_uc7, mock_try_update_certs_uc7, expected_cert_update_called_uc7],
+        ]
+
+        for row in test_input_output_table:
+            name, package_manager, health_store_id, reboot_setting, enable_auto, enable_non_auto, mock_detect_cvm, mock_hibernation, mock_latest_certs, mock_should_reboot, mock_try_update_certs, expected_cert_update_called = row
+
+            runtime = self._create_update_certs_runtime(health_store_id=health_store_id, reboot_setting=reboot_setting, package_manager_name=package_manager)
+            runtime.status_handler.set_current_operation(Constants.INSTALLATION)
+            runtime.status_handler.set_installation_substatus_json()
+            runtime.execution_config.enable_uefi_cert_update_for_auto_patching = enable_auto
+            runtime.execution_config.enable_uefi_cert_update_for_non_auto_patching = enable_non_auto
+
+            backup_detect_cvm = runtime.env_layer.detect_confidential_vm
+            backup_hibernation = runtime.package_manager.is_hibernation_enabled_for_cert_update
+            backup_latest_certs = runtime.package_manager.are_latest_certs_present_with_mokutil_check
+            backup_should_reboot = runtime.package_manager.is_reboot_required_before_cert_update
+            backup_try_update_certs = runtime.package_manager.try_update_certs
+
+            if mock_detect_cvm is not None:
+                runtime.env_layer.detect_confidential_vm = mock_detect_cvm
+            if mock_hibernation is not None:
+                runtime.package_manager.is_hibernation_enabled_for_cert_update = mock_hibernation
+            if mock_latest_certs is not None:
+                runtime.package_manager.are_latest_certs_present_with_mokutil_check = mock_latest_certs
+            if mock_should_reboot is not None:
+                runtime.package_manager.is_reboot_required_before_cert_update = mock_should_reboot
+            runtime.package_manager.try_update_certs = mock_try_update_certs
+
+            runtime.patch_installer.try_update_certificates()
+
+            error_messages = self._get_installation_error_messages(runtime)
+            if expected_cert_update_called:
+                self.assertTrue(any("Certificates may not have been updated" in msg for msg in error_messages),
+                                "cert update should have proceeded for use case: {0}".format(name))
+            else:
+                self.assertFalse(any("attempting to update certificates" in msg for msg in error_messages),
+                                 "cert update must not have been called for use case: {0}".format(name))
+
+            runtime.env_layer.detect_confidential_vm = backup_detect_cvm
+            runtime.package_manager.is_hibernation_enabled_for_cert_update = backup_hibernation
+            runtime.package_manager.are_latest_certs_present_with_mokutil_check = backup_latest_certs
+            runtime.package_manager.is_reboot_required_before_cert_update = backup_should_reboot
+            runtime.package_manager.try_update_certs = backup_try_update_certs
+            runtime.stop()
+    # endregion
+
+    def test_try_update_certificates__with_various_outcomes(self):
+        """Test try_update_certificates outcomes: blocked early (allow check / prerequisites), update succeeds, update fails, update raises exception."""
+
+        # Use case 1: cert update allowed, all prerequisites met, update succeeds - no cert error should be recorded
+        name_uc1 = "allowed_prereqs_met_success"
+        health_store_id_uc1 = "test_id"
+        reboot_setting_uc1 = 'IfRequired'
+        enable_auto_uc1 = None
+        mock_detect_cvm_uc1 = self.mock_detect_confidential_vm_returns_false
+        mock_hibernation_uc1 = self.mock_is_hibernation_enabled_for_cert_update_returns_false
+        mock_latest_certs_uc1 = self.mock_are_latest_certs_present_with_mokutil_check_returns_false
+        mock_should_reboot_uc1 = self.mock_should_reboot_before_cert_update_returns_false
+        mock_try_update_certs_uc1 = self.mock_try_update_certs_returns_true
+        expected_present_uc1 = []
+        expected_absent_uc1 = ["Certificates may not have been updated", "attempting to update certificates"]
+
+        # Use case 2: cert update not allowed (auto-patching explicitly disabled) - try_update_certs must not be reached
+        name_uc2 = "not_allowed_auto_disabled"
+        health_store_id_uc2 = "test_id"
+        reboot_setting_uc2 = None
+        enable_auto_uc2 = False
+        mock_detect_cvm_uc2 = None
+        mock_hibernation_uc2 = None
+        mock_latest_certs_uc2 = None
+        mock_should_reboot_uc2 = None
+        mock_try_update_certs_uc2 = self.mock_try_update_certs_raise_exception
+        expected_present_uc2 = []
+        expected_absent_uc2 = ["attempting to update certificates"]
+
+        # Use case 3: cert update allowed but prerequisites not met (VM is a CVM) - try_update_certs must not be reached
+        name_uc3 = "prereqs_not_met_cvm_detected"
+        health_store_id_uc3 = "test_id"
+        reboot_setting_uc3 = 'IfRequired'
+        enable_auto_uc3 = None
+        mock_detect_cvm_uc3 = self.mock_detect_confidential_vm_by_imds_returns_true
+        mock_hibernation_uc3 = None
+        mock_latest_certs_uc3 = None
+        mock_should_reboot_uc3 = None
+        mock_try_update_certs_uc3 = self.mock_try_update_certs_raise_exception
+        expected_present_uc3 = []
+        expected_absent_uc3 = ["attempting to update certificates"]
+
+        # Use case 4: cert update allowed, all prerequisites met, update returns False - cert error should be recorded
+        name_uc4 = "allowed_prereqs_met_update_fails"
+        health_store_id_uc4 = "test_id"
+        reboot_setting_uc4 = 'IfRequired'
+        enable_auto_uc4 = None
+        mock_detect_cvm_uc4 = self.mock_detect_confidential_vm_returns_false
+        mock_hibernation_uc4 = self.mock_is_hibernation_enabled_for_cert_update_returns_false
+        mock_latest_certs_uc4 = self.mock_are_latest_certs_present_with_mokutil_check_returns_false
+        mock_should_reboot_uc4 = self.mock_should_reboot_before_cert_update_returns_false
+        mock_try_update_certs_uc4 = self.mock_update_certs_returns_false
+        expected_present_uc4 = ["Certificates may not have been updated"]
+        expected_absent_uc4 = []
+
+        # Use case 5: cert update allowed, all prerequisites met, update raises exception - exception error should be recorded
+        name_uc5 = "allowed_prereqs_met_update_raises_exception"
+        health_store_id_uc5 = "test_id"
+        reboot_setting_uc5 = 'IfRequired'
+        enable_auto_uc5 = None
+        mock_detect_cvm_uc5 = self.mock_detect_confidential_vm_returns_false
+        mock_hibernation_uc5 = self.mock_is_hibernation_enabled_for_cert_update_returns_false
+        mock_latest_certs_uc5 = self.mock_are_latest_certs_present_with_mokutil_check_returns_false
+        mock_should_reboot_uc5 = self.mock_should_reboot_before_cert_update_returns_false
+        mock_try_update_certs_uc5 = self.mock_try_update_certs_raise_exception
+        expected_present_uc5 = ["attempting to update certificates"]
+        expected_absent_uc5 = []
+
+        test_input_output_table = [
+            [name_uc1, health_store_id_uc1, reboot_setting_uc1, enable_auto_uc1, mock_detect_cvm_uc1, mock_hibernation_uc1, mock_latest_certs_uc1, mock_should_reboot_uc1, mock_try_update_certs_uc1, expected_present_uc1, expected_absent_uc1],
+            [name_uc2, health_store_id_uc2, reboot_setting_uc2, enable_auto_uc2, mock_detect_cvm_uc2, mock_hibernation_uc2, mock_latest_certs_uc2, mock_should_reboot_uc2, mock_try_update_certs_uc2, expected_present_uc2, expected_absent_uc2],
+            [name_uc3, health_store_id_uc3, reboot_setting_uc3, enable_auto_uc3, mock_detect_cvm_uc3, mock_hibernation_uc3, mock_latest_certs_uc3, mock_should_reboot_uc3, mock_try_update_certs_uc3, expected_present_uc3, expected_absent_uc3],
+            [name_uc4, health_store_id_uc4, reboot_setting_uc4, enable_auto_uc4, mock_detect_cvm_uc4, mock_hibernation_uc4, mock_latest_certs_uc4, mock_should_reboot_uc4, mock_try_update_certs_uc4, expected_present_uc4, expected_absent_uc4],
+            [name_uc5, health_store_id_uc5, reboot_setting_uc5, enable_auto_uc5, mock_detect_cvm_uc5, mock_hibernation_uc5, mock_latest_certs_uc5, mock_should_reboot_uc5, mock_try_update_certs_uc5, expected_present_uc5, expected_absent_uc5],
+        ]
+
+        for row in test_input_output_table:
+            name, health_store_id, reboot_setting, enable_auto, mock_detect_cvm, mock_hibernation, mock_latest_certs, mock_should_reboot, mock_try_update_certs, expected_present, expected_absent = row
+
+            runtime = self._create_update_certs_runtime(health_store_id=health_store_id, reboot_setting=reboot_setting)
+            runtime.status_handler.set_current_operation(Constants.INSTALLATION)
+            runtime.status_handler.set_installation_substatus_json()
+            runtime.execution_config.enable_uefi_cert_update_for_auto_patching = enable_auto
+
+            backup_detect_cvm = runtime.env_layer.detect_confidential_vm
+            backup_hibernation = runtime.package_manager.is_hibernation_enabled_for_cert_update
+            backup_latest_certs = runtime.package_manager.are_latest_certs_present_with_mokutil_check
+            backup_should_reboot = runtime.package_manager.is_reboot_required_before_cert_update
+            backup_try_update_certs = runtime.package_manager.try_update_certs
+
+            if mock_detect_cvm is not None:
+                runtime.env_layer.detect_confidential_vm = mock_detect_cvm
+            if mock_hibernation is not None:
+                runtime.package_manager.is_hibernation_enabled_for_cert_update = mock_hibernation
+            if mock_latest_certs is not None:
+                runtime.package_manager.are_latest_certs_present_with_mokutil_check = mock_latest_certs
+            if mock_should_reboot is not None:
+                runtime.package_manager.is_reboot_required_before_cert_update = mock_should_reboot
+            runtime.package_manager.try_update_certs = mock_try_update_certs
+
+            runtime.patch_installer.try_update_certificates()
+
+            error_messages = self._get_installation_error_messages(runtime)
+            for expected_message in expected_present:
+                self.assertTrue(any(expected_message in msg for msg in error_messages),
+                                "Expected '{0}' for use case: {1}".format(expected_message, name))
+            for absent_message in expected_absent:
+                self.assertFalse(any(absent_message in msg for msg in error_messages),
+                                 "Did not expect '{0}' for use case: {1}".format(absent_message, name))
+
+            runtime.env_layer.detect_confidential_vm = backup_detect_cvm
+            runtime.package_manager.is_hibernation_enabled_for_cert_update = backup_hibernation
+            runtime.package_manager.are_latest_certs_present_with_mokutil_check = backup_latest_certs
+            runtime.package_manager.is_reboot_required_before_cert_update = backup_should_reboot
+            runtime.package_manager.try_update_certs = backup_try_update_certs
+            runtime.stop()
+
 
 if __name__ == '__main__':
     unittest.main()
+

--- a/src/core/tests/Test_PatchInstaller.py
+++ b/src/core/tests/Test_PatchInstaller.py
@@ -974,7 +974,7 @@ class TestPatchInstaller(unittest.TestCase):
             backup_detect_confidential_vm_by_imds = runtime.env_layer.detect_confidential_vm_by_imds
             backup_hibernation = runtime.package_manager.is_hibernation_enabled_for_cert_update
             backup_latest_certs = runtime.package_manager.are_latest_certs_present
-            backup_is_cert_update_supported = runtime.package_manager.is_cert_update_supported
+            backup_is_cert_update_supported = runtime.package_manager.is_cert_update_expected
             backup_try_update_certs = runtime.package_manager.try_update_certs
 
             if "mock_should_reboot" in use_case:
@@ -988,7 +988,7 @@ class TestPatchInstaller(unittest.TestCase):
             if "mock_latest_certs" in use_case:
                 runtime.package_manager.are_latest_certs_present = use_case["mock_latest_certs"]
             if "mock_is_cert_update_supported" in use_case:
-                runtime.package_manager.is_cert_update_supported = use_case["mock_is_cert_update_supported"]
+                runtime.package_manager.is_cert_update_expected = use_case["mock_is_cert_update_supported"]
             if "mock_try_update_certs" in use_case:
                 runtime.package_manager.try_update_certs = use_case["mock_try_update_certs"]
 
@@ -1012,7 +1012,7 @@ class TestPatchInstaller(unittest.TestCase):
             runtime.env_layer.detect_confidential_vm_by_imds = backup_detect_confidential_vm_by_imds
             runtime.package_manager.is_hibernation_enabled_for_cert_update = backup_hibernation
             runtime.package_manager.are_latest_certs_present = backup_latest_certs
-            runtime.package_manager.is_cert_update_supported = backup_is_cert_update_supported
+            runtime.package_manager.is_cert_update_expected = backup_is_cert_update_supported
             runtime.package_manager.try_update_certs = backup_try_update_certs
             runtime.stop()
 

--- a/src/core/tests/Test_PatchInstaller.py
+++ b/src/core/tests/Test_PatchInstaller.py
@@ -80,17 +80,25 @@ class TestPatchInstaller(unittest.TestCase):
     # endregion
 
     # region Utility functions (update cert tests)
-    def _create_update_certs_runtime(self, enable_uefi_cert_update=True, health_store_id=None, operation=Constants.INSTALLATION, reboot_setting=None, package_manager_name=Constants.APT):
+    def _create_update_certs_runtime(self, enable_uefi_cert_update=True, health_store_id=None, operation=Constants.INSTALLATION, reboot_setting=None, package_manager_name=Constants.APT,
+                                     enable_uefi_cert_update_for_auto_patching=None, enable_uefi_cert_update_for_all_patching=None, use_per_mode_uefi_cert_update_settings=False):
+
         argument_composer = ArgumentComposer()
         argument_composer.health_store_id = health_store_id
         argument_composer.operation = operation
         if reboot_setting is not None:
             argument_composer.reboot_setting = reboot_setting
+
+        if not use_per_mode_uefi_cert_update_settings:
+            enable_uefi_cert_update_for_auto_patching = bool(enable_uefi_cert_update)
+            enable_uefi_cert_update_for_all_patching = bool(enable_uefi_cert_update)
+
         config_file_path = Constants.AzGPSPaths.UEFI_SETTINGS
         config_settings = {
-            "EnabledBy": "TestSetup",
-            "LastModified": "2026-04-21",
-            "EnableUEFICertUpdate": True if enable_uefi_cert_update else False,
+            Constants.UEFISettings.ENABLED_BY: "TestSetup",
+            Constants.UEFISettings.LAST_MODIFIED: "2026-04-21",
+            Constants.UEFISettings.ENABLE_UEFI_CERT_UPDATE_FOR_AUTO_PATCHING: enable_uefi_cert_update_for_auto_patching,
+            Constants.UEFISettings.ENABLE_UEFI_CERT_UPDATE_FOR_ALL_PATCHING: enable_uefi_cert_update_for_all_patching,
         }
         self.__write_config_settings_to_file(config_settings, config_file_path=config_file_path)
         runtime = RuntimeCompositor(argument_composer.get_composed_arguments(), True, package_manager_name)
@@ -1150,19 +1158,27 @@ class TestPatchInstaller(unittest.TestCase):
     # region Unit Tests for Certificate Update Allow/Deny Logic
     def test_cert_update_allow_deny_with_various_config_combinations(self):
         """Test cert update allow/deny across APT (default-allow) and non-APT (default-deny) package managers
-        with various EnableUEFICertUpdate configuration combinations.
+        with various EnableUEFICertUpdateForAutoPatching / EnableUEFICertUpdateForAllPatching configuration combinations.
         When cert update is expected to proceed: try_update_certs returns False, producing a
         'Certificates may not have been updated' error to confirm it was reached.
         When cert update is expected to be blocked: try_update_certs raises an exception; the absence
-        of that error in status confirms it was never called."""
+        of that error in status confirms it was never called.
 
-        # Use case 1: APT - both config flags not set (None) - cert update proceeds by default
-        name_uc1 = "APT_default_allow"
+        APT cert update logic (new):
+        - If EnableUEFICertUpdateForAllPatching=True (all patching enabled): allowed for any installation operation (auto or non-auto).
+        - If EnableUEFICertUpdateForAutoPatching=False (auto explicitly disabled): blocked for auto (default) patching; non-default also falls through to blocked.
+        - Default (no explicit config): allowed only for auto (default) patching (health_store_id is set).
+
+        Non-APT cert update logic:
+        - Allowed only when EnableUEFICertUpdateForAutoPatching=True and this is a default (auto) patching operation."""
+
+        # Use case 1: APT - both config flags not set (None) during default (auto) patching - cert update proceeds by default
+        name_uc1 = "APT_default_allow_auto_patching"
         package_manager_uc1 = Constants.APT
-        health_store_id_uc1 = None
+        health_store_id_uc1 = "pub_off_sku_2025.01.01"
         reboot_setting_uc1 = 'IfRequired'
         enable_auto_uc1 = None
-        enable_non_auto_uc1 = None
+        enable_all_uc1 = None
         mock_detect_cvm_uc1 = self.mock_detect_confidential_vm_returns_false
         mock_hibernation_uc1 = self.mock_is_hibernation_enabled_for_cert_update_returns_false
         mock_latest_certs_uc1 = self.mock_are_latest_certs_present_with_mokutil_check_returns_false
@@ -1170,13 +1186,13 @@ class TestPatchInstaller(unittest.TestCase):
         mock_try_update_certs_uc1 = self.mock_update_certs_returns_false
         expected_cert_update_called_uc1 = True
 
-        # Use case 2: APT - auto-patching explicitly disabled - cert update is blocked
+        # Use case 2: APT - auto-patching explicitly disabled during non-default patching - cert update is blocked
         name_uc2 = "APT_auto_explicitly_disabled"
         package_manager_uc2 = Constants.APT
         health_store_id_uc2 = None
         reboot_setting_uc2 = None
         enable_auto_uc2 = False
-        enable_non_auto_uc2 = None
+        enable_all_uc2 = None
         mock_detect_cvm_uc2 = None
         mock_hibernation_uc2 = None
         mock_latest_certs_uc2 = None
@@ -1184,27 +1200,28 @@ class TestPatchInstaller(unittest.TestCase):
         mock_try_update_certs_uc2 = self.mock_try_update_certs_raise_exception
         expected_cert_update_called_uc2 = False
 
-        # Use case 3: APT hybrid mode (auto=False, non_auto=True) during default patching - cert update is blocked
-        name_uc3 = "APT_hybrid_mode_default_patching_blocked"
+        # Use case 3: APT all patching explicitly enabled (all_patching=True) during default patching - cert update is allowed
+        # EnableUEFICertUpdateForAllPatching=True takes precedence and allows cert update for any installation operation
+        name_uc3 = "APT_all_patching_enabled_default_patching_allowed"
         package_manager_uc3 = Constants.APT
         health_store_id_uc3 = "pub_off_sku_2025.01.01"
-        reboot_setting_uc3 = None
+        reboot_setting_uc3 = 'IfRequired'
         enable_auto_uc3 = False
-        enable_non_auto_uc3 = True
-        mock_detect_cvm_uc3 = None
-        mock_hibernation_uc3 = None
-        mock_latest_certs_uc3 = None
-        mock_should_reboot_uc3 = None
-        mock_try_update_certs_uc3 = self.mock_try_update_certs_raise_exception
-        expected_cert_update_called_uc3 = False
+        enable_all_uc3 = True
+        mock_detect_cvm_uc3 = self.mock_detect_confidential_vm_returns_false
+        mock_hibernation_uc3 = self.mock_is_hibernation_enabled_for_cert_update_returns_false
+        mock_latest_certs_uc3 = self.mock_are_latest_certs_present_with_mokutil_check_returns_false
+        mock_should_reboot_uc3 = self.mock_should_reboot_before_cert_update_returns_false
+        mock_try_update_certs_uc3 = self.mock_update_certs_returns_false
+        expected_cert_update_called_uc3 = True
 
-        # Use case 4: APT hybrid mode (auto=False, non_auto=True) during non-default patching - cert update is allowed
-        name_uc4 = "APT_hybrid_mode_non_default_patching_allowed"
+        # Use case 4: APT all patching explicitly enabled (all_patching=True) during non-default patching - cert update is allowed
+        name_uc4 = "APT_all_patching_enabled_non_default_patching_allowed"
         package_manager_uc4 = Constants.APT
         health_store_id_uc4 = None
         reboot_setting_uc4 = 'IfRequired'
         enable_auto_uc4 = False
-        enable_non_auto_uc4 = True
+        enable_all_uc4 = True
         mock_detect_cvm_uc4 = self.mock_detect_confidential_vm_returns_false
         mock_hibernation_uc4 = self.mock_is_hibernation_enabled_for_cert_update_returns_false
         mock_latest_certs_uc4 = self.mock_are_latest_certs_present_with_mokutil_check_returns_false
@@ -1218,7 +1235,7 @@ class TestPatchInstaller(unittest.TestCase):
         health_store_id_uc5 = "pub_off_sku_2025.01.01"
         reboot_setting_uc5 = None
         enable_auto_uc5 = None
-        enable_non_auto_uc5 = None
+        enable_all_uc5 = None
         mock_detect_cvm_uc5 = None
         mock_hibernation_uc5 = None
         mock_latest_certs_uc5 = None
@@ -1232,7 +1249,7 @@ class TestPatchInstaller(unittest.TestCase):
         health_store_id_uc6 = "pub_off_sku_2025.01.01"
         reboot_setting_uc6 = 'IfRequired'
         enable_auto_uc6 = True
-        enable_non_auto_uc6 = None
+        enable_all_uc6 = None
         mock_detect_cvm_uc6 = self.mock_detect_confidential_vm_returns_false
         mock_hibernation_uc6 = self.mock_is_hibernation_enabled_for_cert_update_returns_false
         mock_latest_certs_uc6 = self.mock_are_latest_certs_present_with_mokutil_check_returns_false
@@ -1246,7 +1263,7 @@ class TestPatchInstaller(unittest.TestCase):
         health_store_id_uc7 = None
         reboot_setting_uc7 = None
         enable_auto_uc7 = True
-        enable_non_auto_uc7 = None
+        enable_all_uc7 = None
         mock_detect_cvm_uc7 = None
         mock_hibernation_uc7 = None
         mock_latest_certs_uc7 = None
@@ -1254,24 +1271,43 @@ class TestPatchInstaller(unittest.TestCase):
         mock_try_update_certs_uc7 = self.mock_try_update_certs_raise_exception
         expected_cert_update_called_uc7 = False
 
+        # Use case 8: APT - both config flags not set (None) during non-default patching - cert update is blocked by default
+        name_uc8 = "APT_default_deny_all_patching"
+        package_manager_uc8 = Constants.APT
+        health_store_id_uc8 = None
+        reboot_setting_uc8 = None
+        enable_auto_uc8 = None
+        enable_all_uc8 = None
+        mock_detect_cvm_uc8 = None
+        mock_hibernation_uc8 = None
+        mock_latest_certs_uc8 = None
+        mock_should_reboot_uc8 = None
+        mock_try_update_certs_uc8 = self.mock_try_update_certs_raise_exception
+        expected_cert_update_called_uc8 = False
+
         test_input_output_table = [
-            [name_uc1, package_manager_uc1, health_store_id_uc1, reboot_setting_uc1, enable_auto_uc1, enable_non_auto_uc1, mock_detect_cvm_uc1, mock_hibernation_uc1, mock_latest_certs_uc1, mock_should_reboot_uc1, mock_try_update_certs_uc1, expected_cert_update_called_uc1],
-            [name_uc2, package_manager_uc2, health_store_id_uc2, reboot_setting_uc2, enable_auto_uc2, enable_non_auto_uc2, mock_detect_cvm_uc2, mock_hibernation_uc2, mock_latest_certs_uc2, mock_should_reboot_uc2, mock_try_update_certs_uc2, expected_cert_update_called_uc2],
-            [name_uc3, package_manager_uc3, health_store_id_uc3, reboot_setting_uc3, enable_auto_uc3, enable_non_auto_uc3, mock_detect_cvm_uc3, mock_hibernation_uc3, mock_latest_certs_uc3, mock_should_reboot_uc3, mock_try_update_certs_uc3, expected_cert_update_called_uc3],
-            [name_uc4, package_manager_uc4, health_store_id_uc4, reboot_setting_uc4, enable_auto_uc4, enable_non_auto_uc4, mock_detect_cvm_uc4, mock_hibernation_uc4, mock_latest_certs_uc4, mock_should_reboot_uc4, mock_try_update_certs_uc4, expected_cert_update_called_uc4],
-            [name_uc5, package_manager_uc5, health_store_id_uc5, reboot_setting_uc5, enable_auto_uc5, enable_non_auto_uc5, mock_detect_cvm_uc5, mock_hibernation_uc5, mock_latest_certs_uc5, mock_should_reboot_uc5, mock_try_update_certs_uc5, expected_cert_update_called_uc5],
-            [name_uc6, package_manager_uc6, health_store_id_uc6, reboot_setting_uc6, enable_auto_uc6, enable_non_auto_uc6, mock_detect_cvm_uc6, mock_hibernation_uc6, mock_latest_certs_uc6, mock_should_reboot_uc6, mock_try_update_certs_uc6, expected_cert_update_called_uc6],
-            [name_uc7, package_manager_uc7, health_store_id_uc7, reboot_setting_uc7, enable_auto_uc7, enable_non_auto_uc7, mock_detect_cvm_uc7, mock_hibernation_uc7, mock_latest_certs_uc7, mock_should_reboot_uc7, mock_try_update_certs_uc7, expected_cert_update_called_uc7],
+            [name_uc1, package_manager_uc1, health_store_id_uc1, reboot_setting_uc1, enable_auto_uc1, enable_all_uc1, mock_detect_cvm_uc1, mock_hibernation_uc1, mock_latest_certs_uc1, mock_should_reboot_uc1, mock_try_update_certs_uc1, expected_cert_update_called_uc1],
+            [name_uc2, package_manager_uc2, health_store_id_uc2, reboot_setting_uc2, enable_auto_uc2, enable_all_uc2, mock_detect_cvm_uc2, mock_hibernation_uc2, mock_latest_certs_uc2, mock_should_reboot_uc2, mock_try_update_certs_uc2, expected_cert_update_called_uc2],
+            [name_uc3, package_manager_uc3, health_store_id_uc3, reboot_setting_uc3, enable_auto_uc3, enable_all_uc3, mock_detect_cvm_uc3, mock_hibernation_uc3, mock_latest_certs_uc3, mock_should_reboot_uc3, mock_try_update_certs_uc3, expected_cert_update_called_uc3],
+            [name_uc4, package_manager_uc4, health_store_id_uc4, reboot_setting_uc4, enable_auto_uc4, enable_all_uc4, mock_detect_cvm_uc4, mock_hibernation_uc4, mock_latest_certs_uc4, mock_should_reboot_uc4, mock_try_update_certs_uc4, expected_cert_update_called_uc4],
+            [name_uc5, package_manager_uc5, health_store_id_uc5, reboot_setting_uc5, enable_auto_uc5, enable_all_uc5, mock_detect_cvm_uc5, mock_hibernation_uc5, mock_latest_certs_uc5, mock_should_reboot_uc5, mock_try_update_certs_uc5, expected_cert_update_called_uc5],
+            [name_uc6, package_manager_uc6, health_store_id_uc6, reboot_setting_uc6, enable_auto_uc6, enable_all_uc6, mock_detect_cvm_uc6, mock_hibernation_uc6, mock_latest_certs_uc6, mock_should_reboot_uc6, mock_try_update_certs_uc6, expected_cert_update_called_uc6],
+            [name_uc7, package_manager_uc7, health_store_id_uc7, reboot_setting_uc7, enable_auto_uc7, enable_all_uc7, mock_detect_cvm_uc7, mock_hibernation_uc7, mock_latest_certs_uc7, mock_should_reboot_uc7, mock_try_update_certs_uc7, expected_cert_update_called_uc7],
+            [name_uc8, package_manager_uc8, health_store_id_uc8, reboot_setting_uc8, enable_auto_uc8, enable_all_uc8, mock_detect_cvm_uc8, mock_hibernation_uc8, mock_latest_certs_uc8, mock_should_reboot_uc8, mock_try_update_certs_uc8, expected_cert_update_called_uc8],
         ]
 
         for row in test_input_output_table:
-            name, package_manager, health_store_id, reboot_setting, enable_auto, enable_non_auto, mock_detect_cvm, mock_hibernation, mock_latest_certs, mock_should_reboot, mock_try_update_certs, expected_cert_update_called = row
+            name, package_manager, health_store_id, reboot_setting, enable_auto, enable_all, mock_detect_cvm, mock_hibernation, mock_latest_certs, mock_should_reboot, mock_try_update_certs, expected_cert_update_called = row
 
-            runtime = self._create_update_certs_runtime(health_store_id=health_store_id, reboot_setting=reboot_setting, package_manager_name=package_manager)
+            runtime = self._create_update_certs_runtime(
+                health_store_id=health_store_id,
+                reboot_setting=reboot_setting,
+                package_manager_name=package_manager,
+                enable_uefi_cert_update_for_auto_patching=enable_auto,
+                enable_uefi_cert_update_for_all_patching=enable_all,
+                use_per_mode_uefi_cert_update_settings=True)
             runtime.status_handler.set_current_operation(Constants.INSTALLATION)
             runtime.status_handler.set_installation_substatus_json()
-            runtime.execution_config.enable_uefi_cert_update_for_auto_patching = enable_auto
-            runtime.execution_config.enable_uefi_cert_update_for_non_auto_patching = enable_non_auto
 
             backup_detect_cvm = runtime.env_layer.detect_confidential_vm
             backup_hibernation = runtime.package_manager.is_hibernation_enabled_for_cert_update
@@ -1386,10 +1422,13 @@ class TestPatchInstaller(unittest.TestCase):
         for row in test_input_output_table:
             name, health_store_id, reboot_setting, enable_auto, mock_detect_cvm, mock_hibernation, mock_latest_certs, mock_should_reboot, mock_try_update_certs, expected_present, expected_absent = row
 
-            runtime = self._create_update_certs_runtime(health_store_id=health_store_id, reboot_setting=reboot_setting)
+            runtime = self._create_update_certs_runtime(
+                health_store_id=health_store_id,
+                reboot_setting=reboot_setting,
+                enable_uefi_cert_update_for_auto_patching=enable_auto,
+                use_per_mode_uefi_cert_update_settings=True)
             runtime.status_handler.set_current_operation(Constants.INSTALLATION)
             runtime.status_handler.set_installation_substatus_json()
-            runtime.execution_config.enable_uefi_cert_update_for_auto_patching = enable_auto
 
             backup_detect_cvm = runtime.env_layer.detect_confidential_vm
             backup_hibernation = runtime.package_manager.is_hibernation_enabled_for_cert_update

--- a/src/core/tests/Test_TdnfPackageManager.py
+++ b/src/core/tests/Test_TdnfPackageManager.py
@@ -882,7 +882,7 @@ class TestTdnfPackageManager(unittest.TestCase):
                 package_manager.execution_config.enable_uefi_cert_update_for_all_patching = enable_all
 
                 self.assertEqual(
-                    package_manager.is_cert_update_supported(),
+                    package_manager.is_cert_update_expected(),
                     expected_result,
                     "Failed use case: {0}".format(name)
                 )

--- a/src/core/tests/Test_TdnfPackageManager.py
+++ b/src/core/tests/Test_TdnfPackageManager.py
@@ -855,6 +855,43 @@ class TestTdnfPackageManager(unittest.TestCase):
         self.assertEqual(package_versions[4], '3.12.3-6.azl3')
         self.assertEqual(package_versions[5], '3.12.9-1.azl3')
 
+    def test_is_cert_update_supported__with_various_use_cases(self):
+        """Test inherited PackageManager.is_cert_update_supported behavior for a non-APT package manager."""
+        package_manager = self.container.get('package_manager')
+
+        backup_health_store_id = package_manager.execution_config.health_store_id
+        backup_operation = package_manager.execution_config.operation
+        backup_enable_auto = package_manager.execution_config.enable_uefi_cert_update_for_auto_patching
+        backup_enable_all = package_manager.execution_config.enable_uefi_cert_update_for_all_patching
+
+        test_input_output_table = [
+            ["default_patching_allowed_when_auto_update_is_explicitly_enabled", "pub_off_sku_2025.01.01", Constants.INSTALLATION, True, None, True],
+            ["default_patching_blocked_when_auto_update_is_explicitly_disabled", "pub_off_sku_2025.01.01", Constants.INSTALLATION, False, None, False],
+            ["non_default_patching_blocked_even_when_auto_update_is_explicitly_enabled", None, Constants.ASSESSMENT, True, None, False],
+            ["all_patching_configuration_is_ignored_for_non_apt_package_managers", "pub_off_sku_2025.01.01", Constants.INSTALLATION, None, True, False],
+            ["non_default_patching_blocked_when_auto_update_is_not_set", None, Constants.ASSESSMENT, None, None, False],
+        ]
+
+        try:
+            for row in test_input_output_table:
+                name, health_store_id, operation, enable_auto, enable_all, expected_result = row
+
+                package_manager.execution_config.health_store_id = health_store_id
+                package_manager.execution_config.operation = operation
+                package_manager.execution_config.enable_uefi_cert_update_for_auto_patching = enable_auto
+                package_manager.execution_config.enable_uefi_cert_update_for_all_patching = enable_all
+
+                self.assertEqual(
+                    package_manager.is_cert_update_supported(),
+                    expected_result,
+                    "Failed use case: {0}".format(name)
+                )
+        finally:
+            package_manager.execution_config.health_store_id = backup_health_store_id
+            package_manager.execution_config.operation = backup_operation
+            package_manager.execution_config.enable_uefi_cert_update_for_auto_patching = backup_enable_auto
+            package_manager.execution_config.enable_uefi_cert_update_for_all_patching = backup_enable_all
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/tools/references/patch.uefi.settings
+++ b/src/tools/references/patch.uefi.settings
@@ -1,1 +1,1 @@
-{"EnableUEFICertUpdate": "true", "EnabledBy": "LSG", "LastModified": "2026-05-23"}
+{"EnableUEFICertUpdateForAutoPatching": "true", "EnableUEFICertUpdateForNonAutoPatching": "true", "EnabledBy": "LSG", "LastModified": "2026-05-23"}

--- a/src/tools/references/patch.uefi.settings
+++ b/src/tools/references/patch.uefi.settings
@@ -1,1 +1,1 @@
-{"EnableUEFICertUpdateForAutoPatching": "true", "EnableUEFICertUpdateForNonAutoPatching": "true", "EnabledBy": "LSG", "LastModified": "2026-05-23"}
+{"EnableUEFICertUpdateForAutoPatching": "true", "EnableUEFICertUpdateForAllPatching": "true", "EnabledBy": "LSG", "LastModified": "2026-05-23"}


### PR DESCRIPTION
We have used a feature flag for customers to opt-in to update certificates via default patching or Auto Patching. This change modifies the opt-in logic for Canonical to:
- VM is always opted in (to receive certificate updates) unless explicitly opted out using the same flag as before.
- Customers have the ability receive certificate update on non-auto patching operations for eg: manual installations.
- All non-Canonical distros still have to opt in using the feature flag and will only receive certificate updates during auto patching operation

**How it works**:
There is still an in VM config file that the customer has to add at /var/lib/azure/linuxpatchextension in their VM with structure:
{"EnableUEFICertUpdateForAutoPatching": <bool>, "EnableUEFICertUpdateForNonAutoPatching": <bool>, "EnabledBy": <str>, "LastModified": <str>}
For eg: {"EnableUEFICertUpdateForAutoPatching": "true", "EnableUEFICertUpdateForNonAutoPatching": "true", "EnabledBy": "LSG", "LastModified": "2026-05-23"}

EnableUEFICertUpdateForAutoPatching: Used for enabling certificate updates in auto patching operations
EnableUEFICertUpdateForNonAutoPatching: Used for enabling certificate updates in non-auto patching operations (This is only used by Canonical in current code)

EnableUEFICertUpdateForAutoPatching will always be prioritized over EnableUEFICertUpdateForNonAutoPatching, so instances where both these configs are set to true, certificates will be updated in an auto patching operation

**In-VM Testing**:
1. **Scenario 1**: VM 22.04, no config file in VM, manual patching invoked, **Expected**: certificate not updated. **Result**: **Success**. [2.status.txt](https://github.com/user-attachments/files/30012424/2.status.txt), [2.core.log](https://github.com/user-attachments/files/30012427/2.core.log)

2. **Scenario 2**: VM 22.04, no config file in VM, auto patching invoked, **Expected**: certificate updated. **Result**: **Success**. [3.status.txt](https://github.com/user-attachments/files/30012448/3.status.txt), [3.core.log](https://github.com/user-attachments/files/30012449/3.core.log)

3. **Scenario 3**: VM 22.04, auto patching enabled in config, manual patching invoked, **Expected**: certificate not updated. **Result**: **Success** [2.core.log](https://github.com/user-attachments/files/30014053/2.core.log), [2.status.txt](https://github.com/user-attachments/files/30014054/2.status.txt)

4. **Scenario 4**: VM 22.04, auto patching enabled in config, auto patching invoked, **Expected**: certificate updated. **Result**: **Success** [3.core.log](https://github.com/user-attachments/files/30014097/3.core.log), [3.status.txt](https://github.com/user-attachments/files/30014098/3.status.txt)

5. **Scenario 5**: VM 22.04, all patching enabled in config, manual patching invoked, **Expected**: certificate updated. **Result**: **Success** [2.status.txt](https://github.com/user-attachments/files/30015748/2.status.txt), [2.core.log](https://github.com/user-attachments/files/30015750/2.core.log)

6. **Scenario 6**: VM 22.04, auto patching disabled in config and all patching enabled, manual patching invoked, **Expected**: certificate updated. **Result**: **Success** [2.core.log](https://github.com/user-attachments/files/30017529/2.core.log), [2.status.txt](https://github.com/user-attachments/files/30017530/2.status.txt)

7. **Scenario 7**: VM 22.04, auto patching disabled in config, no all patching config, auto patching invoked, **Expected**: certificate not updated. **Result**: **Success** [3.core.log](https://github.com/user-attachments/files/30018860/3.core.log), [3.status.txt](https://github.com/user-attachments/files/30018861/3.status.txt)

8. **Scenario 8**: VM 22.04, auto patching disabled in config, no all patching config, manual patching invoked, **Expected**: certificate not updated. **Result**: **Success** [2.status.txt](https://github.com/user-attachments/files/30018882/2.status.txt), [2.core.log](https://github.com/user-attachments/files/30018883/2.core.log)

9. **Scenario 9**: VM **RHEL**/SUSE/AzLinux, auto patching enabled in config, manual patching invoked, **Expected**: certificate not updated. **Result**: **Success** [3.status.txt](https://github.com/user-attachments/files/30025115/3.status.txt), [3.core.log](https://github.com/user-attachments/files/30025116/3.core.log)

10. **Scenario 10**: VM **RHEL**/SUSE/AzLinux, auto patching enabled in config, auto patching invoked, **Expected**: certificate not updated. (Will be updated once cert update is supported on this distro) **Result**: **Success** [4.status.txt](https://github.com/user-attachments/files/30025129/4.status.txt), [4.core.log](https://github.com/user-attachments/files/30025130/4.core.log)


**Pending**:
- Using snap for Ubuntu < 22.04. NOTE: This will be implemented in a follow up PR