### PR TITLE
[UEFI] Handling error code 2 for fwupgmgr refresh

### DIFF
--- a/src/core/src/package_managers/AptitudePackageManager.py
+++ b/src/core/src/package_managers/AptitudePackageManager.py
@@ -98,13 +98,9 @@ class AptitudePackageManager(PackageManager):
         self.apt_update_cmd = "sudo apt-get -q update"
         self.min_fwupd_version = "2.0.8" # Refer public docs: https://github.com/fwupd/fwupd/releases/tag/2.0.8 and https://discourse.ubuntu.com/t/microsoft-uefi-ca-rotation-what-it-means-for-ubuntu-users-and-vendors/82652
         self.remove_fwupd_cmd = "sudo apt-get purge -y fwupd"
-        # NOTE: Per Canonical guidance (https://discourse.ubuntu.com/t/microsoft-uefi-ca-rotation-what-it-means-for-ubuntu-users-and-vendors/82652), Ubuntu releases older
-        # than 22.04 need fwupd installed via snap instead of apt, since a suitable (>=2.0.0) version is not available in their apt repos. The snap package still exposes
-        # the same 'fwupdmgr' command on PATH (via /snap/bin, which snapd adds to PATH), so the version/refresh/update commands below remain identical either way.
-        self.is_snap_fwupd_required = self.__is_snap_fwupd_required()
         self.get_installed_fwupd_version_cmd = "fwupdmgr --version"
-        self.install_fwupd_cmd = "sudo snap install fwupd" if self.is_snap_fwupd_required else "sudo apt-get install -y fwupd"
-        self.fwupd_refresh_cmd = "sudo fwupdmgr refresh" # NOTE: This could be made generic in package manager, depending on what solution type is adopted for other distros
+        self.install_fwupd_cmd = "sudo apt-get install -y fwupd"
+        self.fwupd_force_refresh_cmd = "sudo fwupdmgr refresh --force" # NOTE: This could be made generic in package manager, depending on what solution type is adopted for other distros
         self.fwupd_update_cmd = "sudo fwupdmgr update -y"
         self.get_uptime_seconds_cmd = "cat /proc/uptime"
         self.get_hibernation_state_cmd = "cat /sys/power/disk"
@@ -964,20 +960,6 @@ class AptitudePackageManager(PackageManager):
         return self.package_install_expected_avg_time_in_seconds
 
     # region Update certificates in factory defaults
-    def __is_snap_fwupd_required(self):
-        # type: () -> bool
-        """Return True for Ubuntu releases older than 22.04, where Canonical directs users to the fwupd snap."""
-        try:
-            distribution = self.env_layer.platform.linux_distribution()
-            if len(distribution) < 2 or distribution[0].lower() != "ubuntu":
-                return False
-
-            version_parts = distribution[1].split('.')
-            return int(version_parts[0]) < 22
-        except Exception as error:
-            self.composite_logger.log_warning("[APM][Certs] Unable to determine Ubuntu release for fwupd installation method. Using apt. [Error={0}]".format(repr(error)))
-            return False
-
     def is_reboot_required_before_cert_update(self):
         # type: () -> bool
         """ Long-running VMs may not have the minimum firmware required for certificate updates.
@@ -1050,7 +1032,7 @@ class AptitudePackageManager(PackageManager):
             self.__ensure_fwupd_installation()
 
             # shell fwupd commands to update certificates
-            self.__run_cert_shell_command(self.fwupd_refresh_cmd, step_name="FwupdRefresh", raise_on_error=True)
+            self.__run_cert_shell_command(self.fwupd_force_refresh_cmd, step_name="FwupdRefresh", raise_on_error=False)
             self.__run_cert_shell_command(self.fwupd_update_cmd, step_name="FwupdUpdate", raise_on_error=True)
 
             """ NOTE: They tooling used to update here is fwupd (firmware update manager). In this method of updating certs, the exact version of current certs is never pinned
@@ -1157,9 +1139,9 @@ class AptitudePackageManager(PackageManager):
     def __run_cert_shell_command(self, command, step_name, raise_on_error=False):
         """Run non-apt utility commands directly."""
         code, out = self.env_layer.run_command_output(command, False, False)
-        if command == self.fwupd_refresh_cmd and code == 2:
-            # fwupd refresh returns 2 when no updates are available. This is not an error for our purposes.
-            self.composite_logger.log_debug("[APM][UpdateCerts] Shell step succeeded (no updates available). [Step={0}][Command={1}][Code={2}][Output={3}]".format(step_name, str(command), str(code), str(out)))
+        if command == self.fwupd_force_refresh_cmd:
+            # As per the suggestion from trusted launch VM partners, we need to ignore all errors returned by force refresh command and continue to the next step.
+            self.composite_logger.log_debug("[APM][UpdateCerts] Force refresh shell step executed. [Step={0}][Command={1}][Code={2}][Output={3}]".format(step_name, str(command), str(code), str(out)))
             return True, out
         elif code != 0:
             msg = "[APM][UpdateCerts] Shell step failed. [Step={0}][Command={1}][Code={2}][Output={3}]".format(step_name, str(command), str(code), str(out))

--- a/src/core/src/package_managers/AptitudePackageManager.py
+++ b/src/core/src/package_managers/AptitudePackageManager.py
@@ -97,9 +97,13 @@ class AptitudePackageManager(PackageManager):
         self.install_mokutil_cmd = "sudo apt-get install -y -qq mokutil"
         self.apt_update_cmd = "sudo apt-get -q update"
         self.min_fwupd_version = "2.0.8" # Refer public docs: https://github.com/fwupd/fwupd/releases/tag/2.0.8 and https://discourse.ubuntu.com/t/microsoft-uefi-ca-rotation-what-it-means-for-ubuntu-users-and-vendors/82652
-        self.get_installed_fwupd_version_cmd = "fwupdmgr --version"
         self.remove_fwupd_cmd = "sudo apt-get purge -y fwupd"
-        self.install_fwupd_cmd = "sudo apt-get install -y fwupd"
+        # NOTE: Per Canonical guidance (https://discourse.ubuntu.com/t/microsoft-uefi-ca-rotation-what-it-means-for-ubuntu-users-and-vendors/82652), Ubuntu releases older
+        # than 22.04 need fwupd installed via snap instead of apt, since a suitable (>=2.0.0) version is not available in their apt repos. The snap package still exposes
+        # the same 'fwupdmgr' command on PATH (via /snap/bin, which snapd adds to PATH), so the version/refresh/update commands below remain identical either way.
+        self.is_snap_fwupd_required = self.__is_snap_fwupd_required()
+        self.get_installed_fwupd_version_cmd = "fwupdmgr --version"
+        self.install_fwupd_cmd = "sudo snap install fwupd" if self.is_snap_fwupd_required else "sudo apt-get install -y fwupd"
         self.fwupd_refresh_cmd = "sudo fwupdmgr refresh" # NOTE: This could be made generic in package manager, depending on what solution type is adopted for other distros
         self.fwupd_update_cmd = "sudo fwupdmgr update -y"
         self.get_uptime_seconds_cmd = "cat /proc/uptime"
@@ -960,6 +964,20 @@ class AptitudePackageManager(PackageManager):
         return self.package_install_expected_avg_time_in_seconds
 
     # region Update certificates in factory defaults
+    def __is_snap_fwupd_required(self):
+        # type: () -> bool
+        """Return True for Ubuntu releases older than 22.04, where Canonical directs users to the fwupd snap."""
+        try:
+            distribution = self.env_layer.platform.linux_distribution()
+            if len(distribution) < 2 or distribution[0].lower() != "ubuntu":
+                return False
+
+            version_parts = distribution[1].split('.')
+            return int(version_parts[0]) < 22
+        except Exception as error:
+            self.composite_logger.log_warning("[APM][Certs] Unable to determine Ubuntu release for fwupd installation method. Using apt. [Error={0}]".format(repr(error)))
+            return False
+
     def is_reboot_required_before_cert_update(self):
         # type: () -> bool
         """ Long-running VMs may not have the minimum firmware required for certificate updates.
@@ -1139,7 +1157,11 @@ class AptitudePackageManager(PackageManager):
     def __run_cert_shell_command(self, command, step_name, raise_on_error=False):
         """Run non-apt utility commands directly."""
         code, out = self.env_layer.run_command_output(command, False, False)
-        if code != 0:
+        if command == self.fwupd_refresh_cmd and code == 2:
+            # fwupd refresh returns 2 when no updates are available. This is not an error for our purposes.
+            self.composite_logger.log_debug("[APM][UpdateCerts] Shell step succeeded (no updates available). [Step={0}][Command={1}][Code={2}][Output={3}]".format(step_name, str(command), str(code), str(out)))
+            return True, out
+        elif code != 0:
             msg = "[APM][UpdateCerts] Shell step failed. [Step={0}][Command={1}][Code={2}][Output={3}]".format(step_name, str(command), str(code), str(out))
             self.composite_logger.log_error(msg)
             self.status_handler.add_error_to_status(msg, Constants.PatchOperationErrorCodes.CERTIFICATE_UPDATE)

--- a/src/core/tests/Test_AptitudePackageManager.py
+++ b/src/core/tests/Test_AptitudePackageManager.py
@@ -51,6 +51,12 @@ class TestAptitudePackageManager(unittest.TestCase):
     def mock_linux_distribution_to_return_ubuntu_oracular(self):
         return ['Ubuntu', '26.04', 'oracular']
 
+    def mock_linux_distribution_to_return_ubuntu_focal(self):
+        return ['Ubuntu', '20.04', 'focal']
+
+    def mock_linux_distribution_to_return_ubuntu_jammy(self):
+        return ['Ubuntu', '22.04', 'jammy']
+
     def mock_is_pro_working_return_true(self):
         return True
 
@@ -137,6 +143,20 @@ class TestAptitudePackageManager(unittest.TestCase):
     def mock_run_command_output_fwupd_refresh_fails(self, cmd, no_output=False, chk_err=True):
         self.assertGreater(cmd.find(self.runtime.package_manager.fwupd_refresh_cmd), -1)
         return 1, "Error"
+
+    def mock_run_command_output_with_fwupd_exit_code_overrides(self, cmd, no_output=False, chk_err=True):
+        """Reuse the legacy env layer command mocks and override only the fwupd refresh/update exit codes driven by test state."""
+        code, output = self.legacy_run_command_output(cmd, no_output, chk_err)
+
+        if cmd.find(self.runtime.package_manager.fwupd_refresh_cmd) > -1:
+            if self.fwupd_refresh_code == 2:
+                return self.fwupd_refresh_code, "Nothing to do (no updates available)"
+            return self.fwupd_refresh_code, output if self.fwupd_refresh_code == 0 else "Error"
+
+        if cmd.find(self.runtime.package_manager.fwupd_update_cmd) > -1:
+            return self.fwupd_update_code, output if self.fwupd_update_code == 0 else "Error"
+
+        return code, output
 
     def mock_run_command_output_apt_update_cmd_fails(self, cmd, no_output=False, chk_err=True):
         if cmd.find(self.runtime.package_manager.apt_update_cmd) > -1:
@@ -299,6 +319,45 @@ class TestAptitudePackageManager(unittest.TestCase):
         available_updates, package_versions = package_manager.get_available_updates(package_filter)
         self.assertEqual(len(available_updates), 0)
         self.assertEqual(len(package_versions), 0)
+
+    def test_fwupd_commands_use_snap_only_on_ubuntu_releases_older_than_22_04(self):
+        """Canonical guidance requires the fwupd Snap before Ubuntu 22.04, and the archive package from 22.04 onward. fwupdmgr commands (version/refresh/update) are identical either way."""
+        backup_linux_distribution = LegacyEnvLayerExtensions.LegacyPlatform.linux_distribution
+
+        use_cases = [
+            {
+                "name": "ubuntu_20_04_uses_snap",
+                "linux_distribution": self.mock_linux_distribution_to_return_ubuntu_focal,
+                "expected_is_snap_fwupd_required": True,
+                "expected_install_command": "sudo snap install fwupd"
+            },
+            {
+                "name": "ubuntu_22_04_uses_apt",
+                "linux_distribution": self.mock_linux_distribution_to_return_ubuntu_jammy,
+                "expected_is_snap_fwupd_required": False,
+                "expected_install_command": "sudo apt-get install -y fwupd"
+            }
+        ]
+
+        try:
+            for use_case in use_cases:
+                # the Ubuntu release is only read once, in the package manager's constructor, so a fresh runtime/container-built
+                # instance is required per use case (patching an already-constructed package_manager instance is too late)
+                LegacyEnvLayerExtensions.LegacyPlatform.linux_distribution = use_case["linux_distribution"]
+                runtime_for_test = RuntimeCompositor(self.argument_composer, True, Constants.APT)
+                try:
+                    package_manager_for_test = runtime_for_test.container.get('package_manager')
+
+                    self.assertEqual(package_manager_for_test.is_snap_fwupd_required, use_case["expected_is_snap_fwupd_required"], "Failed use case: {0}".format(use_case["name"]))
+                    self.assertEqual(package_manager_for_test.install_fwupd_cmd, use_case["expected_install_command"], "Failed use case: {0}".format(use_case["name"]))
+                    # fwupdmgr commands are identical regardless of install method, per Canonical guidance
+                    self.assertEqual(package_manager_for_test.get_installed_fwupd_version_cmd, "fwupdmgr --version", "Failed use case: {0}".format(use_case["name"]))
+                    self.assertEqual(package_manager_for_test.fwupd_refresh_cmd, "sudo fwupdmgr refresh", "Failed use case: {0}".format(use_case["name"]))
+                    self.assertEqual(package_manager_for_test.fwupd_update_cmd, "sudo fwupdmgr update -y", "Failed use case: {0}".format(use_case["name"]))
+                finally:
+                    runtime_for_test.stop()
+        finally:
+            LegacyEnvLayerExtensions.LegacyPlatform.linux_distribution = backup_linux_distribution
 
     def test_package_manager(self):
         """Unit test for apt package manager"""
@@ -1563,6 +1622,73 @@ class TestAptitudePackageManager(unittest.TestCase):
                 )
         finally:
             package_manager.env_layer.run_command_output = backup_run_command_output
+
+    def test_try_update_certs_fwupd_exit_code_handling__with_various_use_cases(self):
+        """Only fwupd refresh returning exit code 2 (no updates available) must be treated as success in the cert update flow."""
+        package_manager = self.container.get('package_manager')
+
+        backup_run_command_output = package_manager.env_layer.run_command_output
+        backup_add_error_to_status = package_manager.status_handler.add_error_to_status
+        backup_are_latest_certs_present_with_mokutil_check = package_manager.are_latest_certs_present_with_mokutil_check
+        backup_is_reboot_pending = package_manager.is_reboot_pending
+
+        use_cases = [
+            {
+                "name": "fwupd_refresh_returns_code_2_is_treated_as_no_updates_available_and_succeeds",
+                "fwupd_refresh_code": 2,
+                "fwupd_update_code": 0,
+                "expected_result": True,
+                "expected_error_count": 0
+            },
+            {
+                "name": "fwupd_refresh_returns_code_1_is_treated_as_failure",
+                "fwupd_refresh_code": 1,
+                "fwupd_update_code": 0,
+                "expected_result": False,
+                "expected_error_count": 1
+            },
+            {
+                "name": "fwupd_update_returns_code_2_is_treated_as_failure",
+                "fwupd_refresh_code": 0,
+                "fwupd_update_code": 2,
+                "expected_result": False,
+                "expected_error_count": 1
+            },
+            {
+                "name": "all_fwupd_commands_succeed",
+                "fwupd_refresh_code": 0,
+                "fwupd_update_code": 0,
+                "expected_result": True,
+                "expected_error_count": 0
+            }
+        ]
+
+        try:
+            # reuse the legacy env layer command mocks (fwupdmgr --version, refresh, update, apt-get -q update) and only override exit codes under test
+            self.legacy_run_command_output = backup_run_command_output
+            package_manager.env_layer.run_command_output = self.mock_run_command_output_with_fwupd_exit_code_overrides
+            package_manager.status_handler.add_error_to_status = self.mock_add_error_to_status_to_capture_errors
+            package_manager.are_latest_certs_present_with_mokutil_check = self.mock_are_latest_certs_present_return_true
+            package_manager.is_reboot_pending = self.mock_is_reboot_pending_returns_bool_False
+
+            for use_case in use_cases:
+                self.captured_errors_tracking = []
+                self.fwupd_refresh_code = use_case["fwupd_refresh_code"]
+                self.fwupd_update_code = use_case["fwupd_update_code"]
+
+                self.assertEqual(package_manager.try_update_certs(), use_case["expected_result"], "Failed use case: {0}".format(use_case["name"]))
+                self.assertEqual(len(self.captured_errors_tracking), use_case["expected_error_count"], "Failed use case: {0}".format(use_case["name"]))
+
+                if use_case["expected_error_count"] > 0:
+                    self.assertIn("Shell step failed", self.captured_errors_tracking[0][0], "Failed use case: {0}".format(use_case["name"]))
+                    self.assertEqual(self.captured_errors_tracking[0][1], Constants.PatchOperationErrorCodes.CERTIFICATE_UPDATE, "Failed use case: {0}".format(use_case["name"]))
+                else:
+                    self.assertEqual(package_manager.status_handler.is_reboot_pending, False, "Failed use case: {0}".format(use_case["name"]))
+        finally:
+            package_manager.env_layer.run_command_output = backup_run_command_output
+            package_manager.status_handler.add_error_to_status = backup_add_error_to_status
+            package_manager.are_latest_certs_present_with_mokutil_check = backup_are_latest_certs_present_with_mokutil_check
+            package_manager.is_reboot_pending = backup_is_reboot_pending
 
     def test_is_hibernation_enabled_for_cert_update__with_various_use_cases(self):
         """Test is_hibernation_enabled_for_cert_update with various hibernation states"""

--- a/src/core/tests/Test_AptitudePackageManager.py
+++ b/src/core/tests/Test_AptitudePackageManager.py
@@ -51,12 +51,6 @@ class TestAptitudePackageManager(unittest.TestCase):
     def mock_linux_distribution_to_return_ubuntu_oracular(self):
         return ['Ubuntu', '26.04', 'oracular']
 
-    def mock_linux_distribution_to_return_ubuntu_focal(self):
-        return ['Ubuntu', '20.04', 'focal']
-
-    def mock_linux_distribution_to_return_ubuntu_jammy(self):
-        return ['Ubuntu', '22.04', 'jammy']
-
     def mock_is_pro_working_return_true(self):
         return True
 
@@ -141,14 +135,14 @@ class TestAptitudePackageManager(unittest.TestCase):
         return 0, ""
 
     def mock_run_command_output_fwupd_refresh_fails(self, cmd, no_output=False, chk_err=True):
-        self.assertGreater(cmd.find(self.runtime.package_manager.fwupd_refresh_cmd), -1)
+        self.assertGreater(cmd.find(self.runtime.package_manager.fwupd_force_refresh_cmd), -1)
         return 1, "Error"
 
     def mock_run_command_output_with_fwupd_exit_code_overrides(self, cmd, no_output=False, chk_err=True):
         """Reuse the legacy env layer command mocks and override only the fwupd refresh/update exit codes driven by test state."""
         code, output = self.legacy_run_command_output(cmd, no_output, chk_err)
 
-        if cmd.find(self.runtime.package_manager.fwupd_refresh_cmd) > -1:
+        if cmd.find(self.runtime.package_manager.fwupd_force_refresh_cmd) > -1:
             if self.fwupd_refresh_code == 2:
                 return self.fwupd_refresh_code, "Nothing to do (no updates available)"
             return self.fwupd_refresh_code, output if self.fwupd_refresh_code == 0 else "Error"
@@ -319,45 +313,6 @@ class TestAptitudePackageManager(unittest.TestCase):
         available_updates, package_versions = package_manager.get_available_updates(package_filter)
         self.assertEqual(len(available_updates), 0)
         self.assertEqual(len(package_versions), 0)
-
-    def test_fwupd_commands_use_snap_only_on_ubuntu_releases_older_than_22_04(self):
-        """Canonical guidance requires the fwupd Snap before Ubuntu 22.04, and the archive package from 22.04 onward. fwupdmgr commands (version/refresh/update) are identical either way."""
-        backup_linux_distribution = LegacyEnvLayerExtensions.LegacyPlatform.linux_distribution
-
-        use_cases = [
-            {
-                "name": "ubuntu_20_04_uses_snap",
-                "linux_distribution": self.mock_linux_distribution_to_return_ubuntu_focal,
-                "expected_is_snap_fwupd_required": True,
-                "expected_install_command": "sudo snap install fwupd"
-            },
-            {
-                "name": "ubuntu_22_04_uses_apt",
-                "linux_distribution": self.mock_linux_distribution_to_return_ubuntu_jammy,
-                "expected_is_snap_fwupd_required": False,
-                "expected_install_command": "sudo apt-get install -y fwupd"
-            }
-        ]
-
-        try:
-            for use_case in use_cases:
-                # the Ubuntu release is only read once, in the package manager's constructor, so a fresh runtime/container-built
-                # instance is required per use case (patching an already-constructed package_manager instance is too late)
-                LegacyEnvLayerExtensions.LegacyPlatform.linux_distribution = use_case["linux_distribution"]
-                runtime_for_test = RuntimeCompositor(self.argument_composer, True, Constants.APT)
-                try:
-                    package_manager_for_test = runtime_for_test.container.get('package_manager')
-
-                    self.assertEqual(package_manager_for_test.is_snap_fwupd_required, use_case["expected_is_snap_fwupd_required"], "Failed use case: {0}".format(use_case["name"]))
-                    self.assertEqual(package_manager_for_test.install_fwupd_cmd, use_case["expected_install_command"], "Failed use case: {0}".format(use_case["name"]))
-                    # fwupdmgr commands are identical regardless of install method, per Canonical guidance
-                    self.assertEqual(package_manager_for_test.get_installed_fwupd_version_cmd, "fwupdmgr --version", "Failed use case: {0}".format(use_case["name"]))
-                    self.assertEqual(package_manager_for_test.fwupd_refresh_cmd, "sudo fwupdmgr refresh", "Failed use case: {0}".format(use_case["name"]))
-                    self.assertEqual(package_manager_for_test.fwupd_update_cmd, "sudo fwupdmgr update -y", "Failed use case: {0}".format(use_case["name"]))
-                finally:
-                    runtime_for_test.stop()
-        finally:
-            LegacyEnvLayerExtensions.LegacyPlatform.linux_distribution = backup_linux_distribution
 
     def test_package_manager(self):
         """Unit test for apt package manager"""
@@ -1624,7 +1579,7 @@ class TestAptitudePackageManager(unittest.TestCase):
             package_manager.env_layer.run_command_output = backup_run_command_output
 
     def test_try_update_certs_fwupd_exit_code_handling__with_various_use_cases(self):
-        """Only fwupd refresh returning exit code 2 (no updates available) must be treated as success in the cert update flow."""
+        """fwupd refresh command ignores all error codes and succeeds regardless. Other fwupd commands still fail on non-zero exit codes."""
         package_manager = self.container.get('package_manager')
 
         backup_run_command_output = package_manager.env_layer.run_command_output
@@ -1634,18 +1589,25 @@ class TestAptitudePackageManager(unittest.TestCase):
 
         use_cases = [
             {
-                "name": "fwupd_refresh_returns_code_2_is_treated_as_no_updates_available_and_succeeds",
+                "name": "fwupd_refresh_returns_code_2_is_treated_as_success",
                 "fwupd_refresh_code": 2,
                 "fwupd_update_code": 0,
                 "expected_result": True,
                 "expected_error_count": 0
             },
             {
-                "name": "fwupd_refresh_returns_code_1_is_treated_as_failure",
+                "name": "fwupd_refresh_returns_code_1_is_ignored_and_treated_as_success",
                 "fwupd_refresh_code": 1,
                 "fwupd_update_code": 0,
-                "expected_result": False,
-                "expected_error_count": 1
+                "expected_result": True,
+                "expected_error_count": 0
+            },
+            {
+                "name": "fwupd_refresh_returns_code_3_is_ignored_and_treated_as_success",
+                "fwupd_refresh_code": 3,
+                "fwupd_update_code": 0,
+                "expected_result": True,
+                "expected_error_count": 0
             },
             {
                 "name": "fwupd_update_returns_code_2_is_treated_as_failure",

--- a/src/core/tests/library/LegacyEnvLayerExtensions.py
+++ b/src/core/tests/library/LegacyEnvLayerExtensions.py
@@ -580,13 +580,10 @@ class LegacyEnvLayerExtensions():
                                   "Building dependency tree... Done"
                                   "Reading state information... Done "
                                   "2 upgraded, 7 newly installed, 0 to remove and 37 not upgraded")
-                    elif cmd.find("sudo snap install fwupd") > -1:
-                        code = 0
-                        output = "fwupd installed"
-                    elif cmd.find("fwupdmgr refresh") > -1:
+                    elif cmd.find("sudo fwupdmgr refresh") > -1:
                         code = 0
                         output = "Success"
-                    elif cmd.find("fwupdmgr update") > -1:
+                    elif cmd.find("sudo fwupdmgr update") > -1:
                         code = 0
                         output = "Successfully installed firmware"
                 elif self.legacy_package_manager_name is Constants.TDNF:

--- a/src/core/tests/library/LegacyEnvLayerExtensions.py
+++ b/src/core/tests/library/LegacyEnvLayerExtensions.py
@@ -580,10 +580,13 @@ class LegacyEnvLayerExtensions():
                                   "Building dependency tree... Done"
                                   "Reading state information... Done "
                                   "2 upgraded, 7 newly installed, 0 to remove and 37 not upgraded")
-                    elif cmd.find("sudo fwupdmgr refresh") > -1:
+                    elif cmd.find("sudo snap install fwupd") > -1:
+                        code = 0
+                        output = "fwupd installed"
+                    elif cmd.find("fwupdmgr refresh") > -1:
                         code = 0
                         output = "Success"
-                    elif cmd.find("sudo fwupdmgr update") > -1:
+                    elif cmd.find("fwupdmgr update") > -1:
                         code = 0
                         output = "Successfully installed firmware"
                 elif self.legacy_package_manager_name is Constants.TDNF:


### PR DESCRIPTION
This includes:

1. Not marking return code = 2 for fwupdmgr refresh command as error. Refer: https://github.com/fwupd/fwupd/issues/10208 and https://manpages.debian.org/trixie/fwupd/fwupdmgr.1.en.html

As per the suggestion in https://github.com/Azure/LinuxPatchExtension/pull/382#discussion_r3872968979, using sudo fwupdmgr refresh --force command which will take care of the ignorable error code and ignoring all errors arising out of this command. 

Tests Results:
1. [Success] Handling errors for fwupdmgr refresh: Is not marked as an error: [3.core.log](https://github.com/user-attachments/files/31572758/3.core.log), [3.status.txt](https://github.com/user-attachments/files/31572762/3.status.txt)

