### PR TITLE
Flaky UT Fix

### DIFF
--- a/src/extension/tests/Test_ExtOutputStatusHandler.py
+++ b/src/extension/tests/Test_ExtOutputStatusHandler.py
@@ -88,7 +88,7 @@ class TestExtOutputStatusHandler(unittest.TestCase):
         modified_time = stat_file_name.st_mtime
         self.assertEqual(prev_modified_time, modified_time)
 
-        time.sleep(0.03)  # ensure filesystem mtime granularity is exceeded
+        time.sleep(0.08)  # ensure filesystem mtime granularity is exceeded
         ext_status_handler.update_file(file_name)
         stat_file_name = os.stat(os.path.join(dir_path, file_name + ".status"))
         modified_time = stat_file_name.st_mtime

--- a/src/extension/tests/Test_ExtOutputStatusHandler.py
+++ b/src/extension/tests/Test_ExtOutputStatusHandler.py
@@ -15,10 +15,8 @@
 # Requires Python 2.7+
 
 import json
-import os
 import shutil
 import tempfile
-import time
 import unittest
 from extension.src.Constants import Constants
 from extension.src.file_handlers.ExtOutputStatusHandler import ExtOutputStatusHandler
@@ -79,21 +77,15 @@ class TestExtOutputStatusHandler(unittest.TestCase):
 
         ext_status_handler = ExtOutputStatusHandler(self.logger, self.utility, self.json_file_handler, dir_path)
         ext_status_handler.write_status_file(operation, file_name, self.status.Success.lower())
-        stat_file_name = os.stat(os.path.join(dir_path, file_name + ".status"))
-        prev_modified_time = stat_file_name.st_mtime
+        original_status_json = ext_status_handler.read_file(file_name)
 
-        time.sleep(0.02)
         ext_status_handler.update_file("test1")
-        stat_file_name = os.stat(os.path.join(dir_path, file_name + ".status"))
-        modified_time = stat_file_name.st_mtime
-        self.assertEqual(prev_modified_time, modified_time)
+        status_json_after_different_seq_update = ext_status_handler.read_file(file_name)
+        self.assertEqual(original_status_json, status_json_after_different_seq_update)
 
-        time.sleep(0.08)  # ensure filesystem mtime granularity is exceeded
         ext_status_handler.update_file(file_name)
-        stat_file_name = os.stat(os.path.join(dir_path, file_name + ".status"))
-        modified_time = stat_file_name.st_mtime
-        self.assertNotEqual(prev_modified_time, modified_time)  # Fails here on GitHub
         updated_status_json = ext_status_handler.read_file(file_name)
+        self.assertNotEqual(original_status_json, updated_status_json)
         self.assertEqual(updated_status_json[0][self.status_file_fields.status][self.status_file_fields.status_status], self.status.Transitioning.lower())
         self.assertEqual(updated_status_json[0][self.status_file_fields.status][self.status_file_fields.status_name], "Azure Patch Management")
         self.assertEqual(updated_status_json[0][self.status_file_fields.status][self.status_file_fields.status_operation], "Assessment")
@@ -101,9 +93,6 @@ class TestExtOutputStatusHandler(unittest.TestCase):
         self.assertEqual(updated_status_json[0][self.status_file_fields.status][self.status_file_fields.status_formatted_message][self.status_file_fields.status_formatted_message_message], "")
 
         ext_status_handler.update_file(file_name, Constants.Status.Success.lower(), Constants.ExitCode.Okay, "Test message")
-        stat_file_name = os.stat(os.path.join(dir_path, file_name + ".status"))
-        modified_time = stat_file_name.st_mtime
-        self.assertNotEqual(prev_modified_time, modified_time)
         updated_status_json = ext_status_handler.read_file(file_name)
         self.assertEqual(updated_status_json[0][self.status_file_fields.status][self.status_file_fields.status_status], self.status.Success.lower())
         self.assertEqual(updated_status_json[0][self.status_file_fields.status][self.status_file_fields.status_name], "Azure Patch Management")


### PR DESCRIPTION
**DESCRIPTION BY COPILOT AGENT:**
The issue I fixed was a flaky unit test (test_update_file) that depended on:
sleep() timing, and file mtime comparisons.
On some CI filesystems, timestamp granularity is coarse (e.g., 1 second), so the file modification time didn’t always change as expected, causing intermittent failures even when behavior was correct.

I changed the test to be deterministic by validating status file content instead:

Confirm update_file("test1") does not change test.status.
Confirm update_file(file_name) updates test.status content as expected.
Description update
Reworked test_update_file in Test_ExtOutputStatusHandler.py to remove timing/mtime-based assertions that caused CI flakiness due to filesystem timestamp granularity.
The test now validates behavior using status-file content comparisons, ensuring deterministic verification that:

updating a different sequence number does not affect the original status file, and
updating the target sequence number correctly updates status payload fields.