### PR TITLE
Bugfix: Fix Failing UT missing credential sanitizer

### DIFF
--- a/src/core/tests/Test_PatchAssessor.py
+++ b/src/core/tests/Test_PatchAssessor.py
@@ -60,13 +60,13 @@ class TestPatchAssessor(unittest.TestCase):
 
     def test_assessment_telemetry_fail(self):
         backup_telemetry_writer = self.runtime.telemetry_writer
-        telemetry_writer = TelemetryWriter(self.runtime.env_layer, self.runtime.composite_logger, events_folder_path=None, telemetry_supported=False)
+        telemetry_writer = TelemetryWriter(self.runtime.env_layer, self.runtime.composite_logger, self.runtime.credential_sanitizer, events_folder_path=None, telemetry_supported=False)
         self.runtime.patch_assessor.telemetry_writer = telemetry_writer
         self.assertRaises(Exception, self.runtime.patch_assessor.start_assessment)
-        telemetry_writer = TelemetryWriter(self.runtime.env_layer, self.runtime.composite_logger, events_folder_path="events", telemetry_supported=False)
+        telemetry_writer = TelemetryWriter(self.runtime.env_layer, self.runtime.composite_logger, self.runtime.credential_sanitizer, events_folder_path="events", telemetry_supported=False)
         self.runtime.patch_assessor.telemetry_writer = telemetry_writer
         self.assertRaises(Exception, self.runtime.patch_assessor.start_assessment)
-        telemetry_writer = TelemetryWriter(self.runtime.env_layer, self.runtime.composite_logger, events_folder_path=None, telemetry_supported=True)
+        telemetry_writer = TelemetryWriter(self.runtime.env_layer, self.runtime.composite_logger, self.runtime.credential_sanitizer, events_folder_path=None, telemetry_supported=True)
         self.runtime.patch_assessor.telemetry_writer = telemetry_writer
         self.assertRaises(Exception, self.runtime.patch_assessor.start_assessment)
         self.runtime.patch_assessor.telemetry_writer = backup_telemetry_writer


### PR DESCRIPTION
PR at fault : https://github.com/Azure/LinuxPatchExtension/pull/340
The above PR was in review since past few days with Code coverage and UT working fine (passing). After a couple of rebases from master, it failed on the last attempt with parameter passing error 
<img width="1067" height="466" alt="Failure" src="https://github.com/user-attachments/assets/7a6e9f04-0b18-4364-a3df-b2244682ade2" />

- Unsure on why it didn't show up in earlier runs. PR got merged since it was set to auto-merge on approval.
https://github.com/Azure/LinuxPatchExtension/actions - This doesn't show failure either for master branch.  something we need to check.

