### PR TITLE
Fundamentals: Automatically request reviewers

### DIFF
--- a/.github/workflows/auto-request-reviewers.yml
+++ b/.github/workflows/auto-request-reviewers.yml
@@ -11,8 +11,8 @@ permissions:
 
 jobs:
   request-reviewers:
+    if: ${{ github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
-
     steps:
       - name: Request reviewers
         uses: actions/github-script@v7

--- a/.github/workflows/auto-request-reviewers.yml
+++ b/.github/workflows/auto-request-reviewers.yml
@@ -1,0 +1,35 @@
+name: Auto Request Reviewers
+
+on:
+  pull_request:
+    types:
+      - opened
+      - ready_for_review
+
+permissions:
+  pull-requests: write
+
+jobs:
+  request-reviewers:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Request reviewers
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.pulls.requestReviewers({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              reviewers: [
+                'GAURAVRAMRAKHYANI',
+                'kjohn-msft',
+                'michellemcdaniel',
+                'mirichmo',
+                'nikhim-um',
+                'rane-rajasi',
+                'SathishMSFT',
+                'yashnap'
+              ]
+            });

--- a/.github/workflows/auto-request-reviewers.yml
+++ b/.github/workflows/auto-request-reviewers.yml
@@ -5,7 +5,6 @@ on:
     types:
       - opened
       - ready_for_review
-      - synchronize
 
 permissions:
   pull-requests: write

--- a/.github/workflows/auto-request-reviewers.yml
+++ b/.github/workflows/auto-request-reviewers.yml
@@ -5,6 +5,7 @@ on:
     types:
       - opened
       - ready_for_review
+      - synchronize
 
 permissions:
   pull-requests: write

--- a/.github/workflows/auto-request-reviewers.yml
+++ b/.github/workflows/auto-request-reviewers.yml
@@ -1,4 +1,4 @@
-name: Auto Request Reviewers
+name: Request AzGPS Reviewers
 
 on:
   pull_request:
@@ -22,10 +22,10 @@ jobs:
             const author = context.payload.pull_request.user.login;
 
             const reviewers = [
-              'GAURAVRAMRAWOCHYANI',
+              'GAURAVRAMRAKHYANI',
               'kjohn-msft',
-              'michellemcdeniel',
-              'mirichno',
+              'michellemcdaniel',
+              'mirichmo',
               'nikhim-um',
               'rane-rajasi',
               'SathishMSFT',

--- a/.github/workflows/auto-request-reviewers.yml
+++ b/.github/workflows/auto-request-reviewers.yml
@@ -18,18 +18,29 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const author = context.payload.pull_request.user.login;
+
+            const reviewers = [
+              'GAURAVRAMRAWOCHYANI',
+              'kjohn-msft',
+              'michellemcdeniel',
+              'mirichno',
+              'nikhim-um',
+              'rane-rajasi',
+              'SathishMSFT',
+              'yashnap'
+            ];
+
+            const filtered = reviewers.filter(
+              r => r.toLowerCase() !== author.toLowerCase()
+            );
+
+            console.log(`PR author: ${author}`);
+            console.log(`Requesting reviews from: ${filtered.join(", ")}`);
+
             await github.rest.pulls.requestReviewers({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.payload.pull_request.number,
-              reviewers: [
-                'GAURAVRAMRAKHYANI',
-                'kjohn-msft',
-                'michellemcdaniel',
-                'mirichmo',
-                'nikhim-um',
-                'rane-rajasi',
-                'SathishMSFT',
-                'yashnap'
-              ]
+              reviewers: filtered
             });

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
-*       @kjohn-msft @rane-rajasi
+*       @kjohn-msft @rane-rajasi @mirichmo
+

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @kjohn-msft @rane-rajasi @najams
+*       @kjohn-msft @rane-rajasi


### PR DESCRIPTION
This is to incorporate a workflow to automatically add a larger reviewer group to PRs.

Adds backup org owner due to org changes.