### PR TITLE
Bugfix: Validate that process is actually a patching operation before terminating

### DIFF
--- a/src/extension/src/ProcessHandler.py
+++ b/src/extension/src/ProcessHandler.py
@@ -199,9 +199,23 @@ class ProcessHandler(object):
                 # According to "man 2 kill" possible error values are (EINVAL, EPERM, ESRCH) Thus considering this as an error
                 return False
 
+    def is_process_patching_operation(self, pid):
+        try:
+            with self.env_layer.file_system.open("/proc/{0}/cmdline".format(str(pid)), mode="r") as cmdline_file:
+                cmdline = cmdline_file.read()
+                if Constants.CORE_CODE_FILE_NAME in cmdline:
+                    self.logger.log_debug("Process is a patching operation. [PID={0}]".format(str(pid)))
+                    return True
+                else:
+                    self.logger.log_debug("Process is not a patching operation. [PID={0}]".format(str(pid)))
+                    return False
+        except Exception as error:
+            self.logger.log_debug("Error checking if process is a patching operation. [PID={0}] [Error={1}]".format(str(pid), repr(error)))
+            return True  # If we cannot determine, assume it is a patching operation to be safe
+
     def kill_process(self, pid):
         try:
-            if self.is_process_running(pid):
+            if self.is_process_running(pid) and self.is_process_patching_operation(pid):
                 self.logger.log("Terminating process: [PID={0}]".format(str(pid)))
                 os.kill(pid, signal.SIGTERM)
         except OSError as error:

--- a/src/extension/src/ProcessHandler.py
+++ b/src/extension/src/ProcessHandler.py
@@ -214,8 +214,8 @@ class ProcessHandler(object):
                     self.logger.log_debug("Process is not a patching operation. [PID={0}] [CmdLine={1}]".format(str(pid), cmdline))
                     return False
         except Exception as error:
-            self.logger.log_debug("Error checking if process is a patching operation. [PID={0}] [Error={1}]".format(str(pid), repr(error)))
-            return True  # If we cannot determine, assume it is a patching operation to be safe
+            self.logger.log_verbose("Error checking if process is a patching operation. Assuming it is a patching operation. [PID={0}] [Error={1}]".format(str(pid), repr(error)))
+            return True  # If we cannot determine, assume it is a patching operation to be safe, because we do not want to start a patching operation when one is currently running
 
     def kill_process(self, pid):
         try:

--- a/src/extension/src/ProcessHandler.py
+++ b/src/extension/src/ProcessHandler.py
@@ -201,13 +201,17 @@ class ProcessHandler(object):
 
     def is_process_patching_operation(self, pid):
         try:
-            with self.env_layer.file_system.open("/proc/{0}/cmdline".format(str(pid)), mode="r") as cmdline_file:
+            # Patching operation cmdline will look like:
+            # /usr/bin/python3.10 /var/lib/waagent/Microsoft.CPlat.Core.LinuxPatchExtension-1.6.69/MsftLinuxPatchCore.py <args>
+            with self.env_layer.file_system.open("/proc/{0}/cmdline".format(str(pid)), mode="rb") as cmdline_file:
                 cmdline = cmdline_file.read()
+                cmdline = cmdline.replace(b'\x00', b' ').decode("utf-8")  # cmdline is null-separated, so replacing nulls with spaces for easier parsing and logging
+                
                 if Constants.CORE_CODE_FILE_NAME in cmdline:
-                    self.logger.log_debug("Process is a patching operation. [PID={0}]".format(str(pid)))
+                    self.logger.log_verbose("Process is a patching operation. [PID={0}]".format(str(pid)))
                     return True
                 else:
-                    self.logger.log_debug("Process is not a patching operation. [PID={0}]".format(str(pid)))
+                    self.logger.log_debug("Process is not a patching operation. [PID={0}] [CmdLine={1}]".format(str(pid), cmdline))
                     return False
         except Exception as error:
             self.logger.log_debug("Error checking if process is a patching operation. [PID={0}] [Error={1}]".format(str(pid), repr(error)))

--- a/src/extension/src/ProcessHandler.py
+++ b/src/extension/src/ProcessHandler.py
@@ -204,13 +204,12 @@ class ProcessHandler(object):
             # Patching operation cmdline will look like:
             # /usr/bin/python3.10 /var/lib/waagent/Microsoft.CPlat.Core.LinuxPatchExtension-1.6.69/MsftLinuxPatchCore.py <args>
             with self.env_layer.file_system.open("/proc/{0}/cmdline".format(str(pid)), mode="rb") as cmdline_file:
-                cmdline = cmdline_file.read()
-                cmdline = cmdline.replace(b'\x00', b' ').decode("utf-8")  # cmdline is null-separated, so replacing nulls with spaces for easier parsing and logging
-                
-                if Constants.CORE_CODE_FILE_NAME in cmdline:
+                cmdline_bytes = cmdline_file.read()
+                if Constants.CORE_CODE_FILE_NAME.encode("utf-8") in cmdline_bytes:
                     self.logger.log_verbose("Process is a patching operation. [PID={0}]".format(str(pid)))
                     return True
                 else:
+                    cmdline = cmdline_bytes.replace(b'\x00', b' ').decode("utf-8", errors="replace")  # cmdline is null-separated
                     self.logger.log_debug("Process is not a patching operation. [PID={0}] [CmdLine={1}]".format(str(pid), cmdline))
                     return False
         except Exception as error:

--- a/src/extension/tests/Test_ProcessHandler.py
+++ b/src/extension/tests/Test_ProcessHandler.py
@@ -49,6 +49,9 @@ class TestProcessHandler(unittest.TestCase):
     def mock_is_process_running_to_return_true(self, pid):
         return True
 
+    def mock_is_process_running_to_return_true(self, pid):
+        return True
+
     def mock_os_kill_to_raise_exception(self, pid, sig):
         raise OSError
 
@@ -133,6 +136,8 @@ class TestProcessHandler(unittest.TestCase):
         # setting mocks
         is_process_running_backup = ProcessHandler.is_process_running
         ProcessHandler.is_process_running = self.mock_is_process_running_to_return_true
+        is_process_patching_operation_backup = ProcessHandler.is_process_patching_operation
+        ProcessHandler.is_process_patching_operation = self.mock_is_process_patching_operation_to_return_true
         os_kill_backup = os.kill
         os.kill = self.mock_os_kill_to_raise_exception
 
@@ -143,6 +148,7 @@ class TestProcessHandler(unittest.TestCase):
 
         # reseting mocks
         ProcessHandler.is_process_running = is_process_running_backup
+        ProcessHandler.is_process_patching_operation = is_process_patching_operation_backup
         os.kill = os_kill_backup
 
     def test_get_python_cmd(self):

--- a/src/extension/tests/Test_ProcessHandler.py
+++ b/src/extension/tests/Test_ProcessHandler.py
@@ -49,7 +49,7 @@ class TestProcessHandler(unittest.TestCase):
     def mock_is_process_running_to_return_true(self, pid):
         return True
 
-    def mock_is_process_running_to_return_true(self, pid):
+    def mock_is_process_patching_operation_to_return_true(self, pid):
         return True
 
     def mock_os_kill_to_raise_exception(self, pid, sig):

--- a/src/extension/tests/Test_ProcessHandler.py
+++ b/src/extension/tests/Test_ProcessHandler.py
@@ -17,6 +17,7 @@
 import os
 import subprocess
 import sys
+import tempfile
 import unittest
 from extension.src.Constants import Constants
 from extension.src.file_handlers.ExtOutputStatusHandler import ExtOutputStatusHandler
@@ -39,7 +40,8 @@ class TestProcessHandler(unittest.TestCase):
         self.json_file_handler = runtime.json_file_handler
         self.env_layer = runtime.env_layer
         dir_path = os.path.join(os.path.pardir, "tests", "helpers")
-        self.proc_cmdline_path = os.path.join(dir_path, "proc_cmdline")
+        self.test_dir = tempfile.mkdtemp()
+        self.proc_cmdline_path = os.path.join(self.test_dir, "proc_cmdline")
         self.ext_output_status_handler = ExtOutputStatusHandler(self.logger, self.utility, self.json_file_handler, dir_path)
         self.process = subprocess.Popen(["echo", "Hello World!"], shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 

--- a/src/extension/tests/Test_ProcessHandler.py
+++ b/src/extension/tests/Test_ProcessHandler.py
@@ -73,6 +73,9 @@ class TestProcessHandler(unittest.TestCase):
     def mock_file_system_open_to_return_proc_cmdline(self, path, mode):
         return open(self.proc_cmdline_path, mode=mode)
 
+    def mock_file_system_open_raises_exception(self, path, mode):
+        raise FileNotFoundError
+
     def mock_run_command_to_set_auto_assess_shell_file_permission(self, cmd, no_output=False, chk_err=False):
         return 0, "permissions set"
 
@@ -242,6 +245,13 @@ class TestProcessHandler(unittest.TestCase):
         pid = 1234
         
         self.assertFalse(process_handler.is_process_patching_operation(pid))
+
+        self.env_layer.file_system.open = self.mock_file_system_open_raises_exception
+
+        process_handler = ProcessHandler(self.logger, self.env_layer, self.ext_output_status_handler)
+        pid = 1234
+
+        self.assertTrue(process_handler.is_process_patching_operation(pid))
 
         # resetting mocks
         self.env_layer.file_system.open = backup_file_system_open

--- a/src/extension/tests/Test_ProcessHandler.py
+++ b/src/extension/tests/Test_ProcessHandler.py
@@ -246,6 +246,7 @@ class TestProcessHandler(unittest.TestCase):
         
         self.assertFalse(process_handler.is_process_patching_operation(pid))
 
+        # process cmdline exception
         self.env_layer.file_system.open = self.mock_file_system_open_raises_exception
 
         process_handler = ProcessHandler(self.logger, self.env_layer, self.ext_output_status_handler)

--- a/src/extension/tests/Test_ProcessHandler.py
+++ b/src/extension/tests/Test_ProcessHandler.py
@@ -226,35 +226,22 @@ class TestProcessHandler(unittest.TestCase):
     def test_is_process_patching_operation(self):
         # setting mocks
         backup_file_system_open = self.env_layer.file_system.open
-        self.env_layer.file_system.open = self.mock_file_system_open_to_return_proc_cmdline
 
-        # process is patching operation
-        is_patching_operation_content = b'/usr/bin/python3.10\x00/var/lib/waagent/Microsoft.CPlat.Core.LinuxPatchExtension-1.6.69/MsftLinuxPatchCore.py\x00--seqno\x001234\x00--configfile\x00/var/lib/waagent/Microsoft.CPlat.Core.LinuxPatchExtension-1.6.69/config/1234/config.json\x00--envfile\x00/var/lib/waagent/Microsoft.CPlat.Core.LinuxPatchExtension-1.6.69/env/1234/env.json\x00--outputfile\x00/var/lib/waagent/Microsoft.CPlat.Core.LinuxPatchExtension-1.6.69/output/1234/output.json'
-        with open(self.proc_cmdline_path, "wb") as f:
-            f.write(is_patching_operation_content)
-
-        process_handler = ProcessHandler(self.logger, self.env_layer, self.ext_output_status_handler)
-        pid = 1234
-        
-        self.assertTrue(process_handler.is_process_patching_operation(pid))
-
-        # process is not patching operation
-        is_not_patching_operation_content = b'/usr/bin/python3.10\x00/someother/path/some_other_script.py\x00--somearg\x00somevalue'
-        with open(self.proc_cmdline_path, "wb") as f:
-            f.write(is_not_patching_operation_content)
-
-        process_handler = ProcessHandler(self.logger, self.env_layer, self.ext_output_status_handler)
-        pid = 1234
-        
-        self.assertFalse(process_handler.is_process_patching_operation(pid))
-
-        # process cmdline exception
-        self.env_layer.file_system.open = self.mock_file_system_open_raises_exception
+        test_input_output_table = [
+            [self.mock_file_system_open_to_return_proc_cmdline, b'/usr/bin/python3.10\x00/var/lib/waagent/Microsoft.CPlat.Core.LinuxPatchExtension-1.6.69/MsftLinuxPatchCore.py\x00--seqno\x001234\x00--configfile\x00/var/lib/waagent/Microsoft.CPlat.Core.LinuxPatchExtension-1.6.69/config/1234/config.json\x00--envfile\x00/var/lib/waagent/Microsoft.CPlat.Core.LinuxPatchExtension-1.6.69/env/1234/env.json\x00--outputfile\x00/var/lib/waagent/Microsoft.CPlat.Core.LinuxPatchExtension-1.6.69/output/1234/output.json', True],
+            [self.mock_file_system_open_to_return_proc_cmdline, b'/usr/bin/python3.10\x00/someother/path/some_other_script.py\x00--somearg\x00somevalue', False],
+            [self.mock_file_system_open_raises_exception, b'', True]
+        ]
 
         process_handler = ProcessHandler(self.logger, self.env_layer, self.ext_output_status_handler)
         pid = 1234
 
-        self.assertTrue(process_handler.is_process_patching_operation(pid))
+        for row in test_input_output_table:
+            self.env_layer.file_system.open = row[0]
+            content = row[1]
+            with open(self.proc_cmdline_path, "wb") as f:
+                f.write(content)
+            self.assertEqual(process_handler.is_process_patching_operation(pid), row[2])
 
         # resetting mocks
         self.env_layer.file_system.open = backup_file_system_open

--- a/src/extension/tests/Test_ProcessHandler.py
+++ b/src/extension/tests/Test_ProcessHandler.py
@@ -76,7 +76,7 @@ class TestProcessHandler(unittest.TestCase):
         return open(self.proc_cmdline_path, mode=mode)
 
     def mock_file_system_open_raises_exception(self, path, mode):
-        raise FileNotFoundError
+        raise OSError
 
     def mock_run_command_to_set_auto_assess_shell_file_permission(self, cmd, no_output=False, chk_err=False):
         return 0, "permissions set"

--- a/src/extension/tests/Test_ProcessHandler.py
+++ b/src/extension/tests/Test_ProcessHandler.py
@@ -15,6 +15,7 @@
 # Requires Python 2.7+
 
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -47,6 +48,7 @@ class TestProcessHandler(unittest.TestCase):
 
     def tearDown(self):
         VirtualTerminal().print_lowlight("\n----------------- tear down test runner -----------------")
+        shutil.rmtree(self.test_dir)
         self.process.kill()
 
     def mock_is_process_running_to_return_true(self, pid):

--- a/src/extension/tests/Test_ProcessHandler.py
+++ b/src/extension/tests/Test_ProcessHandler.py
@@ -39,6 +39,7 @@ class TestProcessHandler(unittest.TestCase):
         self.json_file_handler = runtime.json_file_handler
         self.env_layer = runtime.env_layer
         dir_path = os.path.join(os.path.pardir, "tests", "helpers")
+        self.proc_cmdline_path = os.path.join(dir_path, "proc_cmdline")
         self.ext_output_status_handler = ExtOutputStatusHandler(self.logger, self.utility, self.json_file_handler, dir_path)
         self.process = subprocess.Popen(["echo", "Hello World!"], shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
@@ -66,6 +67,9 @@ class TestProcessHandler(unittest.TestCase):
 
     def mock_get_python_cmd(self):
         return "python"
+
+    def mock_file_system_open_to_return_proc_cmdline(self, path, mode):
+        return open(self.proc_cmdline_path, mode=mode)
 
     def mock_run_command_to_set_auto_assess_shell_file_permission(self, cmd, no_output=False, chk_err=False):
         return 0, "permissions set"
@@ -211,6 +215,34 @@ class TestProcessHandler(unittest.TestCase):
         subprocess.Popen = subprocess_popen_backup
         process_handler.env_layer.run_command_output = run_command_output_backup
         ExtEnvHandler.get_temp_folder = ext_env_handler_get_temp_folder_backup
+    
+    def test_is_process_patching_operation(self):
+        # setting mocks
+        backup_file_system_open = self.env_layer.file_system.open
+        self.env_layer.file_system.open = self.mock_file_system_open_to_return_proc_cmdline
+
+        # process is patching operation
+        is_patching_operation_content = b'/usr/bin/python3.10\x00/var/lib/waagent/Microsoft.CPlat.Core.LinuxPatchExtension-1.6.69/MsftLinuxPatchCore.py\x00--seqno\x001234\x00--configfile\x00/var/lib/waagent/Microsoft.CPlat.Core.LinuxPatchExtension-1.6.69/config/1234/config.json\x00--envfile\x00/var/lib/waagent/Microsoft.CPlat.Core.LinuxPatchExtension-1.6.69/env/1234/env.json\x00--outputfile\x00/var/lib/waagent/Microsoft.CPlat.Core.LinuxPatchExtension-1.6.69/output/1234/output.json'
+        with open(self.proc_cmdline_path, "wb") as f:
+            f.write(is_patching_operation_content)
+
+        process_handler = ProcessHandler(self.logger, self.env_layer, self.ext_output_status_handler)
+        pid = 1234
+        
+        self.assertTrue(process_handler.is_process_patching_operation(pid))
+
+        # process is not patching operation
+        is_not_patching_operation_content = b'/usr/bin/python3.10\x00/someother/path/some_other_script.py\x00--somearg\x00somevalue'
+        with open(self.proc_cmdline_path, "wb") as f:
+            f.write(is_not_patching_operation_content)
+
+        process_handler = ProcessHandler(self.logger, self.env_layer, self.ext_output_status_handler)
+        pid = 1234
+        
+        self.assertFalse(process_handler.is_process_patching_operation(pid))
+
+        # resetting mocks
+        self.env_layer.file_system.open = backup_file_system_open
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
There are times when the previous patching operation will not be running (reboot, etc), where its PID will be reused before the next patching operation starts. When ProcessHandler checks for running previous patching operations, it will identify this new process which is not the patching extension as a process that needs to be terminated. If this process is a required process for the service, it causes that service to crash.

This change checks the process's cmdline by reading the pid's cmdline file in the proc filesystem. If it contains the patching extension Core filename, then we can be more confident that the process we are about to end is the correct one. If it does not find the core filename in the cmdline, we can guarantee that the process is not a patching operation, and we will not end that process.

Logging:

```
Processes still running from the previous request: [PIDs=[41245]]
Previous patch operation is still in progress with last status update at 2026-07-23T20:10:34Z. Waiting for a maximum of 0:02:59.461797 seconds for it to complete with intermittent status change checks. Next check will be performed after 60 seconds.
Reading file. [File=CoreState.json]
Previous patch operation is still in progress with last status update at 2026-07-23T20:10:34Z. Waiting for a maximum of 0:01:59.403644 seconds for it to complete with intermittent status change checks. Next check will be performed after 60 seconds.
Reading file. [File=CoreState.json]
Previous patch operation is still in progress with last status update at 2026-07-23T20:10:34Z. Waiting for a maximum of 0:00:59.364601 seconds for it to complete with intermittent status change checks. Next check will be performed after 59.364601 seconds.
Reading file. [File=CoreState.json]
Previous request did not complete in time. Terminating all of it's running processes.
DEBUG: Process is a patching operation. [PID=41245]
Terminating process: [PID=41245]
Deleting file. [File=CoreState.json]
DEBUG: Deleting format-matching items from temp folder. [FormatList=[*]][TempFolderLocation=/var/lib/waagent/Microsoft.CPlat.Core.LinuxPatchExtension-1.6.69/tmp]
```