### PR TITLE
Bugfix: Fix Failing UT missing credential sanitizer

### DIFF
--- a/src/extension/tests/Test_ActionHandler.py
+++ b/src/extension/tests/Test_ActionHandler.py
@@ -310,7 +310,7 @@ class TestActionHandler(unittest.TestCase):
 
         # Re-init TelemetryWriter since the env var for compatibility is only checked on init
         os.getenv = mock_os_getenv
-        self.runtime.telemetry_writer = TelemetryWriter(self.runtime.logger, self.runtime.env_layer)
+        self.runtime.telemetry_writer = TelemetryWriter(self.runtime.logger, self.runtime.env_layer, self.runtime.credential_sanitizer)
         self.action_handler.telemetry_writer = self.runtime.telemetry_writer
 
         self.assertTrue(self.action_handler.uninstall() == Constants.ExitCode.Okay)
@@ -339,7 +339,7 @@ class TestActionHandler(unittest.TestCase):
 
         # Re-init TelemetryWriter since the env var for compatibility is only checked on init
         os.getenv = mock_os_getenv
-        self.runtime.telemetry_writer = TelemetryWriter(self.runtime.logger, self.runtime.env_layer)
+        self.runtime.telemetry_writer = TelemetryWriter(self.runtime.logger, self.runtime.env_layer, self.runtime.credential_sanitizer)
         self.action_handler.telemetry_writer = self.runtime.telemetry_writer
 
         self.assertTrue(self.action_handler.uninstall() == Constants.ExitCode.Okay)
@@ -582,7 +582,7 @@ class TestActionHandler(unittest.TestCase):
             '/var/lib/waagent/Microsoft.CPlat.Core.LinuxPatchExtension-1.6.35'
         ]
 
-        all_versions = self.action_handler.filter_files_from_versions(all_versions_including_files);
+        all_versions = self.action_handler.filter_files_from_versions(all_versions_including_files)
         self.assertTrue(len(all_versions) == 2)
         self.assertTrue('/var/lib/waagent/Microsoft.CPlat.Core.LinuxPatchExtension-1.6.36' in all_versions)
         self.assertTrue('/var/lib/waagent/Microsoft.CPlat.Core.LinuxPatchExtension-1.6.35' in all_versions)

--- a/src/extension/tests/Test_ActionHandler.py
+++ b/src/extension/tests/Test_ActionHandler.py
@@ -310,7 +310,6 @@ class TestActionHandler(unittest.TestCase):
 
         # Re-init TelemetryWriter since the env var for compatibility is only checked on init
         os.getenv = mock_os_getenv
-        #test
         self.runtime.telemetry_writer = TelemetryWriter(self.runtime.logger, self.runtime.env_layer, self.runtime.credential_sanitizer)
         self.action_handler.telemetry_writer = self.runtime.telemetry_writer
 

--- a/src/extension/tests/Test_ActionHandler.py
+++ b/src/extension/tests/Test_ActionHandler.py
@@ -310,6 +310,7 @@ class TestActionHandler(unittest.TestCase):
 
         # Re-init TelemetryWriter since the env var for compatibility is only checked on init
         os.getenv = mock_os_getenv
+        #test
         self.runtime.telemetry_writer = TelemetryWriter(self.runtime.logger, self.runtime.env_layer, self.runtime.credential_sanitizer)
         self.action_handler.telemetry_writer = self.runtime.telemetry_writer
 

--- a/src/extension/tests/Test_ExtOutputStatusHandler.py
+++ b/src/extension/tests/Test_ExtOutputStatusHandler.py
@@ -18,6 +18,7 @@ import json
 import os
 import shutil
 import tempfile
+import time
 import unittest
 from extension.src.Constants import Constants
 from extension.src.file_handlers.ExtOutputStatusHandler import ExtOutputStatusHandler
@@ -84,11 +85,13 @@ class TestExtOutputStatusHandler(unittest.TestCase):
         stat_file_name = os.stat(os.path.join(dir_path, file_name + ".status"))
         prev_modified_time = stat_file_name.st_mtime
 
+        time.sleep(0.02)
         ext_status_handler.update_file("test1")
         stat_file_name = os.stat(os.path.join(dir_path, file_name + ".status"))
         modified_time = stat_file_name.st_mtime
         self.assertEqual(prev_modified_time, modified_time)
 
+        time.sleep(0.05)  # ensure filesystem mtime granularity is exceeded
         ext_status_handler.update_file(file_name)
         stat_file_name = os.stat(os.path.join(dir_path, file_name + ".status"))
         modified_time = stat_file_name.st_mtime

--- a/src/extension/tests/Test_ExtOutputStatusHandler.py
+++ b/src/extension/tests/Test_ExtOutputStatusHandler.py
@@ -73,9 +73,6 @@ class TestExtOutputStatusHandler(unittest.TestCase):
         shutil.rmtree(dir_path)
 
     def test_update_file(self):
-        # if self.runtime.is_github_runner:
-        #     return
-
         file_name = "test"
         dir_path = tempfile.mkdtemp()
         operation = "Assessment"
@@ -91,7 +88,7 @@ class TestExtOutputStatusHandler(unittest.TestCase):
         modified_time = stat_file_name.st_mtime
         self.assertEqual(prev_modified_time, modified_time)
 
-        time.sleep(0.02)  # ensure filesystem mtime granularity is exceeded
+        time.sleep(0.03)  # ensure filesystem mtime granularity is exceeded
         ext_status_handler.update_file(file_name)
         stat_file_name = os.stat(os.path.join(dir_path, file_name + ".status"))
         modified_time = stat_file_name.st_mtime

--- a/src/extension/tests/Test_ExtOutputStatusHandler.py
+++ b/src/extension/tests/Test_ExtOutputStatusHandler.py
@@ -72,8 +72,8 @@ class TestExtOutputStatusHandler(unittest.TestCase):
         shutil.rmtree(dir_path)
 
     def test_update_file(self):
-        if self.runtime.is_github_runner:
-            return
+        # if self.runtime.is_github_runner:
+        #     return
 
         file_name = "test"
         dir_path = tempfile.mkdtemp()

--- a/src/extension/tests/Test_ExtOutputStatusHandler.py
+++ b/src/extension/tests/Test_ExtOutputStatusHandler.py
@@ -91,7 +91,7 @@ class TestExtOutputStatusHandler(unittest.TestCase):
         modified_time = stat_file_name.st_mtime
         self.assertEqual(prev_modified_time, modified_time)
 
-        time.sleep(0.05)  # ensure filesystem mtime granularity is exceeded
+        time.sleep(0.02)  # ensure filesystem mtime granularity is exceeded
         ext_status_handler.update_file(file_name)
         stat_file_name = os.stat(os.path.join(dir_path, file_name + ".status"))
         modified_time = stat_file_name.st_mtime

--- a/src/extension/tests/Test_TelemetryWriter.py
+++ b/src/extension/tests/Test_TelemetryWriter.py
@@ -68,7 +68,7 @@ class TestTelemetryWriter(unittest.TestCase):
         with open(os.path.join(self.telemetry_writer.events_folder_path, os.listdir(self.telemetry_writer.events_folder_path)[0]), 'r+') as f:
             events = json.load(f)
             self.assertTrue(events is not None)
-            self.assertEqual(len(events), 2)  # Fails here on GitHub
+            self.assertEqual(len(events), 2)
             self.assertEqual(events[0]["TaskName"], "Test Task")
             self.assertEqual(events[1]["TaskName"], "Test Task2")
             f.close()
@@ -109,9 +109,6 @@ class TestTelemetryWriter(unittest.TestCase):
     #     self.telemetry_writer.get_file_size = telemetry_get_event_file_size_backup
 
     def test_delete_older_events(self):
-        # if self.runtime.is_github_runner:
-        #     return
-
         # deleting older event files before adding new one
         self.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task")
         self.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task2")
@@ -125,7 +122,7 @@ class TestTelemetryWriter(unittest.TestCase):
         self.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task4")
         new_events = os.listdir(self.telemetry_writer.events_folder_path)
         self.assertEqual(len(new_events), 1)
-        self.assertTrue(old_events[0] not in new_events)  # Fails here on GitHub
+        self.assertTrue(old_events[0] not in new_events)
         Constants.TELEMETRY_DIR_SIZE_LIMIT_IN_CHARS = telemetry_dir_size_backup
         Constants.TELEMETRY_EVENT_FILE_SIZE_LIMIT_IN_CHARS = telemetry_event_size_backup
 

--- a/src/extension/tests/Test_TelemetryWriter.py
+++ b/src/extension/tests/Test_TelemetryWriter.py
@@ -38,8 +38,8 @@ class TestTelemetryWriter(unittest.TestCase):
         return ['testevent1.json', 'testevent2.json', 'testevent3.json', 'testevent4.json']
 
     def test_write_event(self):
-        if self.runtime.is_github_runner:
-            return
+        # if self.runtime.is_github_runner:
+        #     return
 
         self.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task")
         with open(os.path.join(self.telemetry_writer.events_folder_path, os.listdir(self.telemetry_writer.events_folder_path)[0]), 'r+') as f:

--- a/src/extension/tests/Test_TelemetryWriter.py
+++ b/src/extension/tests/Test_TelemetryWriter.py
@@ -109,8 +109,8 @@ class TestTelemetryWriter(unittest.TestCase):
     #     self.telemetry_writer.get_file_size = telemetry_get_event_file_size_backup
 
     def test_delete_older_events(self):
-        if self.runtime.is_github_runner:
-            return
+        # if self.runtime.is_github_runner:
+        #     return
 
         # deleting older event files before adding new one
         self.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task")

--- a/src/extension/tests/Test_TelemetryWriter.py
+++ b/src/extension/tests/Test_TelemetryWriter.py
@@ -38,9 +38,6 @@ class TestTelemetryWriter(unittest.TestCase):
         return ['testevent1.json', 'testevent2.json', 'testevent3.json', 'testevent4.json']
 
     def test_write_event(self):
-        # if self.runtime.is_github_runner:
-        #     return
-
         self.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task")
         with open(os.path.join(self.telemetry_writer.events_folder_path, os.listdir(self.telemetry_writer.events_folder_path)[0]), 'r+') as f:
             events = json.load(f)
@@ -64,9 +61,6 @@ class TestTelemetryWriter(unittest.TestCase):
                 f.close()
 
     def test_write_multiple_events_in_same_file(self):
-        if self.runtime.is_github_runner:
-            return
-
         time_backup = time.time
         time.time = self.mock_time
         self.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task")

--- a/src/extension/tests/Test_TelemetryWriter.py
+++ b/src/extension/tests/Test_TelemetryWriter.py
@@ -122,7 +122,7 @@ class TestTelemetryWriter(unittest.TestCase):
         self.telemetry_writer.write_event("testing telemetry write to file", Constants.TelemetryEventLevel.Error, "Test Task4")
         new_events = os.listdir(self.telemetry_writer.events_folder_path)
         self.assertEqual(len(new_events), 1)
-        self.assertTrue(old_events[0] not in new_events)
+        self.assertNotIn(old_events[0], new_events)
         Constants.TELEMETRY_DIR_SIZE_LIMIT_IN_CHARS = telemetry_dir_size_backup
         Constants.TELEMETRY_EVENT_FILE_SIZE_LIMIT_IN_CHARS = telemetry_event_size_backup
 


### PR DESCRIPTION
Similar Issue and Fix :   https://github.com/Azure/LinuxPatchExtension/pull/374 

Its weird because I see failure in one of my PR run : https://github.com/Azure/LinuxPatchExtension/pull/368 
<img width="987" height="352" alt="UTFIx_1" src="https://github.com/user-attachments/assets/74e2aedf-325f-4ec6-beb7-238ff4152de5" />

and the 2nd one looks fine after the same rebase : https://github.com/Azure/LinuxPatchExtension/pull/359 

The addition of credential sanitizer has started exercising new paths which is reducing the coverage from base branch.  
- I've removed the test that were marked to skip on GitHub because they kept failing according to this PR :  https://github.com/Azure/LinuxPatchExtension/pull/129 . ( No comment was mentioned about putting it back or reasoning either) 
- Added sleep time 20s and 30s each for update time use-case which was failing on assertion due to time not getting reflected or writes happening before/around the same time.
Dont see any failures at the moment with the github tests that were failing earlier.
