### PR TITLE
Add LinuxPatchExtensionTeam to PR reviews

### DIFF
--- a/.github/workflows/auto-request-reviewers.yml
+++ b/.github/workflows/auto-request-reviewers.yml
@@ -5,6 +5,7 @@ on:
     types:
       - opened
       - ready_for_review
+      - synchronize
 
 permissions:
   pull-requests: write
@@ -21,6 +22,7 @@ jobs:
             const author = context.payload.pull_request.user.login;
 
             const reviewers = [
+              'Azure/linuxpatchextensionteam',
               'GAURAVRAMRAKHYANI',
               'kjohn-msft',
               'michellemcdaniel',

--- a/.github/workflows/auto-request-reviewers.yml
+++ b/.github/workflows/auto-request-reviewers.yml
@@ -23,13 +23,13 @@ jobs:
 
             const reviewers = [
               'Azure/linuxpatchextensionteam',
-              'GAURAVRAMRAKHYANI',
+              'gauravramrakhyani',
               'kjohn-msft',
               'michellemcdaniel',
               'mirichmo',
               'nikhim-um',
               'rane-rajasi',
-              'SathishMSFT',
+              'Sathishmsft',
               'yashnap'
             ];
 


### PR DESCRIPTION
Modifies the workflow to add the team to reviews automatically.